### PR TITLE
feat: Updating build_plugin.py support script to remove unnecessary a…

### DIFF
--- a/SETUP_SUBMITTER_CMF.md
+++ b/SETUP_SUBMITTER_CMF.md
@@ -43,6 +43,22 @@ cd deadline-cloud-for-unreal-engine
 git switch release
 ```
 
+## Optional - Build and Install Plugin with script
+
+A helper script exists at scripts/build_plugin.py which will optionally automate the next 2 steps for you.  It will attempt to find the latest version of Unreal, build your plugin and python dependencies, and install them in the correct locations.  Settings like the Unreal version to use can be overridden.  See the full help list with:
+
+```
+python scripts/build_plugin.py -h
+```
+
+To build and install your current copy of deadline-cloud-for-unreal-engine as a submitter with the latest Unreal Engine installation, run:
+
+```
+python scripts/build_plugin.py --install
+```
+
+If you've installed with this script successfully, you can now skip to "Submitter Installation Complete"
+
 ## Build the Plugin
 
 Adjust the first two paths below based on where your installation of Unreal lives, and where you installed deadline-cloud-for-unreal-engine.
@@ -134,6 +150,31 @@ The Unreal Plugin currently must be compiled locally.
 
 ## Deadline Software Installation
 
+- clone or download `deadline-cloud-for-unreal-engine` either from the release branch or mainline depending on whether you'd like the most recent tested release or all of the most recent commits.  Note that you'll want to ensure your worker version of the libraries is compatible with the version being used from your submitters.
+
+```
+git clone https://github.com/aws-deadline/deadline-cloud-for-unreal-engine.git
+cd deadline-cloud-for-unreal-engine
+git switch release
+```
+
+Optional - Build and install plugin and dependencies with script
+
+A helper script exists at scripts/build_plugin.py which will optionally automate the remaining installation steps for you.  It will attempt to find the latest version of Unreal, build your plugin and python dependencies, and install them in the correct locations.  Settings like the Unreal version to use can be overridden.  See the full help list with:
+
+```
+python scripts/build_plugin.py -h
+```
+
+To build and install your current copy of deadline-cloud-for-unreal-engine as a worker with the latest Unreal Engine installation, run:
+
+```
+python scripts/build_plugin.py --install --worker
+```
+
+If you've installed with this script successfully, you can now skip to "Submit a Test Render"
+
+
 ```
 python -m pip install deadline-cloud-worker-agent
 ```
@@ -152,7 +193,7 @@ pip install hatch
 hatch build
 python -m pip install dist\my-built-wheel.whl
 ```
-- clone or download deadline-cloud-for-unreal-engine
+
 
 ## Build the Plugin
 

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -1,90 +1,99 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-# Helper script for compiling the plugin and optionally uploading an archive of the binaries and unreal dependencies to S3
+# Helper script for compiling the plugin binaries and Python code and optionally installing it to your Unreal Engine installation
 # Currently only works for Windows
 # Assumes your environment is capable of building the plugin, specifically that you have installed Unreal and the toolchain
 # dependencies as described in https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/blob/mainline/SETUP_SUBMITTER_CMF.md#install-build-tools
 # Assumes you're running from the root of your plugin source directory
 
+import argparse
+import logging
 import shutil
-import boto3
 import os
 import subprocess
 import tempfile
 
 DEFAULT_UE_INSTALL_ROOT = "C:\\Program Files\\Epic Games"
-BUILD_OUTPUT_FOLDER = "Build"
 PLUGIN_FOLDER_NAME = "UnrealDeadlineCloudService"
-BUCKET_PREBUILDS_FOLDER = "component_prebuilds"
-PREBUILD_PLATFORM = "windows-x64"  # Currently only supporting windows
-COMPONENT_ZIP_FILE = "deadline-cloud-for-unreal-engine"
+
+logger = logging.getLogger(__name__)
 
 
-def find_latest_runuat_version(folder: str) -> str:
-    # Finds the latest version in the the given folder by searching for all subfolders which begin with "UE_" and comparing the
-    # version strings which come after the underscore
-    latest_version = "5.2"
+def find_latest_unreal_engine(folder: str) -> str:
+    """
+    Finds the latest version in the given folder by searching for all subfolders which begin with "UE_" and comparing the
+    version strings which come after the underscore
+
+    :param folder: Root UE install folder to list for UE_<version> Unreal Engine version installations
+
+    :return: Path to root of latest Unreal Engine installation in folder
+    """
+
+    if not os.path.exists(folder):
+        raise Exception(f"Could not find Unreal Engine install folder at {folder}")
+
     # Default to 5.2 if no other versions are found
