### PR TITLE
feat: Adds telemetry to submitter and adaptor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.40.*",
+    "deadline == 0.41.*",
     "openjd-adaptor-runtime == 0.5.*",
 ]
 

--- a/src/deadline/unreal_submitter/submitter.py
+++ b/src/deadline/unreal_submitter/submitter.py
@@ -2,10 +2,15 @@
 import unreal
 import threading
 from enum import Enum
-from deadline.client.api import create_job_from_job_bundle
+from deadline.client.api import (
+    create_job_from_job_bundle,
+    get_deadline_cloud_library_telemetry_client,
+)
 from deadline.job_attachments.exceptions import AssetSyncCancelledError
 
 from deadline.unreal_submitter.unreal_open_job.open_job_description import OpenJobDescription
+
+from ._version import version
 
 
 class UnrealSubmitStatus(Enum):
@@ -37,6 +42,14 @@ class UnrealSubmitter:
         self.continue_submission = True  # affect all not submitted jobs
         self.submitted_job_ids: list[str] = []  # use after submit loop is ended
         self._submission_failed_message = ""  # reset after each job in the loop
+
+        # Initialize telemetry client, opt-out is respected
+        get_deadline_cloud_library_telemetry_client().update_common_details(
+            {
+                "deadline-cloud-for-unreal-engine-submitter-version": version,
+                # TODO: record unreal-engine-version
+            }
+        )
 
     @property
     def submission_failed_message(self) -> str:

--- a/src/unreal_plugin/README.md
+++ b/src/unreal_plugin/README.md
@@ -14,5 +14,16 @@ Should be placed in the "Plugins" folder of the UE project.
 ## Development
 See the [DEVELOPMENT](DEVELOPMENT.md) file for development pipelines
 
+## Telemetry
+
+This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
+
+You can opt out of telemetry data collection by either:
+
+1. Setting the environment variable: `DEADLINE_CLOUD_TELEMETRY_OPT_OUT=true`
+2. Setting the config file: `deadline config set telemetry.opt_out true`
+
+Note that setting the environment variable supersedes the config file setting.
+
 ## License
 This project is licensed under the Apache-2.0 License. 

--- a/test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py
@@ -46,6 +46,9 @@ def run_data() -> dict:
 
 
 class TestUnrealAdaptor_on_start:
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.AdaptorServer")
@@ -54,6 +57,7 @@ class TestUnrealAdaptor_on_start:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         init_data: dict,
     ) -> None:
         """Tests that on_start completes without error"""
@@ -62,6 +66,9 @@ class TestUnrealAdaptor_on_start:
         adaptor.on_start()
 
     @patch("time.sleep")
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.AdaptorServer")
@@ -70,6 +77,7 @@ class TestUnrealAdaptor_on_start:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         mock_sleep: Mock,
         init_data: dict,
     ) -> None:
@@ -106,6 +114,9 @@ class TestUnrealAdaptor_on_start:
             == "Could not find a socket path because the server did not finish initializing"
         )
 
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.ActionsQueue.__len__", return_value=1)
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.AdaptorServer")
@@ -114,6 +125,7 @@ class TestUnrealAdaptor_on_start:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         init_data: dict,
     ) -> None:
         """
@@ -139,6 +151,9 @@ class TestUnrealAdaptor_on_start:
         assert str(exc_info.value) == error_msg
 
     @patch.object(UnrealAdaptor, "_unreal_is_running", False)
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.ActionsQueue.__len__", return_value=1)
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.AdaptorServer")
@@ -147,6 +162,7 @@ class TestUnrealAdaptor_on_start:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         init_data: dict,
     ) -> None:
         """
@@ -194,6 +210,9 @@ class TestUnrealAdaptor_on_start:
 
 class TestUnrealAdaptor_on_run:
     @patch("time.sleep")
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.AdaptorServer")
@@ -202,6 +221,7 @@ class TestUnrealAdaptor_on_run:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         mock_sleep: Mock,
         init_data: dict,
         run_data: dict,
@@ -230,6 +250,9 @@ class TestUnrealAdaptor_on_run:
         "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._unreal_is_running",
         new_callable=PropertyMock,
     )
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.AdaptorServer")
@@ -238,6 +261,7 @@ class TestUnrealAdaptor_on_run:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         mock_unreal_is_running: Mock,
         mock_is_rendering: Mock,
         mock_sleep: Mock,
@@ -265,6 +289,9 @@ class TestUnrealAdaptor_on_run:
         )
 
     @patch("time.sleep")
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.AdaptorServer")
@@ -273,6 +300,7 @@ class TestUnrealAdaptor_on_run:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         mock_sleep: Mock,
         init_data: dict,
     ) -> None:
