### PR TITLE
docs: Adding instructions for enabling Windows Long Paths

### DIFF
--- a/SETUP_SUBMITTER_CMF.md
+++ b/SETUP_SUBMITTER_CMF.md
@@ -9,6 +9,10 @@ If you’re setting up on a brand new Windows EC2 Instance as your submitter, a 
 1. Download the Epic Installer and install the latest version of Unreal (5.2 or higher is required)
 1. NVIDIA GRID drivers - Follow Windows instructions - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html#nvidia-GRID-driver
 
+## Windows Long Paths
+
+Many of the steps below may attempt to create files which exceed the default Windows maximum path length.  Before attempting to build and install the Deadline Cloud for Unreal Engine submitter or adapter on a Windows machine you are strongly encouraged to enable Windows Long path support by following the instructions in one of the options from [this page](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry), such as by running the PowerShell command [here](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=powershell#tabpanel_1_powershell).
+
 ## Install Build Tools
 
 The Unreal Submitter Plugin currently must be compiled locally.


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/issues/112

### What was the problem/requirement? (What/Why)
Many of our setup steps create files with fairly long paths.  Our setup instructions previously did not encourage and instruct how to enable Windows Long Paths.

### What was the solution? (How)
Add Windows Long Path instructions and links to documentation.

### What is the impact of this change?
Less customer frustration

### How was this change tested?
A customer followed the steps linked, I've followed the Python installer option.

### Have you run a render job successfully with these changes?
Docs only change

### Was this change documented?
This change is docs.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*