+    latest_version = "5.2"
     for subfolder in os.listdir(folder):
         if subfolder.startswith("UE_"):
             version = subfolder.split("_")[1]
             if version > latest_version:
                 latest_version = version
-    # Check if the "runuat.bat" file exists in the latest folder version, raise an exception if not
-    runuat_path = os.path.join(
-        folder, "UE_" + latest_version, "Engine", "Build", "BatchFiles", "RunUAT.bat"
-    )
-    if not os.path.exists(runuat_path):
+
+    engine_root = os.path.join(folder, "UE_" + latest_version)
+    if not os.path.exists(os.path.join(engine_root, "Engine")):
         raise Exception(
-            f"Could not find RunUAT.bat at {runuat_path}, please supply a --runuat-path or set UE_INSTALL_ROOT to "
+            f"Could not find Unreal Engine folder at {engine_root}, please supply an --engine-root to a valid Unreal installation (Should contain an Engine subfolder) or set UE_INSTALL_ROOT to "
             + "the folder where Unreal is installed (Should contain UE_VERSION.NUM subfolders)"
         )
-    print(f"Found RunUAT.bat at {runuat_path}")
-    return runuat_path
+    return engine_root
 
 
-def build_plugin(
-    runuat_path: str = None,
-    input_folder: str = None,
-    output_folder: str = None,
-    upload_bucket: str = None,
-):
-    print("Building plugin...")
-    # Create a TemporaryDirectory to build into if no output_folder given
-    output_folder = output_folder or tempfile.TemporaryDirectory().name
+def get_plugin_folder(engine_root: str) -> str:
+    """
+    :return: Path to the plugin folder for UnrealDeadlineCloudService in the given Unreal Engine installation
+    """
 
-    # Find the latest version of Unreal Engine
-    if not runuat_path:
-        ue_install_root = os.environ.get("UE_INSTALL_ROOT", DEFAULT_UE_INSTALL_ROOT)
-        ue_install_root = os.path.expanduser(ue_install_root)
-        runuat_path = find_latest_runuat_version(ue_install_root)
+    return os.path.join(engine_root, "Engine", "Plugins", PLUGIN_FOLDER_NAME)
 
-    output_folder = os.path.join(output_folder, BUILD_OUTPUT_FOLDER)
 
-    # Either input_folder path to .uplugin is given, or we assume you're in the root of the repo
-    plugin_input_folder = input_folder or os.path.join(
-        os.getcwd(), "src", "unreal_plugin", "UnrealDeadlineCloudService.uplugin"
-    )
+def build_whl() -> str:
+    """
+    Builds the python .whl file by running "hatch build", capturing the stderr lines for the .whl file path
 
-    # Build the plugin
-    result = subprocess.run(
-        [
-            runuat_path,
-            "BuildPlugin",
-            f"-Plugin={plugin_input_folder}",
-            f"-package={output_folder}",
-            "-TargetPlatform=Win64",
-        ],
-        check=True,
-    )
-    print(f"Build result: {result.returncode}")
+    :return: Path to .whl file
+    """
 
