### PR TITLE
feat!: ExtraCmdArgsFile parameter to handle param length limit

### DIFF
--- a/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
@@ -289,8 +289,6 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
             with open(extra_cmd_args_file, "r") as f:
                 extra_cmd_str = f.read()
 
-        print(f"EXTRA CMD ARGS: {extra_cmd_str}")
-
         # Everythiing between -execcmds=" and " is the value we want to keep
         match = re.search(r'-execcmds=["\']([^"\']*)["\']', extra_cmd_str)
         if match:

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
@@ -289,6 +289,8 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
             with open(extra_cmd_args_file, "r") as f:
                 extra_cmd_str = f.read()
 
+        print(f"EXTRA CMD ARGS: {extra_cmd_str}")
+
         # Everythiing between -execcmds=" and " is the value we want to keep
         match = re.search(r'-execcmds=["\']([^"\']*)["\']', extra_cmd_str)
         if match:

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
@@ -280,7 +280,18 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
 
         unreal_exe = "UnrealEditor-Cmd"
         unreal_project_path = self.init_data.get("project_path", "")
-        extra_cmd_str = self.init_data.get("extra_cmd_args", "")
+
+        # First, read args from file since it can be too long to pass
+        # them to Job parameter (1024 chars limit)
+        extra_cmd_str = ""
+        extra_cmd_args_file = self.init_data.get("extra_cmd_args_file", "")
+        if os.path.exists(extra_cmd_args_file):
+            with open(extra_cmd_args_file, "r") as f:
+                extra_cmd_str = f.read()
+
+        # If file is empty, read from Job parameter
+        if extra_cmd_str == "":
+            extra_cmd_str = self.init_data.get("extra_cmd_args", "")
 
         # Everythiing between -execcmds=" and " is the value we want to keep
         match = re.search(r'-execcmds=["\']([^"\']*)["\']', extra_cmd_str)

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
@@ -289,10 +289,6 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
             with open(extra_cmd_args_file, "r") as f:
                 extra_cmd_str = f.read()
 
