### PR TITLE
feat: support AWS Secrets Manager

### DIFF
--- a/docs/source/docs_usage/p4_credentials_management.rst
+++ b/docs/source/docs_usage/p4_credentials_management.rst
@@ -30,6 +30,73 @@ the new connection will be configured as:
    User = user.from.registry
    Password = password.from.connection
 
+Use AWS Secrets Manager
+***********************
+
+AWS Secrets Manager allows you to store and manage secrets, such as connection credentials,
+in a secure, highly available, and easily managed service. All workers in your fleet (CMF or SMF)
+can access it if you have configured roles and access across workers in your farm.
+
+To make worker apply connection credentials from AWS Secrets Manager, you need to provide the
+name of the secret in the ``AWS_SECRET_P4INFO`` environment variable in any P4 (UGS) Sync Environment you use.
+Or create the new Environment template and prepend it to your Job.
+
+.. code-block:: yaml
+
+   name: P4SyncCmf
+   variables:
+     AWS_SECRET_P4INFO: DeadlineCloud/MyFleet/P4INFO
+
+Secret ``DeadlineCloud/MyFleet/P4INFO`` may contains any of the following key/value pairs:
+
+#. P4PORT - Perforce server port
+#. P4USER - Perforce user
+#. P4PASSWD - Perforce password
+
+.. note:: The names of the keys should be exactly the same
+   as the P4 connection parameters, i. e. ``P4PORT``, ``P4USER``, ``P4PASSWD``
+
+Example:
+
+You have next P4 Sync Environment:
+
+.. code-block:: yaml
+
+   name: P4SyncCmf
+   variables:
+     AWS_SECRET_P4INFO: DeadlineCloud/MyFleet/P4INFO
+     P4USER: j.doe
+     P4PORT: ssl:my-perforce.com:1666
+   ...
+
+And the secret ``DeadlineCloud/MyFleet/P4INFO`` contains:
+
+#. P4PASSWD = MyVeRyS3cretP4ssW0rd
+#. P4USER = aws-admin-user
+
+Environment variables from AWS Secrets Manager will override the ones from the Job. Configured connection
+parameters will be:
+
+.. code-block::
+
+   Port = ssl:my-perforce.com:1666
+   User = aws-admin-user
+   Password = MyVeRyS3cretP4ssW0rd
+
+User appears twice - in Job environment and in AWS Secrets Manager, but last one take precedence.
+
+.. warning::
+   In UGS case you need to use environment data asset for applying P4 secrets -
+   ``src/unreal_plugin/Content/OpenJD_DataAssets/Render/OpenJD_Environment_ApplyP4Secrets.uasset`` -
+   which is referencing to ``src/unreal_plugin/Content/Python/openjd_templates/p4/p4_apply_secrets_environment.yml``.
+
+   This environment apply P4 credentials from AWS Secretes Manager by printing them to the Job log
+   with prefix ``openjd_env:``. Please, see `OpenJD Environment`_ documentation about sharing new
+   environment variables across actions and other environments in runtime. AWS Deadline Cloud
+   constantly evolving and will soon receive an update that will eliminate the need to print variables to set them.
+   But for now it is the only option.
+
+.. _OpenJD Environment: https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md#4-environment
 
 Pass Connection Credentials within the Job Environment
 ******************************************************
@@ -107,6 +174,8 @@ the `Deadline Cloud Queue Environments Git sample`_:
 Conclusions
 ***********
 
+#. The best option is to use AWS Secrets Manager to store connection credentials. It is the most secure,
+   and you can use it for both CMF and SMF.
 #. If you have a CMF farm, where all workers are inside a network that is not accessible from the outside,
    then you can use a single P4 admin user on all workers, changing only ``P4PORT`` if necessary.
    Optionally, you can pass the credentials within the Job Environment.

--- a/docs/source/docs_usage/p4_credentials_management.rst
+++ b/docs/source/docs_usage/p4_credentials_management.rst
@@ -37,6 +37,27 @@ AWS Secrets Manager allows you to store and manage secrets, such as connection c
 in a secure, highly available, and easily managed service. All workers in your fleet (CMF or SMF)
 can access it if you have configured roles and access across workers in your farm.
 
+.. note:: You should configure the access for action ``secretsmanager:GetSecretValue`` for the worker in the queue.
+   For more information visit `Manage access to Windows job user secrets`_. In general, a request to configure access looks like this:
+
+   .. code-block:: json
+
+      {
+        "Version" : "2012-10-17",
+        "Statement" : [
+          //...
+          {
+            "Effect" : "Allow",
+            "Action" : "secretsmanager:GetSecretValue",
+            "Resource" : [
+              "arn:aws:secretsmanager:<your_region>:<your_resource_account>:secret:<your_secret_id_or_wildcard>"
+          }
+          //...
+        ]
+      }
+
+.. _Manage access to Windows job user secrets: https://docs.aws.amazon.com/deadline-cloud/latest/developerguide/manage-access-windows-secrets.html#grant-access
+
 To make worker apply connection credentials from AWS Secrets Manager, you need to provide the
 name of the secret in the ``AWS_SECRET_P4INFO`` environment variable in any P4 (UGS) Sync Environment you use.
 Or create the new Environment template and prepend it to your Job.
@@ -47,6 +68,8 @@ Or create the new Environment template and prepend it to your Job.
    variables:
      AWS_SECRET_P4INFO: DeadlineCloud/MyFleet/P4INFO
 
+.. note:: If ``AWS_SECRET_P4INFO`` value is empty, applying connections from Secrets Manager will be skipped
+
 Secret ``DeadlineCloud/MyFleet/P4INFO`` may contains any of the following key/value pairs:
 
 #. P4PORT - Perforce server port
@@ -56,9 +79,7 @@ Secret ``DeadlineCloud/MyFleet/P4INFO`` may contains any of the following key/va
 .. note:: The names of the keys should be exactly the same
    as the P4 connection parameters, i. e. ``P4PORT``, ``P4USER``, ``P4PASSWD``
 
-Example:
-
-You have next P4 Sync Environment:
+For example, you have next P4 Sync Environment:
 
 .. code-block:: yaml
 
@@ -85,18 +106,25 @@ parameters will be:
 
 User appears twice - in Job environment and in AWS Secrets Manager, but last one take precedence.
 
-.. warning::
-   In UGS case you need to use environment data asset for applying P4 secrets -
-   ``src/unreal_plugin/Content/OpenJD_DataAssets/Render/OpenJD_Environment_ApplyP4Secrets.uasset`` -
-   which is referencing to ``src/unreal_plugin/Content/Python/openjd_templates/p4/p4_apply_secrets_environment.yml``.
+In UGS case you need to prepend to the Job's environments data asset for applying P4 secrets -
+``src/unreal_plugin/Content/OpenJD_DataAssets/Render/OpenJD_Environment_ApplyP4Secrets.uasset`` -
+which is referencing to ``src/unreal_plugin/Content/Python/openjd_templates/p4/p4_apply_secrets_environment.yml``:
 
-   This environment apply P4 credentials from AWS Secretes Manager by printing them to the Job log
+.. literalinclude:: ../../../src/unreal_plugin/Content/Python/openjd_templates/p4/p4_apply_secrets_environment.yml
+    :language: yaml
+    :linenos:
+
+.. warning:: This environment apply P4 credentials from AWS Secretes Manager by printing them to the Job log
    with prefix ``openjd_env:``. Please, see `OpenJD Environment`_ documentation about sharing new
-   environment variables across actions and other environments in runtime. AWS Deadline Cloud
-   constantly evolving and will soon receive an update that will eliminate the need to print variables to set them.
-   But for now it is the only option.
+   environment variables across actions and other environments in runtime.
+
+   **Use with caution because sensitive data, such as the password, port, and user,**
+   **will be reflected in the job execution history.**
 
 .. _OpenJD Environment: https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md#4-environment
+
+You can override ``AWS_SECRET_P4INFO`` value in MRQ Slate UI (Environments overrides block) or update its value
+in the ``src/unreal_plugin/Content/Python/openjd_templates/p4/p4_apply_secrets_environment.yml`` file.
 
 Pass Connection Credentials within the Job Environment
 ******************************************************

--- a/docs/source/docs_usage/p4_credentials_management.rst
+++ b/docs/source/docs_usage/p4_credentials_management.rst
@@ -118,10 +118,18 @@ which is referencing to ``src/unreal_plugin/Content/Python/openjd_templates/p4/p
    with prefix ``openjd_env:``. Please, see `OpenJD Environment`_ documentation about sharing new
    environment variables across actions and other environments in runtime.
 
-   **Use with caution because sensitive data, such as the password, port, and user,**
-   **will be reflected in the job execution history.**
+   **Consider adding a CloudWatch data protection policy to your account if you'll be echoing***
+   **sensitive information. For example, this will apply a global policy to your CloudWatch logs**
+   **which suppresses "openjd_env": lines which appear to be setting environment variables:**
+
+   .. literalinclude:: ../resources/logs_policy_example.sh
+    :language: sh
+    :linenos:
+
+   For more information and options please see `Custom data identifiers`_
 
 .. _OpenJD Environment: https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md#4-environment
+.. _Custom data identifiers: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL-custom-data-identifiers.html
 
 You can override ``AWS_SECRET_P4INFO`` value in MRQ Slate UI (Environments overrides block) or update its value
 in the ``src/unreal_plugin/Content/Python/openjd_templates/p4/p4_apply_secrets_environment.yml`` file.
@@ -202,8 +210,10 @@ the `Deadline Cloud Queue Environments Git sample`_:
 Conclusions
 ***********
 
-#. The best option is to use AWS Secrets Manager to store connection credentials. It is the most secure,
-   and you can use it for both CMF and SMF.
+#. Perforce connection credentials can be stored in centralized location in Secrets Manager from a
+   secret your workers will retrieve at runtime. Be aware that with UGS this method currently
+   requires exposing these credentials to your job logs in your account. Consider using a data
+   protection policy to hide them. This will work for both CMF and SMF.
 #. If you have a CMF farm, where all workers are inside a network that is not accessible from the outside,
    then you can use a single P4 admin user on all workers, changing only ``P4PORT`` if necessary.
    Optionally, you can pass the credentials within the Job Environment.

--- a/docs/source/resources/logs_policy_example.sh
+++ b/docs/source/resources/logs_policy_example.sh
@@ -1,0 +1,38 @@
+aws logs put-account-policy
+--policy-name "MaskOpenJDEnvSecrets"
+--policy-type DATA_PROTECTION_POLICY
+--scope ALL
+--policy-document '{
+  "Name": "openjd_data_protection",
+  "Description": "Hides openjd_env log line data which may be setting sensitive info",
+  "Version": "2021-06-01",
+  "Configuration": {
+    "CustomDataIdentifier": [
+      {"Name": "OpenjdEnv", "Regex": "openjd_env:\s*[^=]+=.*"}
+    ]
+  },
+  "Statement": [
+    {
+      "Sid": "audit-policy",
+      "DataIdentifier": [
+        "OpenjdEnv"
+      ],
+      "Operation": {
+        "Audit": {
+          "NoFindingsDestination": {}
+        }
+      }
+    },
+    {
+      "Sid": "redact-policy",
+      "DataIdentifier": [
+        "OpenjdEnv"
+      ],
+      "Operation": {
+        "Deidentify": {
+          "MaskConfig": {}
+        }
+      }
+    }
+  ]
+}'

