### PR TITLE
fix: Submitter installer fixes

### DIFF
--- a/install_builder/deadline-cloud-for-unreal-engine.xml
+++ b/install_builder/deadline-cloud-for-unreal-engine.xml
@@ -18,6 +18,17 @@
             </distributionFileList>
         </folder>
         <folder>
+            <description>Logger Files</description>
+            <destination>${unreal_plugin_dir}/Content/Python/libraries/deadline/unreal_logger</destination>
+            <name>unreal_logger</name>
+            <platforms>all</platforms>
+            <distributionFileList>
+                <distributionDirectory allowWildcards="1">
+                    <origin>components/deadline-cloud-for-unreal-engine/src/deadline/unreal_logger/*</origin>∂
+                </distributionDirectory>
+            </distributionFileList>
+        </folder>
+        <folder>
             <description>Dependency Files</description>
             <destination>${unreal_plugin_dir}/tmp/unreal_deps</destination>
             <name>unreal_deps</name>
@@ -25,17 +36,6 @@
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">
                     <origin>components/deadline-cloud-for-unreal-engine/dependency_bundle</origin>
-                </distributionDirectory>
-            </distributionFileList>
-        </folder>
-        <folder>
-            <description>Prebuild Outputs</description>
-            <destination>${unreal_plugin_dir}</destination>
-            <name>unreal_prebuilds</name>
-            <platforms>all</platforms>
-            <distributionFileList>
-                <distributionDirectory allowWildcards="1">
-                    <origin>components/deadline-cloud-for-unreal-engine/UnrealDeadlineCloudService/*</origin>
                 </distributionDirectory>
             </distributionFileList>
         </folder>
@@ -128,6 +128,7 @@
         <deleteFile>
             <path>${unreal_plugin_dir}/tmp/unreal_deps</path>
         </deleteFile>
+        <addFilesToUninstaller files="${unreal_plugin_dir}" />
     </postInstallationActionList>
     <shouldPackRuleList>
         <compareText>

--- a/src/unreal_plugin/Content/Python/init_unreal.py
+++ b/src/unreal_plugin/Content/Python/init_unreal.py
@@ -5,20 +5,20 @@ import sys
 
 remote_execution = os.getenv("REMOTE_EXECUTION", "False")
 if remote_execution != "True":
+    libraries_path = f"{os.path.dirname(__file__)}/libraries".replace("\\", "/")
+    if not os.getenv("DEADLINE_CLOUD") and os.path.exists(libraries_path):
+        os.environ["DEADLINE_CLOUD"] = libraries_path
+
+    if os.getenv("DEADLINE_CLOUD") and os.environ["DEADLINE_CLOUD"] not in sys.path:
+        sys.path.append(os.environ["DEADLINE_CLOUD"])
+
     from deadline.unreal_logger import get_logger
 
     logger = get_logger()
 
     logger.info("INIT DEADLINE CLOUD")
 
-    libraries_path = f"{os.path.dirname(__file__)}/libraries".replace("\\", "/")
-    if not os.getenv("DEADLINE_CLOUD") and os.path.exists(libraries_path):
-        os.environ["DEADLINE_CLOUD"] = libraries_path
-
     logger.info(f'DEADLINE CLOUD PATH: {os.getenv("DEADLINE_CLOUD")}')
-    if os.getenv("DEADLINE_CLOUD") and os.environ["DEADLINE_CLOUD"] not in sys.path:
-        sys.path.append(os.environ["DEADLINE_CLOUD"])
-
     # These unused imports are REQUIRED!!!
     # Unreal Engine loads any init_unreal.py it finds in its search paths.
     # These imports finish the setup for the plugin.


### PR DESCRIPTION
Fixes intended to support an intermediate release of the Unreal integration while we continue to take in the larger new features currently in flight.

Importing logger after setting uninstall files in submitter installer.  Adding logger to submitter installer.  Setting uninstall files.

### What was the problem/requirement? (What/Why)

- The new logger module was being imported before adding submitter installer installed dependency path to sys.path
- The new logger module wasn't being included in submitter installer.
- Submitter installer didn't properly uninstall the unreal plugin.

### What was the solution? (How)

- Move the code where we import logger further down.
- Add logger to submitter installer
- Add the unreal plugin to our uninstall files.

### What is the impact of this change?

Unreal submitter should function properly when installed from the submitter installer and uninstall properly.

### How was this change tested?
Built, installed and manual testing with submitter installer.
hatch build/hatch run lint/hatch run fmt/hatch run all:test
Uninstalled program successfully

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*