### PR TITLE
feat: Submitter installer improvements

### DIFF
--- a/install_builder/deadline-cloud-for-unreal-engine.xml
+++ b/install_builder/deadline-cloud-for-unreal-engine.xml
@@ -41,6 +41,34 @@
         <actionList>
             <setInstallerVariable name="all_components" value="${all_components} deadline_cloud_for_unreal_engine"/>
             <setInstallerVariable name="unreal_deps_platform" value="windows"/>
+            <setInstallerVariable name="unreal_install_path" value="C:\Program Files\Epic Games\UE_5.4"/>
+            <registryFind>
+                <keyPattern>*5.*</keyPattern>
+                <namePattern>InstalledDirectory</namePattern>
+                <findAll>1</findAll>
+                <rootKey>HKEY_LOCAL_MACHINE\SOFTWARE\EpicGames\Unreal Engine</rootKey>
+                <searchDepth>1</searchDepth>
+                <variable>unreal_registry_list</variable>
+            </registryFind>
+            <foreach>
+                <variables>key name value</variables>
+                <values>${unreal_registry_list}</values>
+                <actionList>
+                    <actionGroup>
+                        <actionList>
+                            <setInstallerVariable>
+                                <name>unreal_install_path</name>
+                                <value>${value}</value>
+                            </setInstallerVariable>
+                        </actionList>
+                        <ruleList>
+                            <fileExists>
+                                <path>${value}</path>
+                            </fileExists>
+                        </ruleList>
+                    </actionGroup>
+                </actionList>
+            </foreach>
         </actionList>
         <elseActionList>
             <setInstallerVariable name="component(deadline_cloud_for_unreal_engine).show" value="0"/>
@@ -49,23 +77,36 @@
 	</initializationActionList>
 	<parameterList>
 		<stringParameter name="deadline_cloud_for_unreal_engine_summary" ask="0" cliOptionShow="0">
-			<value>Deadline Cloud for Unreal Engine 5.2.1
-- Compatible with Unreal Engine 5
+			<value>Deadline Cloud for Unreal Engine 5.2+
+- Compatible with Unreal Engine 5.2 and later
 - Install the Unreal Engine submitter files to the Plugin directory
 </value>
 		</stringParameter>
+        <directoryParameter>
+            <name>unreal_plugin_root</name>
+            <description>Unreal Plugins folder</description>
+            <explanation>Path to the Unreal Plugins folder to install in</explanation>
+            <value></value>
+            <default>${unreal_install_path}\Engine\Plugins</default>
+            <allowEmptyValue>0</allowEmptyValue>
+            <ask>yes</ask>
+            <cliOptionName>unreal-plugins-folder</cliOptionName>
+            <cliOptionText>Path to the Unreal Plugins directory</cliOptionText>
+            <mustBeWritable>yes</mustBeWritable>
+            <mustExist>1</mustExist>
+        </directoryParameter>
         <directoryParameter>
             <name>unreal_plugin_dir</name>
             <description>Deadline Cloud Unreal Plugin directory</description>
             <explanation>Path to the Deadline Cloud Unreal Plugin directory</explanation>
             <value></value>
-            <default>C:\Program Files\Epic Games\UE_5.2\Engine\Plugins\UnrealDeadlineCloudService</default>
+            <default>${unreal_plugin_root}\UnrealDeadlineCloudService</default>
             <allowEmptyValue>0</allowEmptyValue>
-            <ask>yes</ask>
+            <ask>no</ask>
             <cliOptionName>unreal-plugin-directory</cliOptionName>
             <cliOptionText>Path to the Deadline Cloud Unreal Plugin directory</cliOptionText>
             <mustBeWritable>yes</mustBeWritable>
-            <mustExist>1</mustExist>
+            <mustExist>0</mustExist>
         </directoryParameter>
 	</parameterList>
     <postInstallationActionList>


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Submitter installer defaulted to trying to install in Unreal version 5.2's install folder, even when users did not have 5.2 but did have another version installed.

Submitter installer forced customers to have created the UnrealDeadlineCloudService plugin folder before installing.

Several places in did not correctly reference 5.2 as the minimum version.

### What was the solution? (How)
Updating default installed version path of unreal to 5.4 (Latest official release)

Changed some comments to reflect support for 5.2 and above.

Added a registry check for most recently installed version which will override default when found.

Removed requirement for 'UnrealDeadlineCloudService' Plugins folder to exist for installation to work, only the engine plugins folder needs to exist.

### What is the impact of this change?
Better customer experience installing unreal submitter.

### How was this change tested?
Built and ran submitter installer with a number of different version combinations set in the registry.

Validated UnrealDeadlineCloudService folder was created when necessary and did not block installation if not present.

Ran on Linux to verify no unexpected interactions/errors due to changes.
### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*