### PR TITLE
chore: update deadline-cloud dependency 0.45.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ license = ""
 requires-python = ">=3.7"
 
 dependencies = [
-    "deadline == 0.41.*",
-    "openjd-adaptor-runtime == 0.5.*",
+    "deadline == 0.45.*",
+    "openjd-adaptor-runtime == 0.6.*",
 ]
 
 [project.scripts]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Out of date dependency of the deadline-cloud client lib
### What was the solution? (How)
update dependency
### What is the impact of this change?
qtpy changes in deadline-cloud will be available in submitters
### How was this change tested?
`hatch build` and `hatch run test`

### Was this change documented?

### Is this a breaking change?
no