### PR TITLE
test: Adding an integration test which submits a level sequence job

### DIFF
--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
@@ -1,0 +1,201 @@
+#include "CoreMinimal.h"
+#include "HAL/PlatformTime.h"
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationCommon.h"
+#include "LevelSequence.h"
+#include "MoviePipelineQueueSubsystem.h"
+#include "MoviePipelineQueue.h"
+#include "MovieScene.h"
+#include "MovieRenderPipelineSettings.h"
+#include "MoviePipelineEditorBlueprintLibrary.h"
+#include "MovieRenderPipeline/DeadlineCloudRenderStepSetting.h"
+#include "MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h"
+#include "Modules/ModuleManager.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogCreateJobTest, Log, All);
+
+// Path to the level sequence Asset to attempt to create a job for
+const char LevelSequencePath[] = "/Game/Levels/Main_SEQ.Main_SEQ";
+
+class WaitForJobCreationLogCommand : public IAutomationLatentCommand, public FOutputDevice
+{
+    // Test command for registering/deregistering log listeners, running a render job using the provided queue and executor, and
+    // listening for expected logging output to indicate success
+public:
+    WaitForJobCreationLogCommand(FAutomationTestBase* testInstance, UMoviePipelineQueueSubsystem* queueSubsystem, UMoviePipelineExecutorBase* executorBase)
+        : m_startTime(FPlatformTime::Seconds())
+        , m_renderStarted(false)
+        , m_testInstance(testInstance)
+        , m_queueSubsystem(queueSubsystem)
+        , m_executor(executorBase)
+    {
+        GLog->AddOutputDevice(this);
+        UE_LOG(LogCreateJobTest, Display, TEXT("Registered log listener"));
+    }
+
+    virtual ~WaitForJobCreationLogCommand()
+    {
+        GLog->RemoveOutputDevice(this);
+        UE_LOG(LogCreateJobTest, Display, TEXT("Deregistered log listener"));
+    }
+
+    virtual void Serialize(const TCHAR* msg, ELogVerbosity::Type verbosity, const FName& category) override
+    {
+        // FOutputDevice Log Message handler
+
+        // Check for Python job creation message
+        if (category == TEXT("LogPython") && FCString::Stristr(msg, TEXT("Job creation result: job-")))
+        {
+            UE_LOG(LogCreateJobTest, Display, TEXT("Found job creation log message"));
+            m_jobCreationFound = true;
+        }
+
+        // Check for dialog message
+        if (category == TEXT("None") &&
+            FCString::Stristr(msg, TEXT("Message dialog closed")) &&
+            FCString::Stristr(msg, TEXT("Submitted jobs (1)")))
+        {
+            UE_LOG(LogCreateJobTest, Display, TEXT("Found dialog confirmation message"));
+            m_dialogConfirmationFound = true;
+        }
+    }
+
+    virtual bool Update() override
+    {
+        if (!m_renderStarted)
+        {
+            UE_LOG(LogCreateJobTest, Display, TEXT("Starting render queue"));
+            m_queueSubsystem->RenderQueueWithExecutorInstance(m_executor);
+            m_renderStarted = true;
+        }
+
+        if (m_jobCreationFound && m_dialogConfirmationFound)
+        {
+            UE_LOG(LogCreateJobTest, Display, TEXT("Both conditions met, marking test as successful"));
+            m_testInstance->TestTrue("Job creation succeeded", true);
+
+            return true;
+        }
+
+        if (FPlatformTime::Seconds() - m_startTime > TimeoutSeconds)
+        {
+            UE_LOG(LogCreateJobTest, Error, TEXT("Timed out after %d seconds. Job Creation: %d, Dialog: %d"),
+                TimeoutSeconds, m_jobCreationFound, m_dialogConfirmationFound);
+            m_testInstance->TestTrue("Job creation succeeded", false);
+            return true;
+        }
+        return false;
+    }
+
+private:
+    const int TimeoutSeconds = 180;
+    double m_startTime = {};
+    bool m_jobCreationFound = false;
+    bool m_dialogConfirmationFound = false;
+    bool m_renderStarted = false;
+    FAutomationTestBase* m_testInstance;
+    UMoviePipelineQueueSubsystem* m_queueSubsystem;
+    UMoviePipelineExecutorBase* m_executor;
+};
+
+class RestoreQueueCommand : public IAutomationLatentCommand
+{
+    // Test command for restoring the "original" provided queue to the queue subsystem
+public:
+    RestoreQueueCommand(UMoviePipelineQueueSubsystem* queueSubsystem, UMoviePipelineQueue* originalQueue)
+        : m_queueSubsystem(queueSubsystem)
+        , m_originalQueue(originalQueue)
+    {
+    }
+
+    virtual bool Update() override
+    {
+        UE_LOG(LogCreateJobTest, Display, TEXT("Restoring original queue"));
+        m_queueSubsystem->LoadQueue(m_originalQueue);
+        return true;
+    }
+
+private:
+    UMoviePipelineQueueSubsystem* m_queueSubsystem;
+    UMoviePipelineQueue* m_originalQueue;
+};
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMovieQueueCreateJobTest, "Deadline.Integration.CreateJob",
+    EAutomationTestFlags::EditorContext |
+    EAutomationTestFlags::ProductFilter)
+
+    bool FMovieQueueCreateJobTest::RunTest(const FString& Parameters)
+{
+    UE_LOG(LogCreateJobTest, Display, TEXT("Starting remote render test"));
+
+    // Get and configure project settings
+    UMovieRenderPipelineProjectSettings* ProjectSettings = GetMutableDefault<UMovieRenderPipelineProjectSettings>();
+    if (!ProjectSettings)
+    {
+        UE_LOG(LogCreateJobTest, Error, TEXT("Failed to get project settings"));
+        return false;
+    }
+
+    ProjectSettings->DefaultRemoteExecutor = FSoftClassPath(TEXT("/Engine/PythonTypes.MoviePipelineDeadlineCloudRemoteExecutor"));
+    UE_LOG(LogCreateJobTest, Display, TEXT("Configured project settings"));
+
+    // Get the Queue Subsystem
+    UMoviePipelineQueueSubsystem* QueueSubsystem = GEditor->GetEditorSubsystem<UMoviePipelineQueueSubsystem>();
+    TestNotNull(TEXT("Queue Subsystem should exist"), QueueSubsystem);
+    UE_LOG(LogCreateJobTest, Display, TEXT("Got queue subsystem"));
+
+    // Cache our original queue and create one to use specifically for this test
+    // We'll restore the queue at the end
+    UMoviePipelineQueue* OriginalQueue = QueueSubsystem->GetQueue();
+    UMoviePipelineQueue* TestQueue = NewObject<UMoviePipelineQueue>();
+    QueueSubsystem->LoadQueue(TestQueue);
+
+    UMoviePipelineQueue* ActiveQueue = QueueSubsystem->GetQueue();
+    TestNotNull(TEXT("Active Queue should exist"), ActiveQueue);
+    UE_LOG(LogCreateJobTest, Display, TEXT("Got Active Queue"));
+
+    // Load sequence and create job
+    FString AssetPath = UTF8_TO_TCHAR(LevelSequencePath);
+    ULevelSequence* LevelSequence = LoadObject<ULevelSequence>(nullptr, *AssetPath);
+    TestNotNull(TEXT("LevelSequence should not be null"), LevelSequence);
+    UE_LOG(LogCreateJobTest, Display, TEXT("Got LevelSequence"));
+
+    UMoviePipelineExecutorJob* NewJob = UMoviePipelineEditorBlueprintLibrary::CreateJobFromSequence(ActiveQueue, LevelSequence);
+    if (!NewJob)
+    {
+        UE_LOG(LogCreateJobTest, Error, TEXT("Failed to CreateJobFromSequence"));
+        return false;
+    }
+    UE_LOG(LogCreateJobTest, Display, TEXT("Created job from sequence"));
+
+    // Currently two "expected" warning/error messages which we should try to resolve separately, but don't currently break anything
+    // in our underlying functionality
+    // The QueueManifest message may appear 1 or 2 times depending on whether you've run the test before.
+    AddExpectedError(TEXT("Failed to load '/Engine/MovieRenderPipeline/Editor/QueueManifest': Can't find file"),
+        EAutomationExpectedErrorFlags::Contains, 0);
+    // The -execcmds message WILL appear twice
+    AddExpectedError(TEXT("Appearance of custom '-execcmds' argument on the Render node can cause unpredictable issues"),
+        EAutomationExpectedErrorFlags::Contains, 2);
+
+    // Load and use remote executor
+    TSubclassOf<UMoviePipelineExecutorBase> ExecutorClass = ProjectSettings->DefaultRemoteExecutor.TryLoadClass<UMoviePipelineExecutorBase>();
+    if (!ExecutorClass)
+    {
+        UE_LOG(LogCreateJobTest, Error, TEXT("Failed to load executor class"));
+        return false;
+    }
+
+    FAutomationTestBase* testInstance = this;
+
+    UE_LOG(LogCreateJobTest, Display, TEXT("Creating executor"));
+    UMoviePipelineExecutorBase* executorBase = NewObject<UMoviePipelineExecutorBase>(GetTransientPackage(), ExecutorClass);
+
+    // Command to set up our log listeners and run our job
+    ADD_LATENT_AUTOMATION_COMMAND(WaitForJobCreationLogCommand(testInstance, QueueSubsystem, executorBase));
+
+    // Cleanup command to restore our queue to its original state
+    ADD_LATENT_AUTOMATION_COMMAND(RestoreQueueCommand(QueueSubsystem, OriginalQueue));
+
+    UE_LOG(LogCreateJobTest, Display, TEXT("Test setup complete"));
+    return true;
+}

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/UnrealDeadlineCloudService.Build.cs
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/UnrealDeadlineCloudService.Build.cs
@@ -64,7 +64,8 @@ public class UnrealDeadlineCloudService : ModuleRules
                 "JsonUtilities",
                 "AssetTools",
                 "Projects",
-                "AssetRegistry"
+                "AssetRegistry",
+                "LevelSequence"
             }
             );
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need more thorough integration testing of creating a job successfully from within the editor and submitting it through the submitter.

### What was the solution? (How)
Add a CreateJob integration test

### What is the impact of this change?
Easier to validate changes

### How was this change tested?
Ran the test successfully from within the UI and on the command line.  Tested multiple submissions.

### Have you run a render job successfully with these changes?
Yes

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*