### PR TITLE
test: Swapping out the static asset path in the new CreateJob test fo…

### DIFF
--- a/install_builder/deadline-cloud-for-unreal-engine.xml
+++ b/install_builder/deadline-cloud-for-unreal-engine.xml
@@ -13,7 +13,7 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">
-                    <origin>components/deadline-cloud-for-unreal-engine/src/deadline/unreal_submitter/*</origin>∂
+                    <origin>components/deadline-cloud-for-unreal-engine/src/deadline/unreal_submitter/*</origin>
                 </distributionDirectory>
             </distributionFileList>
         </folder>
@@ -24,7 +24,7 @@
             <platforms>all</platforms>
             <distributionFileList>
                 <distributionDirectory allowWildcards="1">
-                    <origin>components/deadline-cloud-for-unreal-engine/src/deadline/unreal_logger/*</origin>∂
+                    <origin>components/deadline-cloud-for-unreal-engine/src/deadline/unreal_logger/*</origin>
                 </distributionDirectory>
             </distributionFileList>
         </folder>

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
@@ -1,3 +1,4 @@
+#include "AssetRegistry/AssetRegistryModule.h"
 #include "CoreMinimal.h"
 #include "HAL/PlatformTime.h"
 #include "Misc/AutomationTest.h"
@@ -13,9 +14,6 @@
 #include "Modules/ModuleManager.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogCreateJobTest, Log, All);
-
-// Path to the level sequence Asset to attempt to create a job for
-const char LevelSequencePath[] = "/Game/Levels/Main_SEQ.Main_SEQ";
 
 class WaitForJobCreationLogCommand : public IAutomationLatentCommand, public FOutputDevice
 {
@@ -120,6 +118,43 @@ private:
     UMoviePipelineQueue* m_originalQueue;
 };
 
+ULevelSequence* FindFirstLevelSequence()
+{
+    // Get the asset registry
+    FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+    IAssetRegistry& AssetRegistry = AssetRegistryModule.Get();
+
+    // Create filter to search for level sequences
+    FARFilter Filter;
+    Filter.ClassPaths.Add(ULevelSequence::StaticClass()->GetClassPathName());
+    Filter.PackagePaths.Add(TEXT("/Game"));
+    Filter.bRecursivePaths = true;
+
+    // Get all assets matching our filter
+    TArray<FAssetData> AssetList;
+    AssetRegistry.GetAssets(Filter, AssetList);
+
+    // Find the sequence with shortest path
+    ULevelSequence* ShortestPathSequence = nullptr;
+    int32 ShortestDepth = MAX_int32;
+
+    for (const FAssetData& Asset : AssetList)
+    {
+        FString Path = Asset.GetObjectPathString();
+        TArray<FString> PathSegments;
+        Path.ParseIntoArray(PathSegments, TEXT("/"));
+        int32 Depth = PathSegments.Num();
+
+        if (Depth < ShortestDepth)
+        {
+            ShortestDepth = Depth;
+            ShortestPathSequence = Cast<ULevelSequence>(Asset.GetAsset());
+        }
+    }
+
+    return ShortestPathSequence;
+}
+
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMovieQueueCreateJobTest, "Deadline.Integration.CreateJob",
     EAutomationTestFlags::EditorContext |
     EAutomationTestFlags::ProductFilter)
@@ -154,11 +189,11 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMovieQueueCreateJobTest, "Deadline.Integration
     TestNotNull(TEXT("Active Queue should exist"), ActiveQueue);
     UE_LOG(LogCreateJobTest, Display, TEXT("Got Active Queue"));
 
-    // Load sequence and create job
-    FString AssetPath = UTF8_TO_TCHAR(LevelSequencePath);
-    ULevelSequence* LevelSequence = LoadObject<ULevelSequence>(nullptr, *AssetPath);
+    // Find and load level sequence
+    ULevelSequence* LevelSequence = FindFirstLevelSequence();
+
     TestNotNull(TEXT("LevelSequence should not be null"), LevelSequence);
-    UE_LOG(LogCreateJobTest, Display, TEXT("Got LevelSequence"));
+    UE_LOG(LogCreateJobTest, Display, TEXT("Got LevelSequence: %s"), *LevelSequence->GetPathName());
 
     UMoviePipelineExecutorJob* NewJob = UMoviePipelineEditorBlueprintLibrary::CreateJobFromSequence(ActiveQueue, LevelSequence);
     if (!NewJob)


### PR DESCRIPTION
Swapping out the static asset path in the new CreateJob test for an algorithm that will search for a ULevelSequence with the shortest path depth.  

Removing some extra characters causing warnings in our install builder script.

### What was the problem/requirement? (What/Why)
The new CreateJob test intended to be part of our upcoming end to end tests was using a temporary static asset path based on Meerkat.  Now that we've got a better idea of what project we might use we want to make this asset and test more generic, but still potentially work for Meerkat.

### What was the solution? (How)
Switch to a "Find first ULevelSequence with shortest path depth" algoirthm.

### What is the impact of this change?
Test will now work for Meerkat, the project we're currently thinking of using, or any project with a ULevelSequence living somewhere under /Game

### How was this change tested?
Ran test against Meerkat and TP_DMXBP

### Have you run a render job successfully with these changes?
Test only change, ran the current version of the test successfully.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*