-    # Prepare to create an archive.  First create the archive/plugin folder if it doesn't exist
-    archive_folder = os.path.join(output_folder, "archive")
-    plugin_folder = os.path.join(archive_folder, PLUGIN_FOLDER_NAME)
-    print(f"Creating folder {plugin_folder}")
-    os.makedirs(plugin_folder, exist_ok=True)
-    print(f"Copying binaries and resources to {plugin_folder}")
+    # Attempt to build with hatch, if hatch isn't found, install it with pip
+    try:
+        subprocess.run(["hatch", "--version"], check=True, stderr=subprocess.PIPE)
+    except FileNotFoundError:
+        subprocess.run(
+            ["python", "-m", "pip", "install", "hatch"], check=True, stderr=subprocess.PIPE
+        )
+        subprocess.run(["hatch", "--version"], check=True, stderr=subprocess.PIPE)
+
+    result = subprocess.run(["hatch", "build"], check=True, stderr=subprocess.PIPE)
+    lines = result.stderr.decode("utf-8").splitlines()
+    whl_path = None
+    # Go through lines, finding the first which ends in .whl
+    for line in lines:
+        if line.endswith(".whl"):
+            whl_path = line
+            break
+
+    if not whl_path:
+        raise Exception("Failed to retrieve .whl file from hatch build")
+    logger.info(f"Build result: {result.returncode}, whl_path is {whl_path}")
+    return whl_path
+
+
+def install_plugin_build_output(output_folder: str, plugin_folder: str):
+    """
+    Copies the compiled binaries and resources from the given output folder to the given plugin folder
+    """
+
+    logger.info(f"Copying binaries and resources to {plugin_folder}")
     # Copy the Binaries, Content and Resources subfolders to the plugin folder, ignoring .pdb files
     shutil.copytree(
         os.path.join(output_folder, "Binaries"),
@@ -104,35 +113,263 @@ def build_plugin(
     )
     shutil.copy2(os.path.join(output_folder, f"{PLUGIN_FOLDER_NAME}.uplugin"), plugin_folder)
 
-    # Create a zip of the output_folder which contains only the Binaries and Resources subfolders, outputting the archive into output_folder
-    output_archive = os.path.join(archive_folder, f"{COMPONENT_ZIP_FILE}.zip")
-    print(f"Creating archive at {output_archive}")
-    # Create a zip archive of the contents of the archive folder which will be named "deadline-cloud-for-unreal-engine.zip"
-    shutil.make_archive(
-        base_name=os.path.splitext(output_archive)[0],
-        format="zip",
-        root_dir=archive_folder,
-        base_dir=PLUGIN_FOLDER_NAME,
-    )
-    print(f"Archive created: {output_archive}")
 
-    # Optionally upload the archive to S3
-    if upload_bucket:
-        print(f"Uploading archive to S3 bucket {upload_bucket}")
-        s3 = boto3.client("s3")
-        upload_key = f"{BUCKET_PREBUILDS_FOLDER}/{PREBUILD_PLATFORM}/{COMPONENT_ZIP_FILE}.zip"
-        s3.upload_file(output_archive, upload_bucket, upload_key)
-        print(f"Archive uploaded to s3://{upload_bucket}/{upload_key}")
+def install_whl_to_plugin(whl_path: str, engine_root: str):
+    """
+    Installs the given .whl file to the plugin folder in the given Unreal Engine installation
+
+    :param whl_path: Path to .whl file
+    :param engine_root: Path to root of Unreal Engine installation
+    """
+
+    plugin_folder = get_plugin_folder(engine_root)
+
+    python_path = os.path.join(
+        engine_root, "Engine", "Binaries", "ThirdParty", "Python3", "Win64", "python.exe"
+    )
+    if not os.path.exists(python_path):
+        raise Exception(
+            f"Could not find Python executable at {python_path}, please supply an --engine-root to a valid Unreal installation or set UE_INSTALL_ROOT to "
+            + "the folder where Unreal is installed (Should contain UE_VERSION.NUM subfolders)"
+        )
+
+    plugin_libraries_path = os.path.join(plugin_folder, "Content", "Python", "libraries")
+
+    # Pip install the .whl file to the plugin libraries path
+    logger.info(f"Installing {whl_path} to {plugin_libraries_path}")
+    result = subprocess.run(
+        [python_path, "-m", "pip", "install", whl_path, "-t", plugin_libraries_path],
+        check=True,
+    )
+    logger.info(f"Install result: {result.returncode}")
+
+
+def install_plugin(engine_root: str, output_folder: str, whl_path: str):
+    """
+    Installs the plugin to the given Unreal Engine installation, copying the compiled binaries and resources from the given output folder and
+    installing the whl file
+
+    :param engine_root: Path to root of Unreal Engine installation
+    :param output_folder: Path to folder where runuat has output the plugin binaries and resources to
+    :param whl_path: Path to compiled .whl file to install
+    """
+
+    plugin_folder = get_plugin_folder(engine_root)
+
+    if os.path.exists(plugin_folder):
+        logger.info(f"Removing existing plugin folder at {plugin_folder}")
+        shutil.rmtree(plugin_folder)
+
+    install_plugin_build_output(output_folder, plugin_folder)
+    install_whl_to_plugin(whl_path, engine_root)
+    logger.info(f"Plugin installed to {plugin_folder}")
+
+
+def install_whl_global(whl_path: str):
+    """
+    Installs the given .whl file to the global python interpreter
+
+    :param whl_path: Path to whl file
+    """
+
+    if not os.path.exists(whl_path):
+        raise Exception(f"Could not find .whl file at {whl_path}")
+    # Pip install the .whl file to the global python interpreter
+    logger.info(f"Installing {whl_path} to global interpreter")
+    result = subprocess.run(
+        ["python", "-m", "pip", "install", whl_path, "--upgrade"],
+        check=True,
+    )
+    logger.info(f"Install result: {result.returncode}")
+
+
+def find_engine_root() -> str:
+    """
+    Find the latest version of Unreal Engine
+
+    :return: Path to root of engine
+    """
+
+    ue_install_root = os.environ.get("UE_INSTALL_ROOT", DEFAULT_UE_INSTALL_ROOT)
+    ue_install_root = os.path.expanduser(ue_install_root)
+    return find_latest_unreal_engine(ue_install_root)
+
+
+def find_runuat(engine_root: str) -> str:
+    """
+    Check if the "RunUAT.bat" file exists in the expected location for this Engine root, raise an exception if not
+
+    :param engine_root: Path to root of Unreal Engine installation
+
+    :return: Path to RunUAT in the given Unreal Engine installation
+    """
+    if not engine_root:
+        engine_root = find_engine_root()
+    runuat_path = os.path.join(engine_root, "Engine", "Build", "BatchFiles", "RunUAT.bat")
+    if not os.path.exists(runuat_path):
+        raise Exception(
+            f"Could not find RunUAT.bat at {runuat_path}, please supply an --engine-root to a valid Unreal installation or set UE_INSTALL_ROOT to "
+            + "the folder where Unreal is installed (Should contain UE_VERSION.NUM subfolders)"
+        )
+    logger.info(f"Found RunUAT.bat at {runuat_path}")
+    return runuat_path
+
+
+def get_input_uplugin_path() -> str:
+    """
+    Return the path of the .uplugin file to build.  Assumes cwd is the root of deadline-cloud-for-unreal-engine
+
+    :return: Path to .uplugin file within repo
+    """
+
+    uplugin_path = os.path.join(
+        os.getcwd(), "src", "unreal_plugin", "UnrealDeadlineCloudService.uplugin"
+    )
+    if not os.path.exists(uplugin_path):
+        raise Exception(
+            f"Could not find UnrealDeadlineCloudService.uplugin at expected path {uplugin_path}, please run this script from the root of the repo"
+        )
+    return uplugin_path
+
+
+def build_plugin(runuat_path: str, plugin_input_folder: str, output_folder: str):
+    """
+    Run the RunUAT.bat file to build the plugin
+
+    :param runuat_path: Path to RunUAT.bat file
+    :param plugin_input_folder: Path to .uplugin file to build
+    :param output_folder: Path to folder to build the plugin in
+    """
+
+    logger.info("Building plugin...")
+    # Build the plugin
+    result = subprocess.run(
+        [
+            runuat_path,
+            "BuildPlugin",
+            f"-Plugin={plugin_input_folder}",
+            f"-package={output_folder}",
+        ],
+        check=True,
+    )
+    if result.returncode != 0:
+        raise Exception(f"Build failed {result.returncode}")
+
+
+def install_worker_dependencies(engine_root: str):
+    """
+    Installs the dependencies required for the worker plugin to function
+
+    :param engine_root: Path to root of Unreal Engine installation
+    """
+
+    logger.info("Installing worker dependencies...")
+    python_path = os.path.join(
+        engine_root, "Engine", "Binaries", "ThirdParty", "Python3", "Win64", "python.exe"
+    )
+    if not os.path.exists(python_path):
+        raise Exception(
+            f"Could not find Python executable at {python_path}, please supply an --engine-root to a valid Unreal installation or set UE_INSTALL_ROOT to "
+            + "the folder where Unreal is installed (Should contain UE_VERSION.NUM subfolders)"
+        )
+
+    worker_dependencies = ["pywin32"]
+    for dep in worker_dependencies:
+        subprocess.run(
+            [python_path, "-m", "pip", "install", dep],
+            check=True,
+        )
+
+    subprocess.run(
+        ["python", "-m", "pip", "install", "deadline-cloud-worker-agent"],
+        check=True,
+        stderr=subprocess.PIPE,
+    )
+
+
+def build_and_install(
+    engine_root: str = None,
+    uplugin_path: str = None,
+    output_folder: str = None,
+    install: bool = False,
+    worker: bool = False,
+):
+    """
+    Build the plugin and optionally install it to the given Unreal Engine installation
+
+    :param engine_root: Path to root of Unreal Engine installation
+    :param uplugin_path: Path to .uplugin file to build
+    :param output_folder: Path to folder to build the plugin in
+    :param install: Whether to install the plugin to the Unreal Engine installation
+    :param worker: Whether to install the plugin as a worker plugin to the global python interpreter
+    """
+
+    logger.info("Beginning build...")
+
+    # Find the latest version of Unreal Engine
+    if not engine_root:
+        engine_root = find_engine_root()
+
+    runuat_path = find_runuat(engine_root)
+
+    # Create a TemporaryDirectory to build into if no output_folder given
+    output_folder = output_folder or tempfile.TemporaryDirectory().name
+
+    # Either input_folder path to .uplugin is given, or we assume you're in the root of the repo
+    plugin_input_folder = uplugin_path or get_input_uplugin_path()
+
+    build_plugin(runuat_path, plugin_input_folder, output_folder)
+
+    whl_path = build_whl()
+
+    if install:
+        install_plugin(engine_root, output_folder, whl_path)
+
+    if worker:
+        install_whl_global(whl_path)
+        install_worker_dependencies(engine_root)
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description="Build the Deadline Cloud plugin for Unreal Engine"
+    )
+    parser.add_argument(
+        "--engine-root",
+        type=str,
+        help="Path to the root of the Unreal Engine installation.  Attempts to find latest version if not provided.",
+    )
+    parser.add_argument(
+        "--uplugin-path",
+        type=str,
+        help="Path to the .uplugin file for the plugin to build.  Assumes the .uplugin at the default path within this repository if not provided.",
+    )
+    parser.add_argument(
+        "--output-folder",
+        type=str,
+        help="Path to the output folder for the plugin build.  Creates and uses a temporary folder if not provided.",
+    )
+    parser.add_argument(
+        "--install",
+        action="store_true",
+        help="Install the plugin to the Unreal Engine installation",
+    )
+    parser.add_argument(
+        "--worker",
+        action="store_true",
+        help="Install the plugin as a worker plugin to the global python interpreter.  Generally should be paired with --install.",
+    )
+    args = parser.parse_args()
+
+    build_and_install(
+        engine_root=args.engine_root,
+        uplugin_path=args.uplugin_path,
+        output_folder=args.output_folder,
+        install=args.install,
+        worker=args.worker,
+    )
 
 
 if __name__ == "__main__":
