### PR TITLE
fix!: renamed openjd-unreal-engine to unreal-engine-openjd

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ dependencies = [
 ]
 
 [project.scripts]
-openjd-unreal-engine = "deadline.unreal_adaptor.UnrealAdaptor:main"
-# TODO: This is deprecated, use openjd-unreal-engine
+unreal-engine-openjd = "deadline.unreal_adaptor.UnrealAdaptor:main"
+# TODO: This is deprecated, use unreal-engine-openjd
 UnrealAdaptor = "deadline.unreal_adaptor.UnrealAdaptor:main"
 
 [tool.hatch.build]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

had named the new entrypoint incorrectly. It should start with the application and trail with openjd

### What was the solution? (How)

make the switch!

### What is the impact of this change?

we get the proper cli available to users

### How was this change tested?

tested in my own hatch shell that it existed and worked

### Was this change documented?

N/A

### Is this a breaking change?

Yep