### PR TITLE
fix: rename duplicate prefix argument to unreal-plugin-directory

### DIFF
--- a/install_builder/deadline-cloud-for-unreal-engine.xml
+++ b/install_builder/deadline-cloud-for-unreal-engine.xml
@@ -56,13 +56,14 @@
 		</stringParameter>
         <directoryParameter>
             <name>unreal_plugin_dir</name>
-            <description>Path to the Deadline Cloud Unreal Plugin directory</description>
-            <explanation>Deadline Cloud Unreal Plugin directory</explanation>
+            <description>Deadline Cloud Unreal Plugin directory</description>
+            <explanation>Path to the Deadline Cloud Unreal Plugin directory</explanation>
             <value></value>
             <default>C:\Program Files\Epic Games\UE_5.2\Engine\Plugins\UnrealDeadlineCloudService</default>
             <allowEmptyValue>0</allowEmptyValue>
             <ask>yes</ask>
-            <cliOptionName>prefix</cliOptionName>
+            <cliOptionName>unreal-plugin-directory</cliOptionName>
+            <cliOptionText>Path to the Deadline Cloud Unreal Plugin directory</cliOptionText>
             <mustBeWritable>yes</mustBeWritable>
             <mustExist>1</mustExist>
         </directoryParameter>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When reviewing the Deadline Cloud submitter installer, I noticed that there was two arguments with the `--prefix` CLI option

### What was the solution? (How)
This looks like a copy-paste error for the Unreal Engine component of the installer. The current behaviour when the `--prefix` CLI argument is used is unclear - it's surprising that the installer builds at all. For me, the installer errors out when the argument is used.

Also swapped the description and explanation fields for the parameter as the description should be the short-form and the explanation should be the long form.

### What is the impact of this change?
Customers are able to use the `--prefix` argument when using the installer with Unreal Engine.

### How was this change tested?
#### Before
`DeadlineCloudSubmitter-windows-x64-installer.exe --help`

![image](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/assets/127782171/46b7bb7c-152a-436e-9eaa-1bf2d381120a)

`DeadlineCloudSubmitter-windows-x64-installer.exe --prefix C:\Users\test-user\installbuildertest --mode unattended --unattendedmodeui minimal --enable-components deadline_cloud_for_unreal_engine` 

![image](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/assets/127782171/a04aa514-55c0-4b3b-b95b-0e67a0823e06)

![image](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/assets/127782171/815759fc-4035-45ff-986c-c1bcadb014d6)

#### After

`DeadlineCloudSubmitter-windows-x64-installer.exe --help`

![image](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/assets/127782171/6aab5778-cffe-458c-86db-08acc1af1e5c)

`DeadlineCloudSubmitter-windows-x64-installer.exe --prefix C:\Users\test-user\installbuildertest --mode unattended --unattendedmodeui minimal --enable-components deadline_cloud_for_unreal_engine --unreal-plugin-directory C:\Users\test-user\installbuildertest`

<successful installation!>

![image](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/assets/127782171/ae1fb480-ced4-46c8-a0fb-34ff280258f4)


### Was this change documented?
No, not required

### Is this a breaking change?
No, as this CLI option never worked previously, this is not considered a breaking change.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*