--- a/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_custom_step_handler.py
+++ b/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_custom_step_handler.py
@@ -87,13 +87,21 @@ class UnrealCustomStepHandler(BaseStepHandler):
 
             logger.info(f"Custom Step Executor Result: {result}")
             return True
-
-        except (KeyError, RuntimeError) as e:
-            logger.info(
-                f"Custom Step Executor: Error: "
-                f'Error occured while executing the given script {args.get("script_path")}: {str(e)}\n'
-            )
+        except KeyError as e:
             logger.info(traceback.format_exc())
+            logger.info(
+                f"Custom Step Executor: Error: {str(e)}. "
+                f"It is possible `script_path` missed from args {args}\n"
+            )
+            return False
+        except RuntimeError as e:
+            logger.info(traceback.format_exc())
+            logger.info(
+                f"Custom Step Executor: Error: {str(e)}"
+                f"Error occurred while executing the given script {args.get('script_path')} "
+                f"with args {args.get('script_args')} via "
+                f"unreal.PythonScriptLibrary.execute_python_command_ex\n"
+            )
             return False
 
     def wait_result(self, args: Optional[dict] = None) -> None:  # pragma: no cover

--- a/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_custom_step_handler.py
+++ b/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_custom_step_handler.py
@@ -88,19 +88,27 @@ class UnrealCustomStepHandler(BaseStepHandler):
             logger.info(f"Custom Step Executor Result: {result}")
             return True
         except KeyError as e:
