### PR TITLE
feat: Script for producing plugin prebuild archive

### DIFF
--- a/install_builder/deadline-cloud-for-unreal-engine.xml
+++ b/install_builder/deadline-cloud-for-unreal-engine.xml
@@ -18,16 +18,27 @@
             </distributionFileList>
         </folder>
         <folder>
-             <description>Dependency Files</description>
-             <destination>${unreal_plugin_dir}/tmp/unreal_deps</destination>
-             <name>unreal_deps</name>
-             <platforms>all</platforms>
-             <distributionFileList>
-                 <distributionDirectory allowWildcards="1">
-                     <origin>components/deadline-cloud-for-unreal-engine/dependency_bundle</origin>
-                 </distributionDirectory>
-             </distributionFileList>
-         </folder>
+            <description>Dependency Files</description>
+            <destination>${unreal_plugin_dir}/tmp/unreal_deps</destination>
+            <name>unreal_deps</name>
+            <platforms>all</platforms>
+            <distributionFileList>
+                <distributionDirectory allowWildcards="1">
+                    <origin>components/deadline-cloud-for-unreal-engine/dependency_bundle</origin>
+                </distributionDirectory>
+            </distributionFileList>
+        </folder>
+        <folder>
+            <description>Prebuild Outputs</description>
+            <destination>${unreal_plugin_dir}</destination>
+            <name>unreal_prebuilds</name>
+            <platforms>all</platforms>
+            <distributionFileList>
+                <distributionDirectory allowWildcards="1">
+                    <origin>components/deadline-cloud-for-unreal-engine/UnrealDeadlineCloudService/*</origin>
+                </distributionDirectory>
+            </distributionFileList>
+        </folder>
     </folderList>
     <initializationActionList>
     <if>

--- a/install_builder/deadline-cloud-for-unreal-engine.xml
+++ b/install_builder/deadline-cloud-for-unreal-engine.xml
@@ -41,6 +41,34 @@
         <actionList>
             <setInstallerVariable name="all_components" value="${all_components} deadline_cloud_for_unreal_engine"/>
             <setInstallerVariable name="unreal_deps_platform" value="windows"/>
+            <setInstallerVariable name="unreal_install_path" value="C:\Program Files\Epic Games\UE_5.4"/>
+            <registryFind>
+                <keyPattern>*5.*</keyPattern>
+                <namePattern>InstalledDirectory</namePattern>
+                <findAll>1</findAll>
+                <rootKey>HKEY_LOCAL_MACHINE\SOFTWARE\EpicGames\Unreal Engine</rootKey>
+                <searchDepth>1</searchDepth>
+                <variable>unreal_registry_list</variable>
+            </registryFind>
+            <foreach>
+                <variables>key name value</variables>
+                <values>${unreal_registry_list}</values>
+                <actionList>
+                    <actionGroup>
+                        <actionList>
+                            <setInstallerVariable>
+                                <name>unreal_install_path</name>
+                                <value>${value}</value>
+                            </setInstallerVariable>
+                        </actionList>
+                        <ruleList>
+                            <fileExists>
+                                <path>${value}</path>
+                            </fileExists>
+                        </ruleList>
+                    </actionGroup>
+                </actionList>
+            </foreach>
         </actionList>
         <elseActionList>
             <setInstallerVariable name="component(deadline_cloud_for_unreal_engine).show" value="0"/>
@@ -49,23 +77,36 @@
 	</initializationActionList>
 	<parameterList>
 		<stringParameter name="deadline_cloud_for_unreal_engine_summary" ask="0" cliOptionShow="0">
-			<value>Deadline Cloud for Unreal Engine 5.2.1
-- Compatible with Unreal Engine 5
+			<value>Deadline Cloud for Unreal Engine 5.2+
+- Compatible with Unreal Engine 5.2 and later
 - Install the Unreal Engine submitter files to the Plugin directory
 </value>
 		</stringParameter>
+        <directoryParameter>
+            <name>unreal_plugin_root</name>
+            <description>Unreal Plugins folder</description>
+            <explanation>Path to the Unreal Plugins folder to install in</explanation>
+            <value></value>
+            <default>${unreal_install_path}\Engine\Plugins</default>
+            <allowEmptyValue>0</allowEmptyValue>
+            <ask>yes</ask>
+            <cliOptionName>unreal-plugins-folder</cliOptionName>
+            <cliOptionText>Path to the Unreal Plugins directory</cliOptionText>
+            <mustBeWritable>yes</mustBeWritable>
+            <mustExist>1</mustExist>
+        </directoryParameter>
         <directoryParameter>
             <name>unreal_plugin_dir</name>
             <description>Deadline Cloud Unreal Plugin directory</description>
             <explanation>Path to the Deadline Cloud Unreal Plugin directory</explanation>
             <value></value>
-            <default>C:\Program Files\Epic Games\UE_5.2\Engine\Plugins\UnrealDeadlineCloudService</default>
+            <default>${unreal_plugin_root}\UnrealDeadlineCloudService</default>
             <allowEmptyValue>0</allowEmptyValue>
-            <ask>yes</ask>
+            <ask>no</ask>
             <cliOptionName>unreal-plugin-directory</cliOptionName>
             <cliOptionText>Path to the Deadline Cloud Unreal Plugin directory</cliOptionText>
             <mustBeWritable>yes</mustBeWritable>
-            <mustExist>1</mustExist>
+            <mustExist>0</mustExist>
         </directoryParameter>
 	</parameterList>
     <postInstallationActionList>

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -1,0 +1,97 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+# Helper script for compiling the plugin and optionally uploading an archive of the binaries and unreal dependencies to S3
+# Currently only works for Windows
+# Assumes your environment is capable of building the plugin, specifically that you have installed Unreal and the toolchain
+# dependencies as described in https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/blob/mainline/SETUP_SUBMITTER_CMF.md#install-build-tools
+# Assumes you're running from the root of your plugin source directory
+
+import shutil
+import boto3
+import os
+import subprocess
+import tempfile
+
+DEFAULT_UE_INSTALL_ROOT = "C:\\Program Files\\Epic Games"
+BUILD_OUTPUT_FOLDER = "Build"
+PLUGIN_FOLDER_NAME = "UnrealDeadlineCloudService"
+BUCKET_PREBUILDS_FOLDER = "component_prebuilds"
+PREBUILD_PLATFORM = "windows-x64" # Currently only supporting windows
+COMPONENT_ZIP_FILE = "deadline-cloud-for-unreal-engine"
+
+def find_latest_runuat_version(folder: str) -> str:
+    # Finds the latest version in the the given folder by searching for all subfolders which begin with "UE_" and comparing the
+    # version strings which come after the underscore
+    latest_version = "5.2"
+    # Default to 5.2 if no other versions are found
+    for subfolder in os.listdir(folder):
+        if subfolder.startswith("UE_"):
+            version = subfolder.split("_")[1]
+            if version > latest_version:
+                latest_version = version
+    # Check if the "runuat.bat" file exists in the latest folder version, raise an exception if not
+    runuat_path = os.path.join(folder, "UE_" + latest_version, "Engine", "Build", "BatchFiles", "RunUAT.bat")
+    if not os.path.exists(runuat_path):
+        raise Exception(f"Could not find RunUAT.bat at {runuat_path}, please supply a --runuat-path or set UE_INSTALL_ROOT to " +
+                        "the folder where Unreal is installed (Should contain UE_VERSION.NUM subfolders)")
+    print(f"Found RunUAT.bat at {runuat_path}")
+    return runuat_path
+
+
+def build_plugin(runuat_path: str = None, input_folder: str = None, output_folder: str = None, upload_bucket: str = None):
+    print(f"Building plugin...")
+    # Create a TemporaryDirectory to build into if no output_folder given
+    output_folder = output_folder or tempfile.TemporaryDirectory().name
+
+    # Find the latest version of Unreal Engine
+    if not runuat_path:
+        ue_install_root = os.environ.get("UE_INSTALL_ROOT", DEFAULT_UE_INSTALL_ROOT)
+        ue_install_root = os.path.expanduser(ue_install_root)
+        runuat_path = find_latest_runuat_version(ue_install_root)
+
+    output_folder = os.path.join(output_folder, BUILD_OUTPUT_FOLDER)
+
+    # Either input_folder path to .uplugin is given, or we assume you're in the root of the repo
+    plugin_input_folder = input_folder or os.path.join(os.getcwd(), "src", "unreal_plugin", "UnrealDeadlineCloudService.uplugin")
+
+    # Build the plugin
+    result = subprocess.run([runuat_path, "BuildPlugin", f"-Plugin={plugin_input_folder}", f"-package={output_folder}", "-TargetPlatform=Win64"], check=True)
+    print(f"Build result: {result.returncode}")
+
+    # Prepare to create an archive.  First create the archive/plugin folder if it doesn't exist
+    archive_folder = os.path.join(output_folder, "archive")
+    plugin_folder = os.path.join(archive_folder, PLUGIN_FOLDER_NAME)
+    print(f"Creating folder {plugin_folder}")
+    os.makedirs(plugin_folder, exist_ok=True)
+    print(f"Copying binaries and resources to {plugin_folder}")
+    # Copy the Binaries, Content and Resources subfolders to the plugin folder, ignoring .pdb files
+    shutil.copytree(os.path.join(output_folder, "Binaries"), os.path.join(plugin_folder, "Binaries"), dirs_exist_ok=True, ignore=shutil.ignore_patterns("*.pdb"))
+    shutil.copytree(os.path.join(output_folder, "Resources"), os.path.join(plugin_folder, "Resources"), dirs_exist_ok=True)
+    shutil.copytree(os.path.join(output_folder, "Content"), os.path.join(plugin_folder, "Content"), dirs_exist_ok=True)
+    shutil.copy2(os.path.join(output_folder,f"{PLUGIN_FOLDER_NAME}.uplugin"), plugin_folder)
+
+    # Create a zip of the output_folder which contains only the Binaries and Resources subfolders, outputting the archive into output_folder
+    output_archive = os.path.join(archive_folder, f'{COMPONENT_ZIP_FILE}.zip')
+    print(f"Creating archive at {output_archive}")
+    # Create a zip archive of the contents of the archive folder which will be named "deadline-cloud-for-unreal-engine.zip"
+    shutil.make_archive(base_name=os.path.splitext(output_archive)[0], format='zip', root_dir=archive_folder, base_dir=PLUGIN_FOLDER_NAME)
+    print(f"Archive created: {output_archive}")
+
+    # Optionally upload the archive to S3
+    if upload_bucket:
+        print(f"Uploading archive to S3 bucket {upload_bucket}")
+        s3 = boto3.client('s3')
+        upload_key = f'{BUCKET_PREBUILDS_FOLDER}/{PREBUILD_PLATFORM}/{COMPONENT_ZIP_FILE}.zip'
+        s3.upload_file(output_archive, upload_bucket, upload_key)
+        print(f"Archive uploaded to s3://{upload_bucket}/{upload_key}")
+
+if __name__ == "__main__":
+    # Parse optional command line arguments for runuat_path, input_folder, output_folder, upload_bucket
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runuat-path", help="Path to RunUAT.bat")
+    parser.add_argument("--input-folder", help="Path to plugin input folder")
+    parser.add_argument("--output-folder", help="Path to output folder")
+    parser.add_argument("--upload-bucket", help="S3 bucket to upload archive to")
+    args = parser.parse_args()
+    build_plugin(args.runuat_path, args.input_folder, args.output_folder, args.upload_bucket)

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -16,8 +16,9 @@ DEFAULT_UE_INSTALL_ROOT = "C:\\Program Files\\Epic Games"
 BUILD_OUTPUT_FOLDER = "Build"
 PLUGIN_FOLDER_NAME = "UnrealDeadlineCloudService"
 BUCKET_PREBUILDS_FOLDER = "component_prebuilds"
-PREBUILD_PLATFORM = "windows-x64" # Currently only supporting windows
+PREBUILD_PLATFORM = "windows-x64"  # Currently only supporting windows
 COMPONENT_ZIP_FILE = "deadline-cloud-for-unreal-engine"
+
 
 def find_latest_runuat_version(folder: str) -> str:
     # Finds the latest version in the the given folder by searching for all subfolders which begin with "UE_" and comparing the
@@ -30,15 +31,24 @@ def find_latest_runuat_version(folder: str) -> str:
             if version > latest_version:
                 latest_version = version
     # Check if the "runuat.bat" file exists in the latest folder version, raise an exception if not
-    runuat_path = os.path.join(folder, "UE_" + latest_version, "Engine", "Build", "BatchFiles", "RunUAT.bat")
+    runuat_path = os.path.join(
+        folder, "UE_" + latest_version, "Engine", "Build", "BatchFiles", "RunUAT.bat"
+    )
     if not os.path.exists(runuat_path):
-        raise Exception(f"Could not find RunUAT.bat at {runuat_path}, please supply a --runuat-path or set UE_INSTALL_ROOT to " +
-                        "the folder where Unreal is installed (Should contain UE_VERSION.NUM subfolders)")
+        raise Exception(
+            f"Could not find RunUAT.bat at {runuat_path}, please supply a --runuat-path or set UE_INSTALL_ROOT to "
+            + "the folder where Unreal is installed (Should contain UE_VERSION.NUM subfolders)"
+        )
     print(f"Found RunUAT.bat at {runuat_path}")
     return runuat_path
 
 
-def build_plugin(runuat_path: str = None, input_folder: str = None, output_folder: str = None, upload_bucket: str = None):
+def build_plugin(
+    runuat_path: str = None,
+    input_folder: str = None,
+    output_folder: str = None,
+    upload_bucket: str = None,
+):
     print(f"Building plugin...")
     # Create a TemporaryDirectory to build into if no output_folder given
     output_folder = output_folder or tempfile.TemporaryDirectory().name
@@ -52,10 +62,21 @@ def build_plugin(runuat_path: str = None, input_folder: str = None, output_folde
     output_folder = os.path.join(output_folder, BUILD_OUTPUT_FOLDER)
 
     # Either input_folder path to .uplugin is given, or we assume you're in the root of the repo
-    plugin_input_folder = input_folder or os.path.join(os.getcwd(), "src", "unreal_plugin", "UnrealDeadlineCloudService.uplugin")
+    plugin_input_folder = input_folder or os.path.join(
+        os.getcwd(), "src", "unreal_plugin", "UnrealDeadlineCloudService.uplugin"
+    )
 
     # Build the plugin
-    result = subprocess.run([runuat_path, "BuildPlugin", f"-Plugin={plugin_input_folder}", f"-package={output_folder}", "-TargetPlatform=Win64"], check=True)
+    result = subprocess.run(
+        [
+            runuat_path,
+            "BuildPlugin",
+            f"-Plugin={plugin_input_folder}",
+            f"-package={output_folder}",
+            "-TargetPlatform=Win64",
+        ],
+        check=True,
+    )
     print(f"Build result: {result.returncode}")
 
     # Prepare to create an archive.  First create the archive/plugin folder if it doesn't exist
@@ -65,29 +86,49 @@ def build_plugin(runuat_path: str = None, input_folder: str = None, output_folde
     os.makedirs(plugin_folder, exist_ok=True)
     print(f"Copying binaries and resources to {plugin_folder}")
     # Copy the Binaries, Content and Resources subfolders to the plugin folder, ignoring .pdb files
-    shutil.copytree(os.path.join(output_folder, "Binaries"), os.path.join(plugin_folder, "Binaries"), dirs_exist_ok=True, ignore=shutil.ignore_patterns("*.pdb"))
-    shutil.copytree(os.path.join(output_folder, "Resources"), os.path.join(plugin_folder, "Resources"), dirs_exist_ok=True)
-    shutil.copytree(os.path.join(output_folder, "Content"), os.path.join(plugin_folder, "Content"), dirs_exist_ok=True)
-    shutil.copy2(os.path.join(output_folder,f"{PLUGIN_FOLDER_NAME}.uplugin"), plugin_folder)
+    shutil.copytree(
+        os.path.join(output_folder, "Binaries"),
+        os.path.join(plugin_folder, "Binaries"),
+        dirs_exist_ok=True,
+        ignore=shutil.ignore_patterns("*.pdb"),
+    )
+    shutil.copytree(
+        os.path.join(output_folder, "Resources"),
+        os.path.join(plugin_folder, "Resources"),
+        dirs_exist_ok=True,
+    )
+    shutil.copytree(
+        os.path.join(output_folder, "Content"),
+        os.path.join(plugin_folder, "Content"),
+        dirs_exist_ok=True,
+    )
+    shutil.copy2(os.path.join(output_folder, f"{PLUGIN_FOLDER_NAME}.uplugin"), plugin_folder)
 
     # Create a zip of the output_folder which contains only the Binaries and Resources subfolders, outputting the archive into output_folder
-    output_archive = os.path.join(archive_folder, f'{COMPONENT_ZIP_FILE}.zip')
+    output_archive = os.path.join(archive_folder, f"{COMPONENT_ZIP_FILE}.zip")
     print(f"Creating archive at {output_archive}")
     # Create a zip archive of the contents of the archive folder which will be named "deadline-cloud-for-unreal-engine.zip"
-    shutil.make_archive(base_name=os.path.splitext(output_archive)[0], format='zip', root_dir=archive_folder, base_dir=PLUGIN_FOLDER_NAME)
+    shutil.make_archive(
+        base_name=os.path.splitext(output_archive)[0],
+        format="zip",
+        root_dir=archive_folder,
+        base_dir=PLUGIN_FOLDER_NAME,
+    )
     print(f"Archive created: {output_archive}")
 
     # Optionally upload the archive to S3
     if upload_bucket:
         print(f"Uploading archive to S3 bucket {upload_bucket}")
-        s3 = boto3.client('s3')
-        upload_key = f'{BUCKET_PREBUILDS_FOLDER}/{PREBUILD_PLATFORM}/{COMPONENT_ZIP_FILE}.zip'
+        s3 = boto3.client("s3")
+        upload_key = f"{BUCKET_PREBUILDS_FOLDER}/{PREBUILD_PLATFORM}/{COMPONENT_ZIP_FILE}.zip"
         s3.upload_file(output_archive, upload_bucket, upload_key)
         print(f"Archive uploaded to s3://{upload_bucket}/{upload_key}")
+
 
 if __name__ == "__main__":
     # Parse optional command line arguments for runuat_path, input_folder, output_folder, upload_bucket
     import argparse
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--runuat-path", help="Path to RunUAT.bat")
     parser.add_argument("--input-folder", help="Path to plugin input folder")

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -49,7 +49,7 @@ def build_plugin(
     output_folder: str = None,
     upload_bucket: str = None,
 ):
-    print(f"Building plugin...")
+    print("Building plugin...")
     # Create a TemporaryDirectory to build into if no output_folder given
     output_folder = output_folder or tempfile.TemporaryDirectory().name
 

--- a/src/unreal_plugin/Content/Python/settings.py
+++ b/src/unreal_plugin/Content/Python/settings.py
@@ -352,7 +352,7 @@ class DeadlineCloudDeveloperSettingsImplementation(unreal.DeadlineCloudDeveloper
         unreal.log("login")
 
         def on_pending_authorization(**kwargs):
-            if kwargs["credential_type"] == AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN:
+            if kwargs["credentials_source"] == AwsCredentialsSource.DEADLINE_CLOUD_MONITOR_LOGIN:
                 unreal.EditorDialog.show_message(
                     "Deadline Cloud",
                     "Opening Deadline Cloud Monitor. Please login before returning here.",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to potentially support prebuilds of the plugin's binaries in our submitter installer.  

The "Login" button on the projects settings page was throwing and error and not always functioning correctly due to an incorrect argument.

### What was the solution? (How)
Add a helper script for building our plugin, creating an archive with the output binaries and other plugin dependencies, and optionally uploading it to an S3 bucket.

Update install builder xml to optionally consume dependencies from the archive.

Update the argument name.

### What is the impact of this change?
None currently.

### How was this change tested?
Built and uploaded archive locally.  Built submitter installer with the bucket used during build, installed the plugin with submitter installer, ran unreal, observed the plugin functioning properly.

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*