-    # Parse optional command line arguments for runuat_path, input_folder, output_folder, upload_bucket
-    import argparse
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--runuat-path", help="Path to RunUAT.bat")
-    parser.add_argument("--input-folder", help="Path to plugin input folder")
-    parser.add_argument("--output-folder", help="Path to output folder")
-    parser.add_argument("--upload-bucket", help="S3 bucket to upload archive to")
-    args = parser.parse_args()
-    build_plugin(args.runuat_path, args.input_folder, args.output_folder, args.upload_bucket)
+    main()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The build helper script previously located the latest RunUAT.bat and built the plugin but did not have options to install the binaries and didn't build or install the dependent python libraries.  We want this script to simplify developer workflows by allowing for both, including an option to build/install for the worker (So also installing the adaptor globally, installing worker dependencies).

This script will additionally be used in future automated testing setup, so it needed better encapsulation of the various methods.

### What was the solution? (How)
- Check for and install hatch
- Build python whl with hatch
- Add --install option which will install binaries and whl to the plugin folder in the given Unreal Engine installation
- Add --worker option which will install the whl globally and install additional dependencies
- Remove no longer useful --upload-bucket option
- Refactor to better encapsulate methods, add more documentation

### What is the impact of this change?
Easier developer iteration cycle

### How was this change tested?
Local testing as both the submitter and worker.  This script will be integrated with upcoming automated testing.

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

Yes

### Is this a breaking change?

No

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
*delete text ending here*

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*