### PR TITLE
fix: Updating CHANGELOG processing to handle recent breaking changes …

### DIFF
--- a/.semantic_release/CHANGELOG.md.j2
+++ b/.semantic_release/CHANGELOG.md.j2
@@ -8,16 +8,16 @@
         {% endfor %}
     {% endif %}
 
-    {% if "feature" in release["elements"] %}
+    {% if "features" in release["elements"] %}
 ### Features
-        {% for commit in release["elements"]["feature"] %}
+        {% for commit in release["elements"]["features"] %}
 * {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(": ")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
         {% endfor %}
     {% endif %}
 
-    {% if "fix" in release["elements"] %}
+    {% if "bug fixes" in release["elements"] %}
 ### Bug Fixes
-        {% for commit in release["elements"]["fix"] %}
+        {% for commit in release["elements"]["bug fixes"] %}
 * {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(":")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
         {% endfor %}
     {% endif %}


### PR DESCRIPTION
…in python-semantic-release

### What was the problem/requirement? (What/Why)
In a recent version of python-semantic-release the keys for parsing some update types was changed.

### What was the solution? (How)
Update the parsing code to conform to new syntax.

### What is the impact of this change?
CHANGELOG will generate correctly again

### How was this change tested?
ran hatch run release:bump locally, saw CHANGELOG populated

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*