-        # If file is empty, read from Job parameter
-        if extra_cmd_str == "":
-            extra_cmd_str = self.init_data.get("extra_cmd_args", "")
-
         # Everythiing between -execcmds=" and " is the value we want to keep
         match = re.search(r'-execcmds=["\']([^"\']*)["\']', extra_cmd_str)
         if match:

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/init_data.schema.json
@@ -3,7 +3,8 @@
     "type": "object",
     "properties": {
         "project_path": { "type": "string" },
-        "extra_cmd_args": { "type": "string" }
+        "extra_cmd_args": { "type": "string" },
+        "extra_cmd_args_file": { "type":  "string" }
     },
     "required": [
         "project_path"

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/init_data.schema.json
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/init_data.schema.json
@@ -3,7 +3,6 @@
     "type": "object",
     "properties": {
         "project_path": { "type": "string" },
-        "extra_cmd_args": { "type": "string" },
         "extra_cmd_args_file": { "type":  "string" }
     },
     "required": [

--- a/src/deadline/unreal_submitter/templates/default_unreal_job_template_v07.yaml
+++ b/src/deadline/unreal_submitter/templates/default_unreal_job_template_v07.yaml
@@ -29,10 +29,6 @@ parameterDefinitions:
   type: STRING
   default: ""
 
-- name: ExtraCmdArgs
-  type: STRING
-  default: ""
-
 - name: ExtraCmdArgsFile
   type: PATH
   objectType: FILE
@@ -50,7 +46,6 @@ jobEnvironments:
           type: TEXT
           data: |
             project_path: {{Param.ProjectFilePath}}
-            extra_cmd_args: {{Param.ExtraCmdArgs}}
             extra_cmd_args_file: {{Param.ExtraCmdArgsFile}}
       actions:
         onEnter:

--- a/src/deadline/unreal_submitter/templates/default_unreal_job_template_v07.yaml
+++ b/src/deadline/unreal_submitter/templates/default_unreal_job_template_v07.yaml
@@ -33,6 +33,11 @@ parameterDefinitions:
   type: STRING
   default: ""
 
+- name: ExtraCmdArgsFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+
 jobEnvironments:
   - name: LaunchUnrealEditor
     description: Launch UnrealEditor and define the current context as Remote Execution

--- a/src/deadline/unreal_submitter/templates/default_unreal_job_template_v07.yaml
+++ b/src/deadline/unreal_submitter/templates/default_unreal_job_template_v07.yaml
@@ -51,6 +51,7 @@ jobEnvironments:
           data: |
             project_path: {{Param.ProjectFilePath}}
             extra_cmd_args: {{Param.ExtraCmdArgs}}
+            extra_cmd_args_file: {{Param.ExtraCmdArgsFile}}
       actions:
         onEnter:
           command: unreal-engine-openjd

--- a/src/deadline/unreal_submitter/unreal_open_job/open_job_description.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/open_job_description.py
@@ -274,8 +274,6 @@ class OpenJobDescription:
         # TODO handling unreal substitution templates
         output_path = output_path.replace("{project_dir}", project_directory)
 
-        cmd_args = self._get_ue_cmd_args(mrq_job)
-
         parameter_values = [
             {
                 "name": "LevelPath",
@@ -294,24 +292,15 @@ class OpenJobDescription:
                 "value": project_directory,
             },
             {"name": "OutputPath", "value": output_path},
+            {
+                "name": "ExtraCmdArgsFile",
+                "value": create_deadline_cloud_temp_file(
+                    file_prefix="ExtraCmdArgsFile",
+                    file_data=" ".join(self._get_ue_cmd_args(mrq_job)),
+                    file_ext=".txt",
+                ),
+            },
         ]
-
-        cmd_args_str = " ".join(cmd_args)
-
-        cmd_args_param = {"name": "ExtraCmdArgs"}
-        if len(cmd_args_str) <= 1024:
-            cmd_args_param["value"] = cmd_args_str
-        else:
-            cmd_args_param["value"] = mrq_job.preset_overrides.job_shared_settings.extra_cmd_args
-        parameter_values.append(cmd_args_param)
-
-        cmd_args_file_param = {
-            "name": "ExtraCmdArgsFile",
-            "value": create_deadline_cloud_temp_file(
-                file_prefix="ExtraCmdArgsFile", file_data=cmd_args_str, file_ext=".txt"
-            ),
-        }
-        parameter_values.append(cmd_args_file_param)
 
         shared_parameter_values = JobSharedSettings(
             mrq_job.preset_overrides.job_shared_settings

--- a/src/deadline/unreal_submitter/unreal_open_job/open_job_description.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/open_job_description.py
@@ -14,6 +14,7 @@ from deadline.unreal_submitter.common import (
     get_project_directory,
     get_project_file_path,
     soft_obj_path_to_str,
+    create_deadline_cloud_temp_file,
 )
 from deadline.unreal_submitter.unreal_dependency_collector.common import (
     DependencyFilters,
@@ -293,8 +294,24 @@ class OpenJobDescription:
                 "value": project_directory,
             },
             {"name": "OutputPath", "value": output_path},
-            {"name": "ExtraCmdArgs", "value": " ".join(cmd_args)},
         ]
+
+        cmd_args_str = " ".join(cmd_args)
+
+        cmd_args_param = {"name": "ExtraCmdArgs"}
+        if len(cmd_args_str) <= 1024:
+            cmd_args_param["value"] = cmd_args_str
+        else:
+            cmd_args_param["value"] = mrq_job.preset_overrides.job_shared_settings.extra_cmd_args
+        parameter_values.append(cmd_args_param)
+
+        cmd_args_file_param = {
+            "name": "ExtraCmdArgsFile",
+            "value": create_deadline_cloud_temp_file(
+                file_prefix="ExtraCmdArgsFile", file_data=cmd_args_str, file_ext=".txt"
+            ),
+        }
+        parameter_values.append(cmd_args_file_param)
 
         shared_parameter_values = JobSharedSettings(
             mrq_job.preset_overrides.job_shared_settings


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Unreal Submitter collect necessary system command line arguments + user's custom argumets and pass them as STRING  parameter. The result string can exceed the limit of OpenJD STRING parameter length limit of 1024 characters.

### What was the solution? (How)
On Submitter:
Add new parameter ExtraCmdArgsFile of type PATH where the result arguments string saved to the Job template.

On Adaptor:
Read from file ExtraCmdArgsFile

### What is the impact of this change?
User can submit the job with UE cmd arguments of any length

### How was this change tested?
Unittest + QA

### Was this change documented?
Yes

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*