-            logger.info(traceback.format_exc())
-            logger.info(
+            logger.error(traceback.format_exc())
+            logger.error(
                 f"Custom Step Executor: Error: {str(e)}. "
-                f"It is possible `script_path` missed from args {args}\n"
+                f"It is possible `script_path` missed from args {args}"
             )
             return False
         except RuntimeError as e:
-            logger.info(traceback.format_exc())
-            logger.info(
+            logger.error(traceback.format_exc())
+            logger.error(
                 f"Custom Step Executor: Error: {str(e)}"
                 f"Error occurred while executing the given script {args.get('script_path')} "
                 f"with args {args.get('script_args')} via "
-                f"unreal.PythonScriptLibrary.execute_python_command_ex\n"
+                f"unreal.PythonScriptLibrary.execute_python_command_ex"
+            )
+            return False
+        except Exception as e:
+            logger.error(traceback.format_exc())
+            logger.error(
+                f"Custom Step Executor: Error: {str(e)}"
+                f"Unexpected error occurred while executing the given script "
+                f"{args.get('script_path')}"
             )
             return False
 

--- a/src/deadline/unreal_perforce_utils/app.py
+++ b/src/deadline/unreal_perforce_utils/app.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Optional
 
 from deadline.unreal_logger import get_logger
-from deadline.unreal_perforce_utils import perforce, exceptions
+from deadline.unreal_perforce_utils import perforce, exceptions, secret_manager
 
 logger = get_logger()
 
@@ -386,3 +386,37 @@ def delete_workspace(workspace_name: Optional[str] = None, project_name: Optiona
 
     if last_exception and isinstance(last_exception, Exception):
         raise last_exception
+
+
+def apply_perforce_secrets() -> None:
+    """
+    Apply secrets from Boto3 SecretsManager to Perforce environment variables. Try to find secret
+    by name stored in AWS_SECRET_P4INFO and apply all key/value pairs from it as environment variables.
+
+    The following environment variables can be set:
+
+    - P4USER
+    - P4PASSWD
+    - P4PORT
+
+    .. warning::
+       Use with caution! In current implementation all retrieved env variables will be applied with
+       printing to stdout, some sensitive data can be reflected in the job execution history.
+
+    """
+
+    logger.warning(
+        "When using environment variables to connect to Perforce, they will appear in the logs "
+        "with the prefix 'openjd_env'. Use with caution because sensitive data, such as the "
+        "password, port, and user, will be reflected in the job execution history."
+    )
+    logger.info("Applying perforce secrets from Boto3 SecretsManager ...")
+
+    p4_info = secret_manager.get_perforce_info()
+    if not p4_info:
+        logger.info("No perforce secrets found in Boto3 SecretsManager. Skip applying")
+        return
+
+    for env_name, env_value in p4_info.items():
+        # For some reason, adaptor doesn't show logger records, need to R&D
+        print(f"openjd_env: {env_name}={env_value}")

--- a/src/deadline/unreal_perforce_utils/app.py
+++ b/src/deadline/unreal_perforce_utils/app.py
@@ -400,15 +400,18 @@ def apply_perforce_secrets() -> None:
     - P4PORT
 
     .. warning::
-       Use with caution! In current implementation all retrieved env variables will be applied with
-       printing to stdout, some sensitive data can be reflected in the job execution history.
+       Be aware that by default environment variables are persisted by printing to stdout
+       (See the openjd_env: line at the end of this method). Consider adding a CloudWatch data
+       protection policy to prevent potentially sensitive information from being echoed to your logs.
+       (See Custom data identifiers - https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL-custom-data-identifiers.html)
 
     """
 
     logger.warning(
-        "When using environment variables to connect to Perforce, they will appear in the logs "
-        "with the prefix 'openjd_env'. Use with caution because sensitive data, such as the "
-        "password, port, and user, will be reflected in the job execution history."
+        "Be aware that by default environment variables are persisted by printing to stdout."
+        "Consider adding a CloudWatch data protection policy to prevent potentially sensitive "
+        "information from being echoed to your logs. (See Custom data identifiers - "
+        "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL-custom-data-identifiers.html)"
     )
     logger.info("Applying perforce secrets from Boto3 SecretsManager ...")
 

--- a/src/deadline/unreal_perforce_utils/cli.py
+++ b/src/deadline/unreal_perforce_utils/cli.py
@@ -7,7 +7,9 @@ from deadline.unreal_perforce_utils import app
 
 def parse_args():
     argparser = argparse.ArgumentParser("unreal-perforce-utils")
-    argparser.add_argument("command", choices=["create_workspace", "delete_workspace"])
+    argparser.add_argument(
+        "command", choices=["create_workspace", "delete_workspace", "apply_perforce_secrets"]
+    )
     argparser.add_argument("-UnrealProjectName", required=False, help="Unreal Project Name")
     argparser.add_argument(
         "-UnrealProjectRelativePath", required=False, help="Relative path to the workspace root"
@@ -45,6 +47,9 @@ def main():
         app.delete_workspace(
             workspace_name=args.PerforceWorkspaceName, project_name=args.UnrealProjectName
         )
+
+    if args.command == "apply_perforce_secrets":
+        app.apply_perforce_secrets()
 
 
 if __name__ == "__main__":

--- a/src/deadline/unreal_perforce_utils/exceptions.py
+++ b/src/deadline/unreal_perforce_utils/exceptions.py
@@ -15,3 +15,9 @@ class PerforceConnectionError(Exception):
     """Raised when failed to connect to the Perforce with given credentials"""
 
     pass
+
+
+class SecretsManagerError(Exception):
+    """Raised when failed to get secret from Boto3 SecretsManager"""
+
+    pass

--- a/src/deadline/unreal_perforce_utils/perforce.py
+++ b/src/deadline/unreal_perforce_utils/perforce.py
@@ -6,7 +6,7 @@ from P4 import P4, P4Exception
 from typing import Optional, Any
 
 from deadline.unreal_logger import get_logger
-from deadline.unreal_perforce_utils import exceptions
+from deadline.unreal_perforce_utils import exceptions, secret_manager
 
 
 logger = get_logger()
@@ -16,11 +16,15 @@ class PerforceConnection:
     """
     Wrapper around the P4 object of p4python package
 
-    P4 connection can be created by passing port, user, password and charset to the constructor
-    or setting appropriate P4PORT, P4USER and P4PASSWD environment variables.
+    P4 connection can be created by:
+
+    1. passing port, user, password and charset to the constructor
+    2. providing AWS Secrets Manager secret name in env variable AWS_SECRET_P4INFO where
+       p4 connection parameters are stored
+    3. setting appropriate P4PORT, P4USER and P4PASSWD environment variables.
 
     .. note::
-       Current connection properties will be used by default
+       Default connection properties will be used if none of the above is provided
     """
 
     def __init__(
@@ -33,11 +37,13 @@ class PerforceConnection:
         p4 = P4()
         p4.charset = charset
 
-        p4_port = port or os.getenv("P4PORT")
+        p4_secret = secret_manager.get_perforce_info() or {}
+
+        p4_port = port or p4_secret.get("P4PORT") or os.getenv("P4PORT")
         if p4_port:
             p4.port = p4_port
 
-        p4_user = user or os.getenv("P4USER")
+        p4_user = user or p4_secret.get("P4USER") or os.getenv("P4USER")
         if p4_user:
             p4.user = p4_user
 
@@ -55,7 +61,7 @@ class PerforceConnection:
         # appropriate property will be set automatically. That means right here if
         # os.environ["P4PASSWD"] = "SomePass" then p4.password will be set to "SomePass".
         # But let's be defensive and set it explicitly
-        p4_password = password or os.getenv("P4PASSWD")
+        p4_password = password or p4_secret.get("P4PASSWD") or os.getenv("P4PASSWD")
         if p4_password:
             p4.password = p4_password
             p4.run_login()

--- a/src/deadline/unreal_perforce_utils/perforce.py
+++ b/src/deadline/unreal_perforce_utils/perforce.py
@@ -32,6 +32,7 @@ class PerforceConnection:
         port: Optional[str] = None,
         user: Optional[str] = None,
         password: Optional[str] = None,
+        client: Optional[str] = None,
         charset="none",
     ):
         p4 = P4()
@@ -65,6 +66,10 @@ class PerforceConnection:
         if p4_password:
             p4.password = p4_password
             p4.run_login()
+
+        p4_client = client or os.getenv("P4CLIENT")
+        if p4_client:
+            p4.client = p4_client
 
         self.p4 = p4
 

--- a/src/deadline/unreal_perforce_utils/secret_manager.py
+++ b/src/deadline/unreal_perforce_utils/secret_manager.py
@@ -3,13 +3,14 @@
 import os
 import ast
 import traceback
-from typing import Optional
+from typing import Optional, Any
 
 import boto3
 from botocore.exceptions import ClientError
 from botocore.utils import InstanceMetadataRegionFetcher
 
 from deadline.unreal_logger import get_logger
+from deadline.unreal_perforce_utils import exceptions
 
 
 logger = get_logger()
@@ -38,37 +39,60 @@ def get_secret_manager_client():
     return boto3.client(**client_params)
 
 
-def get_secret_from_env(secret_variable_name: str) -> Optional[str]:
+def get_secret(secret_name: str) -> str:
     """
     Retrieves a secret from Boto3 SecretsManager using passed environment variable name to get secret name.
 
-    :param secret_variable_name: The name of the environment variable containing the secret id
-    :type secret_variable_name: str
+    :param secret_name: The name (id) of the secret
+    :type secret_name: str
     :return: The secret string
-    :rtype: Optional[str]
+    :rtype: str
     """
-    logger.info(f"Getting secret from environment variable: {secret_variable_name}")
+    logger.info(f"Getting secret by name: {secret_name}")
 
     sm_client = get_secret_manager_client()
-
-    secret_id = os.getenv(secret_variable_name)
-    if secret_id in [None, ""]:
-        logger.warning(f"Cant get secret from empty environment variable {secret_variable_name}")
-        return None
-
     try:
-        response = sm_client.get_secret_value(SecretId=secret_id)
+        response = sm_client.get_secret_value(SecretId=secret_name)
     except ClientError as e:
-        logger.warning(
-            f"Failed to get secret from Boto3 SecretsManager by id {secret_id}."
+        raise exceptions.SecretsManagerError(
+            f"Failed to get secret from Boto3 SecretsManager by name {secret_name}."
             f"{e} -- {traceback.format_exc()}"
         )
-        return None
 
     if "SecretString" not in response:
         raise KeyError(f"SecretString key not found in response: {response}")
 
     return response["SecretString"]
+
+
+def validate_perforce_info(perforce_info_str: str, allowed_keys: set[str]) -> dict[str, Any]:
+    try:
+        perforce_info = ast.literal_eval(perforce_info_str)
+        if not isinstance(perforce_info, dict):
+            raise ValueError(
+                f"Perforce info string content is not a dictionary: {perforce_info_str}"
+            )
+
+        actual_keys = set(perforce_info.keys())
+        if not actual_keys:
+            raise ValueError(
+                "Perforce info must not be empty and should contain at least one of "
+                f"{allowed_keys}"
+            )
+
+        if not actual_keys.issubset(allowed_keys):
+            raise ValueError(
+                f"Perforce info contains invalid keys. "
+                f"Allowed keys: {allowed_keys}. Found: {actual_keys}"
+            )
+
+        return perforce_info
+
+    except (ValueError, SyntaxError) as e:
+        raise exceptions.SecretsManagerError(
+            f"Failed to parse perforce info from Boto3 SecretsManager: {perforce_info_str}."
+            f"{e} -- {traceback.format_exc()}"
+        )
 
 
 def get_perforce_info() -> Optional[dict[str, str]]:
@@ -81,11 +105,15 @@ def get_perforce_info() -> Optional[dict[str, str]]:
     """
 
     secret_env_name = "AWS_SECRET_P4INFO"
-    if os.getenv(secret_env_name) in [None, ""]:
+    secret_env_value = os.getenv(secret_env_name)
+    if secret_env_value == "":
         logger.warning(
-            f"{secret_env_name} environment variable not found or empty. Cant get perforce info"
+            f"{secret_env_name} environment variable is empty string ''. Skip get perforce info"
         )
         return None
+    if secret_env_value is None:
+        logger.warning(f"{secret_env_name} environment variable not found. Skip get perforce info")
+        return None
 
-    p4_info_secret = get_secret_from_env(secret_env_name)
-    return ast.literal_eval(p4_info_secret) if p4_info_secret else None
+    p4_info_secret = get_secret(secret_env_value)
+    return validate_perforce_info(p4_info_secret, allowed_keys={"P4PORT", "P4USER", "P4PASSWD"})

--- a/src/deadline/unreal_perforce_utils/secret_manager.py
+++ b/src/deadline/unreal_perforce_utils/secret_manager.py
@@ -2,9 +2,11 @@
 
 import os
 import ast
+import traceback
 from typing import Optional
 
 import boto3
+from botocore.exceptions import ClientError
 from botocore.utils import InstanceMetadataRegionFetcher
 
 from deadline.unreal_logger import get_logger
@@ -45,18 +47,24 @@ def get_secret_from_env(secret_variable_name: str) -> Optional[str]:
     :return: The secret string
     :rtype: Optional[str]
     """
-    logger.info(f"Getting perforce secret from environment variable: {secret_variable_name}")
+    logger.info(f"Getting secret from environment variable: {secret_variable_name}")
 
     sm_client = get_secret_manager_client()
 
     secret_id = os.getenv(secret_variable_name)
     if secret_id in [None, ""]:
+        logger.warning(f"Cant get secret from empty environment variable {secret_variable_name}")
+        return None
+
+    try:
+        response = sm_client.get_secret_value(SecretId=secret_id)
+    except ClientError as e:
         logger.warning(
-            f"Cant get perforce secret from empty environment variable {secret_variable_name}"
+            f"Failed to get secret from Boto3 SecretsManager by id {secret_id}."
+            f"{e} -- {traceback.format_exc()}"
         )
         return None
 
-    response = sm_client.get_secret_value(SecretId=secret_id)
     if "SecretString" not in response:
         raise KeyError(f"SecretString key not found in response: {response}")
 

--- a/src/deadline/unreal_perforce_utils/secret_manager.py
+++ b/src/deadline/unreal_perforce_utils/secret_manager.py
@@ -1,0 +1,83 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+import ast
+from typing import Optional
+
+import boto3
+from botocore.utils import InstanceMetadataRegionFetcher
+
+from deadline.unreal_logger import get_logger
+
+
+logger = get_logger()
+
+
+def get_secret_manager_client():
+    """
+    Creates a boto3 client for the AWS SecretsManager service.
+
+    This function figures out the region to use. If the environment variable
+    `AWS_REGION_NAME` is set, it will be used. Otherwise, the region will be
+    determined by the `botocore.utils.InstanceMetadataRegionFetcher.retrieve_region()`.
+
+    :return: A SecretsManager client
+    """
+
+    client_params = {"service_name": "secretsmanager"}
+
+    if "AWS_REGION_NAME" in os.environ and os.environ["AWS_REGION_NAME"] != "":
+        client_params["region_name"] = os.environ["AWS_REGION_NAME"]
+    else:
+        fetcher = InstanceMetadataRegionFetcher()
+        client_params["region_name"] = fetcher.retrieve_region()
+    logger.info(f"SecretsManager client parameters: {client_params}")
+
+    return boto3.client(**client_params)
+
+
+def get_secret_from_env(secret_variable_name: str) -> Optional[str]:
+    """
+    Retrieves a secret from Boto3 SecretsManager using passed environment variable name to get secret name.
+
+    :param secret_variable_name: The name of the environment variable containing the secret id
+    :type secret_variable_name: str
+    :return: The secret string
+    :rtype: Optional[str]
+    """
+    logger.info(f"Getting perforce secret from environment variable: {secret_variable_name}")
+
+    sm_client = get_secret_manager_client()
+
+    secret_id = os.getenv(secret_variable_name)
+    if secret_id in [None, ""]:
+        logger.warning(
+            f"Cant get perforce secret from empty environment variable {secret_variable_name}"
+        )
+        return None
+
+    response = sm_client.get_secret_value(SecretId=secret_id)
+    if "SecretString" not in response:
+        raise KeyError(f"SecretString key not found in response: {response}")
+
+    return response["SecretString"]
+
+
+def get_perforce_info() -> Optional[dict[str, str]]:
+    """
+    Retrieves perforce connection parameters from Boto3 SecretsManager
+    using AWS_SECRET_P4INFO environment to get secret name.
+
+    :return: The perforce connection parameters
+    :rtype: Optional[dict[str, str]]
+    """
+
+    secret_env_name = "AWS_SECRET_P4INFO"
+    if os.getenv(secret_env_name) in [None, ""]:
+        logger.warning(
+            f"{secret_env_name} environment variable not found or empty. Cant get perforce info"
+        )
+        return None
+
+    p4_info_secret = get_secret_from_env(secret_env_name)
+    return ast.literal_eval(p4_info_secret) if p4_info_secret else None

--- a/src/deadline/unreal_perforce_utils/unreal_source_control.py
+++ b/src/deadline/unreal_perforce_utils/unreal_source_control.py
@@ -1,0 +1,179 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+import unreal
+import configparser
+
+from deadline.unreal_logger import get_logger
+from deadline.unreal_perforce_utils import exceptions
+
+
+logger = get_logger()
+
+
+_SOURCE_CONTROL_INI_RELATIVE_PATH = "Saved/Config/WindowsEditor/SourceControlSettings.ini"
+_CONFIGURE_PERFORCE_MESSAGE = (
+    "Please, configure Source Control plugin to use Perforce during the submission"
+)
+
+
+def validate_source_control_file(sc_file: str) -> str:
+    """
+    Check if SourceControlSettings.ini file exists
+
+    :param sc_file: Path to the SourceControlSettings.ini file
+    :return: Path to the SourceControlSettings.ini file
+    :raises FileNotFoundError: If SourceControlSettings.ini file does not exist
+    """
+
+    if not os.path.exists(sc_file):
+        raise FileNotFoundError(
+            f"SourceControlSettings.ini not found: {sc_file}. "
+            f"Check if Unreal Source Control is enabled, relaunch the project and try again."
+        )
+
+    return sc_file
+
+
+def validate_has_section(
+    sc_settings: configparser.ConfigParser,
+    section_name: str,
+) -> configparser.ConfigParser:
+    """
+    Validate that the given configparser object has the specified section.
+
+    :param sc_settings: A configparser object containing the source control settings.
+    :param section_name: The name of the section to validate.
+    :return: The configparser object if the section is found.
+    :raises KeyError: If the section is not found in the configparser object.
+    """
+
+    if not sc_settings.has_section(section_name):
+        raise KeyError(f"{section_name} section not found in {_SOURCE_CONTROL_INI_RELATIVE_PATH}")
+
+    return sc_settings
+
+
+def validate_has_option(
+    sc_settings: configparser.ConfigParser,
+    section_name: str,
+    option_name: str,
+) -> configparser.ConfigParser:
+    """
+    Validate that the given configparser object has the specified option in the specified section.
+
+    :param sc_settings: A configparser object containing the source control settings.
+    :param section_name: The name of the section to validate.
+    :param option_name: The name of the option to check for within the section.
+    :return: The configparser object if the option is found in the specified section.
+    :raises KeyError: If the option is not found in the specified section of the configparser object.
+    """
+
+    try:
+        sc_settings.get(section_name, option_name)
+    except configparser.NoOptionError:
+        raise KeyError(
+            f"{section_name} section does not contain '{option_name}' setting "
+            f"in {_SOURCE_CONTROL_INI_RELATIVE_PATH}"
+        )
+
+    return sc_settings
+
+
+def validate_provider(sc_settings: configparser.ConfigParser) -> configparser.ConfigParser:
+    """
+    Check if SourceControlSettings.ini file Provider is "Perforce"
+
+    :param sc_settings: A configparser object containing the source control settings.
+    :return: The configparser object if the settings are valid.
+    :raises ValueError: If the settings are not valid.
+    """
+    section_name = "SourceControl.SourceControlSettings"
+    option_name = "Provider"
+    validate_has_option(sc_settings, section_name, option_name)
+
+    provider = sc_settings.get(section_name, option_name)
+    if provider != "Perforce":
+        raise ValueError(
+            f"{section_name}.{option_name} = {provider}. "
+            f"Can't get Perforce connection settings. {_CONFIGURE_PERFORCE_MESSAGE}"
+            f""
+        )
+
+    return sc_settings
+
+
+def validate_perforce_source_control_settings(
+    sc_settings: configparser.ConfigParser,
+) -> configparser.ConfigParser:
+    """
+    Check if SourceControlSettings.ini has the valid Perforce connection settings.
+    Raises an errors if there are any missing keys or values for Port, User and Workspace
+
+    :param sc_settings: A configparser object containing the source control settings.
+    :return: The configparser object if the settings are valid.
+    :raises KeyError: If the settings are not valid.
+    """
+
+    section_name = "PerforceSourceControl.PerforceSourceControlSettings"
+    expected_keys = {"Port", "UserName", "Workspace"}
+
+    missed_keys: set[str] = {
+        k for k in expected_keys if not sc_settings.has_option(section_name, k)
+    }
+    if missed_keys:
+        raise KeyError(
+            "Some keys are missed in PerforceSourceControl.PerforceSourceControlSettings. "
+            f"Expected: {expected_keys}. Actual: {expected_keys - missed_keys}. "
+            f"{_CONFIGURE_PERFORCE_MESSAGE}"
+        )
+
+    missed_values: set[str] = {k for k in expected_keys if not sc_settings.get(section_name, k)}
+    if missed_values:
+        raise ValueError(
+            f"Some parameters is unfilled in PerforceSourceControl.PerforceSourceControlSettings: "
+            f"{missed_values}. "
+            f"{_CONFIGURE_PERFORCE_MESSAGE}"
+        )
+
+    return sc_settings
+
+
+def get_connection_settings_from_ue_source_control() -> dict[str, str]:
+    """
+    Parse /Saved/Config/WindowsEditor/SourceControlSettings.ini file inside project's directory
+    and return dictionary with Port, User and Workspace
+
+    :return: P4 connection settings as dictionary (port, user, workspace)
+    :rtype: dict[str, str]
+    """
+
+    if not unreal.SourceControl.is_available():
+        raise exceptions.UnrealSourceControlNotAvailableError(
+            f"Unreal Source Control is not available. {_CONFIGURE_PERFORCE_MESSAGE}"
+        )
+
+    project_dir = os.path.dirname(
+        unreal.Paths.convert_relative_path_to_full(unreal.Paths.get_project_file_path())
+    ).replace("\\", "/")
+
+    source_control_ini = f"{project_dir}/{_SOURCE_CONTROL_INI_RELATIVE_PATH}"
+    validate_source_control_file(source_control_ini)
+
+    config = configparser.ConfigParser()
+    config.read(source_control_ini)
+
+    validate_has_section(config, "SourceControl.SourceControlSettings")
+    validate_provider(config)
+
+    perforce_section_name = "PerforceSourceControl.PerforceSourceControlSettings"
+    validate_has_section(config, perforce_section_name)
+    validate_perforce_source_control_settings(config)
+
+    connection_settings = {
+        "port": config.get(perforce_section_name, "Port"),
+        "user": config.get(perforce_section_name, "UserName"),
+        "workspace": config.get(perforce_section_name, "Workspace"),
+    }
+    logger.info(f"UE Source Control connection settings for Perforce: {connection_settings}")
+    return connection_settings

--- a/src/deadline/unreal_submitter/exceptions.py
+++ b/src/deadline/unreal_submitter/exceptions.py
@@ -13,12 +13,6 @@ class ParametersAreNotConsistentError(DeadlineCloudSubmitterException):
     pass
 
 
-class PerforceConnectionError(DeadlineCloudSubmitterException):
-    """Raised when failed to connect to the Perforce with given credentials"""
-
-    pass
-
-
 class RenderStepCountConstraintError(DeadlineCloudSubmitterException):
     """Raised when the number of Render Steps in a Render Job is different from 1."""
 
@@ -45,3 +39,7 @@ class PathContainsNonValidCharacters(DeadlineCloudSubmitterException):
 
 class FailedToDetectFilesTransferStrategy(DeadlineCloudSubmitterException):
     """Raised when its failed to detect which strategy to use for transfer files to render"""
+
+
+class ProjectIsNotUnderWorkspaceError(Exception):
+    """Raised when current Unreal Project is not under the current Workspace"""

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -791,7 +791,7 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         p4_conn = perforce.PerforceConnection(
             port=conn_settings["port"],
             user=conn_settings["user"],
-            client=conn_settings["workspace"]
+            client=conn_settings["workspace"],
         )
 
         parameter_values = RenderUnrealOpenJob.update_job_parameter_values(

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -48,7 +48,7 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job_step_host_require
 )
 
 from deadline.unreal_logger import get_logger
-from deadline.unreal_perforce_utils import perforce
+from deadline.unreal_perforce_utils import perforce, unreal_source_control
 
 
 logger = get_logger()
@@ -752,6 +752,20 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             if override_environment:
                 env.variables = override_environment.variables.variables
 
+    @staticmethod
+    def _get_project_path_relative_to_workspace_root(workspace_root: str) -> str:
+        workspace_root = workspace_root.replace("\\", "/")
+        unreal_project_path = common.get_project_file_path().replace("\\", "/")
+        if not unreal_project_path.startswith(workspace_root):
+            raise exceptions.ProjectIsNotUnderWorkspaceError(
+                f"Project {unreal_project_path} is not under the workspace root: {workspace_root}"
+            )
+
+        unreal_project_relative_path = unreal_project_path.replace(workspace_root, "")
+        unreal_project_relative_path = unreal_project_relative_path.lstrip("/")
+
+        return unreal_project_relative_path
+
     def _build_parameter_values_for_ugs(self, parameter_values: list[dict]) -> list[dict]:
         """
         Build and return list of parameter values for the OpenJob in the Unreal Game Sync integration.
@@ -773,7 +787,12 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         :rtype: list[dict]
         """
 
-        p4_conn = perforce.PerforceConnection()
+        conn_settings = unreal_source_control.get_connection_settings_from_ue_source_control()
+        p4_conn = perforce.PerforceConnection(
+            port=conn_settings["port"],
+            user=conn_settings["user"],
+            client=conn_settings["workspace"]
+        )
 
         parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
             job_parameter_values=parameter_values,
@@ -795,9 +814,9 @@ class RenderUnrealOpenJob(UnrealOpenJob):
 
         client_root = p4_conn.get_client_root()
         if isinstance(client_root, str):
-            unreal_project_path = common.get_project_file_path().replace("\\", "/")
-            unreal_project_relative_path = unreal_project_path.replace(client_root, "")
-            unreal_project_relative_path = unreal_project_relative_path.lstrip("/")
+            unreal_project_relative_path = self._get_project_path_relative_to_workspace_root(
+                workspace_root=client_root,
+            )
 
             parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
                 job_parameter_values=parameter_values,
@@ -840,7 +859,12 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         :rtype: list[dict]
         """
 
-        p4 = perforce.PerforceConnection()
+        conn_settings = unreal_source_control.get_connection_settings_from_ue_source_control()
+        p4 = perforce.PerforceConnection(
+            port=conn_settings["port"],
+            user=conn_settings["user"],
+            client=conn_settings["workspace"],
+        )
 
         parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
             job_parameter_values=parameter_values,
@@ -856,9 +880,9 @@ class RenderUnrealOpenJob(UnrealOpenJob):
 
         client_root = p4.get_client_root()
         if isinstance(client_root, str):
-            unreal_project_path = common.get_project_file_path().replace("\\", "/")
-            unreal_project_relative_path = unreal_project_path.replace(client_root, "")
-            unreal_project_relative_path = unreal_project_relative_path.lstrip("/")
+            unreal_project_relative_path = self._get_project_path_relative_to_workspace_root(
+                workspace_root=client_root,
+            )
 
             parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
                 job_parameter_values=parameter_values,
@@ -868,7 +892,11 @@ class RenderUnrealOpenJob(UnrealOpenJob):
 
         workspace_spec_template = common.create_deadline_cloud_temp_file(
             file_prefix=OpenJobParameterNames.PERFORCE_WORKSPACE_SPECIFICATION_TEMPLATE,
-            file_data=perforce.get_perforce_workspace_specification_template(),
+            file_data=perforce.get_perforce_workspace_specification_template(
+                port=conn_settings["port"],
+                user=conn_settings["user"],
+                client=conn_settings["workspace"],
+            ),
             file_ext=".json",
         )
         parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
@@ -1072,7 +1100,12 @@ class RenderUnrealOpenJob(UnrealOpenJob):
 
         local_dependencies = self._get_mrq_job_dependency_paths()
 
-        p4_conn = perforce.PerforceConnection()
+        conn_settings = unreal_source_control.get_connection_settings_from_ue_source_control()
+        p4_conn = perforce.PerforceConnection(
+            port=conn_settings["port"],
+            user=conn_settings["user"],
+            client=conn_settings["workspace"],
+        )
         depot_dependencies = p4_conn.get_depot_file_paths(local_dependencies)
 
         return depot_dependencies

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -763,7 +763,7 @@ class RenderUnrealOpenJob(UnrealOpenJob):
 
         pattern = re.compile(re.escape(workspace_root), re.IGNORECASE)
 
-        unreal_project_relative_path = pattern.sub('', unreal_project_path, count=1).lstrip('/')
+        unreal_project_relative_path = pattern.sub("", unreal_project_path, count=1).lstrip("/")
         if unreal_project_relative_path == unreal_project_path:
             raise RuntimeError(
                 "Something went wrong during getting Unreal Project Path relative to "

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -756,13 +756,20 @@ class RenderUnrealOpenJob(UnrealOpenJob):
     def _get_project_path_relative_to_workspace_root(workspace_root: str) -> str:
         workspace_root = workspace_root.replace("\\", "/")
         unreal_project_path = common.get_project_file_path().replace("\\", "/")
-        if not unreal_project_path.startswith(workspace_root):
+        if not unreal_project_path.lower().startswith(workspace_root.lower()):
             raise exceptions.ProjectIsNotUnderWorkspaceError(
                 f"Project {unreal_project_path} is not under the workspace root: {workspace_root}"
             )
 
-        unreal_project_relative_path = unreal_project_path.replace(workspace_root, "")
-        unreal_project_relative_path = unreal_project_relative_path.lstrip("/")
+        pattern = re.compile(re.escape(workspace_root), re.IGNORECASE)
+
+        unreal_project_relative_path = pattern.sub('', unreal_project_path, count=1).lstrip('/')
+        if unreal_project_relative_path == unreal_project_path:
+            raise RuntimeError(
+                "Something went wrong during getting Unreal Project Path relative to "
+                f"Perforce Workspace Root. Project path is {unreal_project_path}. "
+                f"Workspace Root: {workspace_root}"
+            )
 
         return unreal_project_relative_path
 

--- a/src/unreal_plugin/Content/OpenJD_DataAssets/Perforce/OpenJD_P4_Environment_SyncCmf.uasset
+++ b/src/unreal_plugin/Content/OpenJD_DataAssets/Perforce/OpenJD_P4_Environment_SyncCmf.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:04ae567cd1a0dee76b13826fdcf0f6cec524628bf32243de95857cf72d4a00fa
-size 2209
+oid sha256:2d33f28bb0dc75a435b5996a84824957c5cf8c2e816480eec270fa849740ec1a
+size 2235

--- a/src/unreal_plugin/Content/OpenJD_DataAssets/Render/OpenJD_Environment_ApplyP4Secrets.uasset
+++ b/src/unreal_plugin/Content/OpenJD_DataAssets/Render/OpenJD_Environment_ApplyP4Secrets.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca0a903f2f27969d42465b6af0896de593a3451cb43d0b0d3f23d33e57e8dc02
+size 2183

--- a/src/unreal_plugin/Content/OpenJD_DataAssets/UGS/OpenJD_UGS_Job_Render_P4Secrets.uasset
+++ b/src/unreal_plugin/Content/OpenJD_DataAssets/UGS/OpenJD_UGS_Job_Render_P4Secrets.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f039b385deda8b3fcfb1748afc142ac581f523b37ed2dcbdf80ab7cc8d4655a6
+size 4887

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_apply_secrets_environment.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_apply_secrets_environment.yml
@@ -1,0 +1,16 @@
+# OpenJD Environment for getting Perforce credentials from AWS SecretManager and applying them for connection.
+# When using environment variables to connect to Perforce, they will appear in the logs with
+# the prefix "openjd_env". Use with caution because sensitive data, such as the password, port,
+# and user, will be reflected in the job execution history."
+
+name: P4ApplySecrets
+variables:
+  AWS_SECRET_P4INFO: ""
+script:
+  actions:
+    onEnter:
+      command: unreal-engine-p4-utils
+      args:
+      - apply_perforce_secrets
+      cancelation:
+        mode: NOTIFY_THEN_TERMINATE

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_sync_cmf_environment.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_sync_cmf_environment.yml
@@ -1,6 +1,7 @@
 name: P4SyncCmf
 variables:
   P4_CLIENTS_ROOT_DIRECTORY: 'D:\projects'
+  AWS_SECRET_P4INFO: ''
 script:
   actions:
     onEnter:

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_sync_smf_environment.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_sync_smf_environment.yml
@@ -1,4 +1,6 @@
 name: P4SyncSmf
+variables:
+  AWS_SECRET_P4INFO: ''
 script:
   actions:
     onEnter:

--- a/test/deadline_perforce_utils_for_unreal/test_app.py
+++ b/test/deadline_perforce_utils_for_unreal/test_app.py
@@ -61,3 +61,30 @@ class TestUnrealP4UtilsApp:
 
         # THEN
         assert exc_info
+
+    @pytest.mark.parametrize(
+        "p4_info, openjd_env_output",
+        [
+            (
+                {"P4PORT": "port", "P4USER": "user", "P4PASSWD": "pass"},
+                ["openjd_env: P4PORT=port", "openjd_env: P4USER=user", "openjd_env: P4PASSWD=pass"],
+            ),
+            ({}, []),
+        ],
+    )
+    @patch("deadline.unreal_perforce_utils.secret_manager.get_perforce_info")
+    def test_apply_perforce_secrets(
+        self, get_perforce_info_mock: Mock, p4_info: dict[str, str], openjd_env_output: list[str]
+    ):
+
+        # GIVEN
+        get_perforce_info_mock.return_value = p4_info
+
+        # WHEN
+        with patch("builtins.print") as print_mock:
+            app.apply_perforce_secrets()
+
+        # THEN
+        assert len(print_mock.mock_calls) == len(openjd_env_output)
+        for i, call in enumerate(print_mock.mock_calls):
+            assert call.args[0] == openjd_env_output[i]

--- a/test/deadline_perforce_utils_for_unreal/test_secret_manager.py
+++ b/test/deadline_perforce_utils_for_unreal/test_secret_manager.py
@@ -1,10 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import os
+import ast
 import pytest
 from typing import Union
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
+from deadline.unreal_perforce_utils import exceptions
 from deadline.unreal_perforce_utils import secret_manager
 
 
@@ -59,72 +61,102 @@ class TestSecretManager:
                     secret_manager.get_secret_manager_client()
                     boto3_client_mock.assert_called_once_with(**expected_params)
 
-    @pytest.mark.parametrize(
-        "var_name, env_vars, found",
-        [
-            ("AWS_SECRET_P4INFO", {"AWS_SECRET_P4INFO": "secret"}, True),
-            ("AWS_SECRET_P4INFO", {"AWS_SECRET_OTHER": "secret"}, False),
-            ("AWS_SECRET_P4INFO", {"AWS_SECRET_P4INFO": ""}, False),
-            ("", {"AWS_SECRET_P4INFO": "secret"}, False),
-            ("AWS_SECRET_OTHER", {"AWS_SECRET_P4INFO": "secret"}, False),
-        ],
-    )
     @patch("deadline.unreal_perforce_utils.secret_manager.get_secret_manager_client")
-    def test_get_secret_from_env(
-        self,
-        get_secret_manager_client_mock: Mock,
-        var_name: str,
-        env_vars: dict[str, str],
-        found: bool,
-    ):
+    def test_get_secret(self, get_secret_manager_client_mock: Mock):
         # GIVEN
+        expected_result = "{'P4USER': 'aws-user'}"
         mock_client = get_secret_manager_client_mock.return_value
-        mock_client.get_secret_value.return_value = {"SecretString": "{'P4USER': 'aws-user'}"}
+        mock_client.get_secret_value.return_value = {"SecretString": expected_result}
 
         # WHEN
-        with patch.dict(os.environ, env_vars, clear=True):
-            result = secret_manager.get_secret_from_env(var_name)
+        result = secret_manager.get_secret("secret-name")
 
         # THEN
-        assert (result is not None) == found
+        assert result == expected_result
 
     @patch("deadline.unreal_perforce_utils.secret_manager.get_secret_manager_client")
-    def test_get_secret_from_env_failed(self, get_secret_manager_client_mock: Mock):
+    def test_get_secret_failed_to_get_secret(self, get_secret_manager_client_mock: Mock):
         # GIVEN
+        mock_client = get_secret_manager_client_mock.return_value
+        mock_client.get_secret_value = MagicMock(
+            side_effect=secret_manager.ClientError(
+                {"Error": {"Code": "ResourceNotFoundException"}}, "get_secret_value"
+            ),
+        )
+
+        # WHEN & THEN
+        with pytest.raises(exceptions.SecretsManagerError):
+            secret_manager.get_secret("secret-name")
+
+    @patch("deadline.unreal_perforce_utils.secret_manager.get_secret_manager_client")
+    def test_get_secret_failed_to_find_secret_string(self, get_secret_manager_client_mock: Mock):
         mock_client = get_secret_manager_client_mock.return_value
         mock_client.get_secret_value.return_value = {"NotSecretString": "OtherInfo"}
 
         # WHEN & THEN
-        with patch.dict(os.environ, {"AWS_SECRET_P4INFO": "secret"}, clear=True):
-            with pytest.raises(KeyError):
-                secret_manager.get_secret_from_env("AWS_SECRET_P4INFO")
+        with pytest.raises(KeyError):
+            secret_manager.get_secret("secret-name")
 
     @pytest.mark.parametrize(
-        "env_vars, p4_info, expected_result",
+        "p4_info_str, allowed_keys",
         [
+            ("123,user,port", {}),
+            ("cant eval", {}),
+            ("123", {}),
+            ("{}", {}),
+            ("{'P4OTHER': 'other'}", {"P4USER"}),
+            ("{'P4OTHER': 'other', 'P4USER': 'aws-user'}", {"P4USER"}),
+            ("{'P4OTHER': 'other', 'P4USER': 'aws-user'}", {}),
+        ],
+    )
+    def test_validate_perforce_info_failed(self, p4_info_str: str, allowed_keys: set[str]):
+        # GIVEN & WHEN
+        with pytest.raises(exceptions.SecretsManagerError):
+            secret_manager.validate_perforce_info(p4_info_str, allowed_keys)
+
+    @pytest.mark.parametrize(
+        "p4_info_str, allowed_keys",
+        [
+            ("{'P4USER': 'aws-user'}", {"P4USER"}),
+            ("{'P4USER': 'aws-user'}", {"P4USER", "P4PORT"}),
+            ("{'P4USER': 'aws-user', 'P4PORT': 'aws-port'}", {"P4USER", "P4PORT"}),
+            ("{'P4USER': 'aws-user', 'P4PASSWD': 'aws-pass'}", {"P4USER", "P4PASSWD"}),
+            ("{'P4USER': 'aws-user', 'P4PASSWD': 'aws-pass'}", {"P4USER", "P4PASSWD", "P4PORT"}),
+            (
+                "{'P4USER': 'aws-user', 'P4PASSWD': 'aws-pass', 'P4PORT': 'aws-port'}",
+                {"P4USER", "P4PASSWD", "P4PORT"},
+            ),
+        ],
+    )
+    def test_validate_perforce_info(self, p4_info_str: str, allowed_keys: set[str]):
+        # WHEN
+        p4_info = secret_manager.validate_perforce_info(p4_info_str, allowed_keys)
+
+        # THEN
+        assert p4_info == ast.literal_eval(p4_info_str)
+
+    @pytest.mark.parametrize(
+        "env_vars, get_secret_output, expected_result",
+        [
+            ({"AWS_SECRET_P4INFO": ""}, None, None),
+            ({}, None, None),
             (
                 {"AWS_SECRET_P4INFO": "secret"},
                 "{'P4PASSWD': 'pass', 'P4USER': 'user', 'P4PORT': 'port'}",
                 {"P4PASSWD": "pass", "P4USER": "user", "P4PORT": "port"},
             ),
-            (
-                {"AWS_SECRET_P4INFO": ""},
-                "{'P4PASSWD': 'pass', 'P4USER': 'user', 'P4PORT': 'port'}",
-                None,
-            ),
-            ({"AWS_SECRET_P4INFO": "secret"}, None, None),
         ],
     )
-    @patch("deadline.unreal_perforce_utils.secret_manager.get_secret_from_env")
+    @patch("deadline.unreal_perforce_utils.secret_manager.get_secret")
     def test_get_perforce_info(
         self,
-        get_perforce_secret_mock: Mock,
+        get_secret_mock: Mock,
         env_vars: dict[str, str],
-        p4_info: Union[dict[str, str], None],
+        get_secret_output: Union[dict[str, str], None],
         expected_result: Union[dict[str, str], None],
     ):
         # GIVEN
-        get_perforce_secret_mock.return_value = p4_info
+        get_secret_mock.return_value = get_secret_output
 
         # WHEN
         with patch.dict(os.environ, env_vars, clear=True):

--- a/test/deadline_perforce_utils_for_unreal/test_secret_manager.py
+++ b/test/deadline_perforce_utils_for_unreal/test_secret_manager.py
@@ -1,0 +1,134 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+import pytest
+from typing import Union
+from unittest.mock import Mock, patch
+
+from deadline.unreal_perforce_utils import secret_manager
+
+
+class TestSecretManager:
+
+    @pytest.mark.parametrize(
+        "env_vars, fetcher_output, expected_params",
+        [
+            (
+                {"AWS_REGION_NAME": "env-region"},
+                "fetcher-region",
+                {"service_name": "secretsmanager", "region_name": "env-region"},
+            ),
+            (
+                {"AWS_REGION_NAME": "env-region"},
+                None,
+                {"service_name": "secretsmanager", "region_name": "env-region"},
+            ),
+            (
+                {},
+                "fetcher-region",
+                {"service_name": "secretsmanager", "region_name": "fetcher-region"},
+            ),
+            (
+                {},
+                None,
+                {"service_name": "secretsmanager", "region_name": None},
+            ),
+            (
+                {"AWS_REGION_NAME": ""},
+                "fetcher-region",
+                {"service_name": "secretsmanager", "region_name": "fetcher-region"},
+            ),
+            (
+                {"AWS_REGION_NAME": ""},
+                None,
+                {"service_name": "secretsmanager", "region_name": None},
+            ),
+        ],
+    )
+    def test_get_secret_manager_client(
+        self, env_vars: dict[str, str], fetcher_output: str, expected_params: dict[str, str]
+    ):
+
+        # GIVEN & WHEN
+        with patch(
+            "deadline.unreal_perforce_utils.secret_manager.InstanceMetadataRegionFetcher"
+        ) as fetcher_mock:
+            with patch.dict(os.environ, env_vars, clear=True):
+                with patch("boto3.client") as boto3_client_mock:
+                    fetcher_mock.return_value.retrieve_region.return_value = fetcher_output
+                    secret_manager.get_secret_manager_client()
+                    boto3_client_mock.assert_called_once_with(**expected_params)
+
+    @pytest.mark.parametrize(
+        "var_name, env_vars, found",
+        [
+            ("AWS_SECRET_P4INFO", {"AWS_SECRET_P4INFO": "secret"}, True),
+            ("AWS_SECRET_P4INFO", {"AWS_SECRET_OTHER": "secret"}, False),
+            ("AWS_SECRET_P4INFO", {"AWS_SECRET_P4INFO": ""}, False),
+            ("", {"AWS_SECRET_P4INFO": "secret"}, False),
+            ("AWS_SECRET_OTHER", {"AWS_SECRET_P4INFO": "secret"}, False),
+        ],
+    )
+    @patch("deadline.unreal_perforce_utils.secret_manager.get_secret_manager_client")
+    def test_get_secret_from_env(
+        self,
+        get_secret_manager_client_mock: Mock,
+        var_name: str,
+        env_vars: dict[str, str],
+        found: bool,
+    ):
+        # GIVEN
+        mock_client = get_secret_manager_client_mock.return_value
+        mock_client.get_secret_value.return_value = {"SecretString": "{'P4USER': 'aws-user'}"}
+
+        # WHEN
+        with patch.dict(os.environ, env_vars, clear=True):
+            result = secret_manager.get_secret_from_env(var_name)
+
+        # THEN
+        assert (result is not None) == found
+
+    @patch("deadline.unreal_perforce_utils.secret_manager.get_secret_manager_client")
+    def test_get_secret_from_env_failed(self, get_secret_manager_client_mock: Mock):
+        # GIVEN
+        mock_client = get_secret_manager_client_mock.return_value
+        mock_client.get_secret_value.return_value = {"NotSecretString": "OtherInfo"}
+
+        # WHEN & THEN
+        with patch.dict(os.environ, {"AWS_SECRET_P4INFO": "secret"}, clear=True):
+            with pytest.raises(KeyError):
+                secret_manager.get_secret_from_env("AWS_SECRET_P4INFO")
+
+    @pytest.mark.parametrize(
+        "env_vars, p4_info, expected_result",
+        [
+            (
+                {"AWS_SECRET_P4INFO": "secret"},
+                "{'P4PASSWD': 'pass', 'P4USER': 'user', 'P4PORT': 'port'}",
+                {"P4PASSWD": "pass", "P4USER": "user", "P4PORT": "port"},
+            ),
+            (
+                {"AWS_SECRET_P4INFO": ""},
+                "{'P4PASSWD': 'pass', 'P4USER': 'user', 'P4PORT': 'port'}",
+                None,
+            ),
+            ({"AWS_SECRET_P4INFO": "secret"}, None, None),
+        ],
+    )
+    @patch("deadline.unreal_perforce_utils.secret_manager.get_secret_from_env")
+    def test_get_perforce_info(
+        self,
+        get_perforce_secret_mock: Mock,
+        env_vars: dict[str, str],
+        p4_info: Union[dict[str, str], None],
+        expected_result: Union[dict[str, str], None],
+    ):
+        # GIVEN
+        get_perforce_secret_mock.return_value = p4_info
+
+        # WHEN
+        with patch.dict(os.environ, env_vars, clear=True):
+            result = secret_manager.get_perforce_info()
+
+        # THEN
+        assert result == expected_result

--- a/test/deadline_perforce_utils_for_unreal/test_unreal_source_control.py
+++ b/test/deadline_perforce_utils_for_unreal/test_unreal_source_control.py
@@ -1,0 +1,136 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import sys
+import pytest
+import configparser
+from unittest.mock import patch, Mock, MagicMock
+
+unreal_mock = MagicMock()
+sys.modules["unreal"] = unreal_mock
+
+from deadline.unreal_perforce_utils import unreal_source_control  # noqa: E402
+
+
+class TestUnrealSourceControl:
+
+    @pytest.mark.parametrize("exists", [True, False])
+    def test_validate_source_control_file(self, exists: bool):
+        # GIVEN & WHEN
+        with patch("os.path.exists", return_value=exists):
+            # THEN
+            if exists:
+                assert (
+                    unreal_source_control.validate_source_control_file("path/to/file")
+                    == "path/to/file"
+                )
+            else:
+                with pytest.raises(FileNotFoundError):
+                    unreal_source_control.validate_source_control_file("path/to/file")
+
+    @pytest.mark.parametrize("exists", [True, False])
+    def test_validate_has_section(self, exists: bool):
+        # GIVEN
+        config = Mock()
+        config.has_section.return_value = exists
+
+        # WHEN & THEN
+        if exists:
+            assert unreal_source_control.validate_has_section(config, "section") == config
+        else:
+            with pytest.raises(KeyError):
+                unreal_source_control.validate_has_section(config, "section")
+
+    @pytest.mark.parametrize("exists", [True, False])
+    def test_validate_has_option(self, exists: bool):
+        # GIVEN
+        config = Mock()
+
+        if exists:
+            config.get.return_value = "option"
+        else:
+            config.get = MagicMock(side_effect=configparser.NoOptionError("option", "section"))
+
+        # WHEN & THEN
+        if exists:
+            assert unreal_source_control.validate_has_option(config, "section", "option") == config
+        else:
+            with pytest.raises(KeyError):
+                unreal_source_control.validate_has_option(config, "section", "option")
+
+    @patch(
+        target="deadline.unreal_perforce_utils.unreal_source_control.validate_has_option",
+        return_value=True,
+    )
+    def test_validate_provider_passed(self, validate_has_option_mock: Mock):
+        # GIVEN
+        config = Mock()
+        config.get.return_value = "Perforce"
+
+        # WHEN
+        result = unreal_source_control.validate_provider(config)
+
+        # THEN
+        assert result == config
+
+    @pytest.mark.parametrize(
+        "has_option, get_result, exc_type",
+        [(False, None, KeyError), (True, "NotPerforce", ValueError)],
+    )
+    def test_validate_provider_failed(
+        self, has_option: bool, get_result: str, exc_type: type[Exception]
+    ):
+        config = configparser.ConfigParser()
+        config.add_section("SourceControl.SourceControlSettings")
+        if has_option:
+            config["SourceControl.SourceControlSettings"]["Provider"] = "NotPerforce"
+
+        # WHEN & THEN
+        with pytest.raises(exc_type):
+            unreal_source_control.validate_provider(config)
+
+    def test_validate_perforce_source_control_settings_passed(self):
+        # GIVEN
+        config = configparser.ConfigParser()
+        config.add_section("PerforceSourceControl.PerforceSourceControlSettings")
+        config["PerforceSourceControl.PerforceSourceControlSettings"] = {
+            "Port": "1234",
+            "UserName": "user",
+            "Workspace": "workspace",
+        }
+
+        # WHEN
+        result = unreal_source_control.validate_perforce_source_control_settings(config)
+
+        # THEN
+        assert result == config
+
+    @pytest.mark.parametrize(
+        "options, exc_type",
+        [
+            ({"Port": "1234", "UserName": "user"}, KeyError),
+            ({"Port": "1234", "Workspace": "workspace"}, KeyError),
+            ({"Workspace": "workspace", "UserName": "user"}, KeyError),
+            ({"UserName": "user"}, KeyError),
+            ({"Workspace": "workspace"}, KeyError),
+            ({"Workspace": "Port"}, KeyError),
+            ({}, KeyError),
+            ({"Port": "1234", "UserName": "user", "Workspace": ""}, ValueError),
+            ({"Port": "1234", "UserName": "", "Workspace": "workspace"}, ValueError),
+            ({"Port": "", "UserName": "user", "Workspace": "workspace"}, ValueError),
+            ({"Port": "1234", "UserName": "", "Workspace": ""}, ValueError),
+            ({"Port": "", "UserName": "user", "Workspace": ""}, ValueError),
+            ({"Port": "", "UserName": "", "Workspace": "workspace"}, ValueError),
+            ({"Port": "", "UserName": "", "Workspace": ""}, ValueError),
+        ],
+    )
+    def test_validate_perforce_source_control_settings_failed(
+        self, options: dict[str, str], exc_type: type[Exception]
+    ):
+        # GIVEN
+        config = configparser.ConfigParser()
+        config.add_section("PerforceSourceControl.PerforceSourceControlSettings")
+        config["PerforceSourceControl.PerforceSourceControlSettings"] = options
+
+        # WHEN & THEN
+        with pytest.raises(exc_type):
+            unreal_source_control.validate_perforce_source_control_settings(config)

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
@@ -31,6 +31,7 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job import (  # noqa:
     UnrealOpenJobParameterDefinition,
     TransferProjectFilesStrategy,
 )
+from deadline.unreal_submitter import exceptions  # noqa: E402
 
 
 class TestUnrealOpenJobStepParameterDefinition:
@@ -416,3 +417,43 @@ class TestRenderUnrealOpenJob:
 
         # THEN
         assert transfer_strategy == strategy
+
+    @pytest.mark.parametrize(
+        "workspace_root, project_path, expected_relative_path",
+        [
+            (
+                "C:/Workspaces/Workspace1",
+                "C:/Workspaces/Workspace1\Project1.uproject",
+                "Project1.uproject",
+            ),
+            (
+                "C:\Workspaces/workspace1",
+                "C:/workspaces/Workspace1/UE5\Project1.uproject",
+                "UE5/Project1.uproject",
+            ),
+        ],
+    )
+    def test__get_project_path_relative_to_workspace_root(
+        self, workspace_root: str, project_path: str, expected_relative_path: str
+    ):
+        # GIVEN & WHEN
+        with patch("deadline.unreal_submitter.common.get_project_file_path", return_value=project_path):
+            relative_path = RenderUnrealOpenJob._get_project_path_relative_to_workspace_root(workspace_root)
+
+        # THEN
+        assert relative_path == expected_relative_path
+
+    @pytest.mark.parametrize(
+        "workspace_root, project_path",
+        [
+            ("C:/Workspaces/Workspace1", "C:/Workspaces/Workspace2\Project1.uproject"),
+            ("C:\Workspaces/workspace1", "C:/workspaces/Workspace2/UE5\Project1.uproject"),
+        ],
+    )
+    def test__get_project_path_relative_to_workspace_root_failed(
+        self, workspace_root: str, project_path: str
+    ):
+        # GIVEN & WHEN $ THEN
+        with patch("deadline.unreal_submitter.common.get_project_file_path", return_value=project_path):
+            with pytest.raises(exceptions.ProjectIsNotUnderWorkspaceError):
+                RenderUnrealOpenJob._get_project_path_relative_to_workspace_root(workspace_root)

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
@@ -437,8 +437,12 @@ class TestRenderUnrealOpenJob:
         self, workspace_root: str, project_path: str, expected_relative_path: str
     ):
         # GIVEN & WHEN
-        with patch("deadline.unreal_submitter.common.get_project_file_path", return_value=project_path):
-            relative_path = RenderUnrealOpenJob._get_project_path_relative_to_workspace_root(workspace_root)
+        with patch(
+            "deadline.unreal_submitter.common.get_project_file_path", return_value=project_path
+        ):
+            relative_path = RenderUnrealOpenJob._get_project_path_relative_to_workspace_root(
+                workspace_root=workspace_root,
+            )
 
         # THEN
         assert relative_path == expected_relative_path
@@ -454,6 +458,8 @@ class TestRenderUnrealOpenJob:
         self, workspace_root: str, project_path: str
     ):
         # GIVEN & WHEN $ THEN
-        with patch("deadline.unreal_submitter.common.get_project_file_path", return_value=project_path):
+        with patch(
+            "deadline.unreal_submitter.common.get_project_file_path", return_value=project_path
+        ):
             with pytest.raises(exceptions.ProjectIsNotUnderWorkspaceError):
                 RenderUnrealOpenJob._get_project_path_relative_to_workspace_root(workspace_root)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
When using Perforce /UGS, it is necessary to pass sensitive parameters such as password, user, port. It is necessary to minimize their transfer through Job environment variables and use a special secret manager to increase the security of user data

### What was the solution? (How)

- Provide "AWS_SECRET_P4INFO" environment variable that contains name of the secret that need to find to retrieve P4 connection parameters (any of them).
- Use this environment variable on the worker side to retrieve connection parameters using Boto3 client for SecretsManager service.

### What is the impact of this change?
Now all of the users' sensitive data, such as P4 Password can be applied without passing within Job environment

### How was this change tested?

- unit tests
- smoke tests
- Have you run the unit tests? Yes

### Have you run a render job successfully with these changes?
Yes

### Was this change documented?
Yes

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*