@@ -297,6 +325,9 @@ class TestUnrealAdaptor_on_run:
 
 class TestUnrealAdaptor_on_stop:
     @patch("time.sleep")
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.AdaptorServer")
@@ -305,6 +336,7 @@ class TestUnrealAdaptor_on_stop:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         mock_sleep: Mock,
         init_data: dict,
         run_data: dict,
@@ -371,6 +403,9 @@ class TestUnrealAdaptor_on_cleanup:
         mock_server_thread.join.assert_called_once_with(timeout=0.01)
 
     @patch("time.sleep")
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_deadline_telemetry_client"
+    )
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.AdaptorServer")
@@ -379,6 +414,7 @@ class TestUnrealAdaptor_on_cleanup:
         mock_server: Mock,
         mock_logging_subprocess: Mock,
         mock_actions_queue: Mock,
+        mock_telemetry_client: Mock,
         mock_sleep: Mock,
         init_data: dict,
         run_data: dict,

--- a/test/deadline_submitter_for_unreal/unit/cases/test_unreal_submitter.py
+++ b/test/deadline_submitter_for_unreal/unit/cases/test_unreal_submitter.py
@@ -48,7 +48,10 @@ def create_job_from_bundle_mock(
 
 class TestUnrealSubmitter(unittest.TestCase):
     @unittest.skip("mocks not set up properly")
-    def test_add_job(self, submitter=UnrealSubmitter()):
+    @patch("deadline.unreal_submitter.submitter.get_deadline_cloud_library_telemetry_client")
+    def test_add_job(self, mock_telemetry_client: Mock, submitter=None):
+        if not submitter:
+            submitter = UnrealSubmitter()
         for job in PIPELINE_QUEUE.get_jobs():
             new_queue = unreal.MoviePipelineQueue()
             new_job = new_queue.duplicate_job(job)
@@ -61,7 +64,8 @@ class TestUnrealSubmitter(unittest.TestCase):
         "deadline.unreal_submitter.submitter.create_job_from_job_bundle",
         side_effect=create_job_from_bundle_mock,
     )
-    def test_submit_jobs(self, create_job_from_bundle_mock: Mock):
+    @patch("deadline.unreal_submitter.submitter.get_deadline_cloud_library_telemetry_client")
+    def test_submit_jobs(self, mock_telemetry_client: Mock, create_job_from_bundle_mock: Mock):
         submitter = UnrealSubmitter(silent_mode=True)
         self.test_add_job(submitter)
         submitter.submit_jobs()
@@ -72,7 +76,10 @@ class TestUnrealSubmitter(unittest.TestCase):
         "deadline.unreal_submitter.submitter.create_job_from_job_bundle",
         side_effect=create_job_from_bundle_mock,
     )
-    def test_cancel_submit_jobs(self, create_job_from_bundle_mock: Mock):
+    @patch("deadline.unreal_submitter.submitter.get_deadline_cloud_library_telemetry_client")
+    def test_cancel_submit_jobs(
+        self, mock_telemetry_client: Mock, create_job_from_bundle_mock: Mock
+    ):
         submitter = UnrealSubmitter(silent_mode=True)
         self.test_add_job(submitter)
 
@@ -89,7 +96,13 @@ class TestUnrealSubmitter(unittest.TestCase):
         "deadline.unreal_submitter.submitter.create_job_from_job_bundle",
         side_effect=create_job_from_bundle_mock,
     )
-    def test_fail_submit_jobs(self, create_job_from_bundle_mock: Mock, failed_message_mock: Mock):
+    @patch("deadline.unreal_submitter.submitter.get_deadline_cloud_library_telemetry_client")
+    def test_fail_submit_jobs(
+        self,
+        mock_telemetry_client: Mock,
+        create_job_from_bundle_mock: Mock,
+        failed_message_mock: Mock,
+    ):
         fail_message = "Test interrupt submission"
         failed_message_mock.side_effect = [fail_message, fail_message, fail_message]
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We can't currently tell if anyone is using unreal engine submitters / adaptors

### What was the solution? (How)
Uses changes from https://github.com/casillas2/deadline-cloud/pull/205 to capture more package information when sending telemetry data, and changes from https://github.com/casillas2/deadline-cloud/pull/212 to opt out of telemetry from an environment variable.

Note, I could not for the life of me figure out where to get the Engine Version number. I looked through the [python api](https://docs.unrealengine.com/5.3/en-US/PythonAPI/genindex-all.html) but all I could find was the [VersionInfoHandler](https://docs.unrealengine.com/5.3/en-US/PythonAPI/class/VersionInfoHandler.html) which has no information and appears to only report the version of a specific object given to it.

### What is the impact of this change?
We can better tell how customers use our software and if they use unreal engine

### How was this change tested?
- with assistance from @erico-aws we ran the submitter and adaptor and confirmed that telemetry was sent successfully
- ran unit tests using deadline-cloud changes from mainline, they passed

### Was this change documented?
Updated README with opt out instructions

### Is this a breaking change?
No