### PR TITLE
chore(installer): fix submitter installer component name

### DIFF
--- a/install_builder/deadline-cloud-for-unreal-engine.xml
+++ b/install_builder/deadline-cloud-for-unreal-engine.xml
@@ -9,7 +9,7 @@
         <folder>
             <description>Submitter Files</description>
             <destination>${unreal_plugin_dir}/Content/Python/libraries/deadline/unreal_submitter</destination>
-            <name>unreal-submitter</name>
+            <name>unreal_submitter</name>
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The InstallBuilder XML component uses a nonvalid name `unreal-submitter`. InstallBuilder does not allow `-`, and I got this error when building the installer locally:
```
Element <name> can only contain alphanumeric or '_' characters, but its current value is 'unreal-submitter'
```

### What was the solution? (How)
Replace `-` with `_`

### What is the impact of this change?
Installer build works

### How was this change tested?
Built the installer

### Was this change documented?
No

### Is this a breaking change?
No