### PR TITLE
test: Fixing some incorrect job configuration settings in the CreateJ…

### DIFF
--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -141,36 +141,42 @@ void UMoviePipelineDeadlineCloudExecutorJob::UpdateAttachmentFields()
 	}
 }
 
+void UMoviePipelineDeadlineCloudExecutorJob::JobPresetChanged()
+{
+	const UDeadlineCloudJob* SelectedJobPreset = this->JobPreset;
+
+	if (!SelectedJobPreset)
+	{
+		this->JobPreset = CreateDefaultJobPresetFromTemplates(JobPreset);
+		SelectedJobPreset = this->JobPreset;
+	}
+
+	this->PresetOverrides.HostRequirements = SelectedJobPreset->JobPresetStruct.HostRequirements;
+	this->PresetOverrides.JobSharedSettings = SelectedJobPreset->JobPresetStruct.JobSharedSettings;
+
+	this->PresetOverrides.JobAttachments.InputFiles.Files =
+		SelectedJobPreset->JobPresetStruct.JobAttachments.InputFiles.Files;
+
+	this->PresetOverrides.JobAttachments.InputDirectories.Directories =
+		SelectedJobPreset->JobPresetStruct.JobAttachments.InputDirectories.Directories;
+
+	this->PresetOverrides.JobAttachments.OutputDirectories.Directories =
+		SelectedJobPreset->JobPresetStruct.JobAttachments.OutputDirectories.Directories;
+
+	this->ParameterDefinitionOverrides.Parameters =
+		SelectedJobPreset->ParameterDefinition.Parameters;
+
+	this->StepsOverrides = GetStepsToOverride(SelectedJobPreset);
+	this->EnvironmentsOverrides = GetEnvironmentsToOverride(SelectedJobPreset);
+}
+
 void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
 {
 	// Check if we changed the job Preset an update the override details
 	if (const FName PropertyName = PropertyChangedEvent.GetPropertyName(); PropertyName == "JobPreset")
 	{
-		const UDeadlineCloudJob* SelectedJobPreset = this->JobPreset;
+		JobPresetChanged();
 
-		if (!SelectedJobPreset)
-		{
-			this->JobPreset = CreateDefaultJobPresetFromTemplates(JobPreset);
-			SelectedJobPreset = this->JobPreset;
-		}
-
-		this->PresetOverrides.HostRequirements = SelectedJobPreset->JobPresetStruct.HostRequirements;
-		this->PresetOverrides.JobSharedSettings = SelectedJobPreset->JobPresetStruct.JobSharedSettings;
-
-		this->PresetOverrides.JobAttachments.InputFiles.Files =
-			SelectedJobPreset->JobPresetStruct.JobAttachments.InputFiles.Files;
-
-		this->PresetOverrides.JobAttachments.InputDirectories.Directories =
-			SelectedJobPreset->JobPresetStruct.JobAttachments.InputDirectories.Directories;
-
-		this->PresetOverrides.JobAttachments.OutputDirectories.Directories =
-			SelectedJobPreset->JobPresetStruct.JobAttachments.OutputDirectories.Directories;
-
-		this->ParameterDefinitionOverrides.Parameters =
-			SelectedJobPreset->ParameterDefinition.Parameters;
-
-		this->StepsOverrides = GetStepsToOverride(SelectedJobPreset);
-		this->EnvironmentsOverrides = GetEnvironmentsToOverride(SelectedJobPreset);
 		// Update MRQ widget request
 		if (OnRequestDetailsRefresh.IsBound())
 		{

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
@@ -86,7 +86,7 @@ public:
     }
 
 private:
-    const int TimeoutSeconds = 180;
+    const int TimeoutSeconds = 300;
     double m_startTime = {};
     bool m_jobCreationFound = false;
     bool m_dialogConfirmationFound = false;
@@ -172,7 +172,20 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMovieQueueCreateJobTest, "Deadline.Integration
     }
 
     ProjectSettings->DefaultRemoteExecutor = FSoftClassPath(TEXT("/Engine/PythonTypes.MoviePipelineDeadlineCloudRemoteExecutor"));
+    TSubclassOf<UMoviePipelineExecutorBase> RemoteClass = ProjectSettings->DefaultRemoteExecutor.TryLoadClass<UMoviePipelineExecutorBase>();
+    TestTrue(TEXT("Failed to load remote executor class"), RemoteClass != nullptr);
+
+    ProjectSettings->DefaultExecutorJob = UMoviePipelineDeadlineCloudExecutorJob::StaticClass();
+    TestNotNull(TEXT("Failed to set executor job"), ProjectSettings->DefaultExecutorJob.TryLoadClass<UMoviePipelineExecutorJob>());
+
     UE_LOG(LogCreateJobTest, Display, TEXT("Configured project settings"));
+
+    UE_LOG(LogCreateJobTest, Display, TEXT("DefaultExecutorJob set to: %s"),
+        *ProjectSettings->DefaultExecutorJob.ToString());
+
+    TSubclassOf<UMoviePipelineExecutorJob> ExecutorJobClass = ProjectSettings->DefaultExecutorJob.TryLoadClass<UMoviePipelineExecutorJob>();
+    UE_LOG(LogCreateJobTest, Display, TEXT("TryLoadClass returned: %s"),
+        ExecutorJobClass ? *ExecutorJobClass->GetName() : TEXT("nullptr"));
 
     // Get the Queue Subsystem
     UMoviePipelineQueueSubsystem* QueueSubsystem = GEditor->GetEditorSubsystem<UMoviePipelineQueueSubsystem>();
@@ -195,10 +208,30 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMovieQueueCreateJobTest, "Deadline.Integration
     TestNotNull(TEXT("LevelSequence should not be null"), LevelSequence);
     UE_LOG(LogCreateJobTest, Display, TEXT("Got LevelSequence: %s"), *LevelSequence->GetPathName());
 
-    UMoviePipelineExecutorJob* NewJob = UMoviePipelineEditorBlueprintLibrary::CreateJobFromSequence(ActiveQueue, LevelSequence);
-    if (!NewJob)
+    TSoftClassPtr<UMoviePipelineDeadlineCloudExecutorJob> SoftClassPtr = TSoftClassPtr<UMoviePipelineDeadlineCloudExecutorJob>(ProjectSettings->DefaultExecutorJob);
+    UMoviePipelineDeadlineCloudExecutorJob* NewJob = NewObject<UMoviePipelineDeadlineCloudExecutorJob>(GetTransientPackage(), SoftClassPtr.LoadSynchronous());
+
+    NewJob->JobPresetChanged();
+    UMoviePipelineEditorBlueprintLibrary::EnsureJobHasDefaultSettings(NewJob);
+
+    TestNotNull(TEXT("JobPreset should not be null"), NewJob->JobPreset.Get());
+    UE_LOG(LogCreateJobTest, Display, TEXT("Created JobPreset"));
+
+    FSoftObjectPath CurrentWorld;
+
+    UWorld* EditorWorld = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+
+    CurrentWorld = FSoftObjectPath(EditorWorld);
+
+    FSoftObjectPath Sequence(LevelSequence);
+    NewJob->Map = CurrentWorld;
+    NewJob->SetSequence(Sequence);
+    NewJob->JobName = NewJob->Sequence.GetAssetName();
+
+    UMoviePipelineExecutorJob* QueueJob = ActiveQueue->DuplicateJob(NewJob);
+    if (!QueueJob)
     {
-        UE_LOG(LogCreateJobTest, Error, TEXT("Failed to CreateJobFromSequence"));
+        UE_LOG(LogCreateJobTest, Error, TEXT("Failed to Duplicate Job into queue"));
         return false;
     }
     UE_LOG(LogCreateJobTest, Display, TEXT("Created job from sequence"));
@@ -208,9 +241,9 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMovieQueueCreateJobTest, "Deadline.Integration
     // The QueueManifest message may appear 1 or 2 times depending on whether you've run the test before.
     AddExpectedError(TEXT("Failed to load '/Engine/MovieRenderPipeline/Editor/QueueManifest': Can't find file"),
         EAutomationExpectedErrorFlags::Contains, 0);
-    // The -execcmds message WILL appear twice
+    // The -execcmds message may appear 1 or 2 times depending on whether you've run the test before
     AddExpectedError(TEXT("Appearance of custom '-execcmds' argument on the Render node can cause unpredictable issues"),
-        EAutomationExpectedErrorFlags::Contains, 2);
+        EAutomationExpectedErrorFlags::Contains, 0);
 
     // Load and use remote executor
     TSubclassOf<UMoviePipelineExecutorBase> ExecutorClass = ProjectSettings->DefaultRemoteExecutor.TryLoadClass<UMoviePipelineExecutorBase>();

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
@@ -102,7 +102,7 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, config, Category = "DeadlineCloud")
     TArray<FDeadlineCloudEnvironmentOverride> EnvironmentsOverrides = TArray<FDeadlineCloudEnvironmentOverride>();
 
-
+    void JobPresetChanged();
 protected:
 
 #if WITH_EDITOR


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The new CreateJob test was creating and completing a job successfully in deadline cloud, however some configuration on the job wasn't correct, so the outputs weren't correct.

### What was the solution? (How)
Change how we're creating and configuring the job in the test.

### What is the impact of this change?
The test will output the expected images.

### How was this change tested?
Ran tests locally

### Have you run a render job successfully with these changes?
Yes

![createjobtestsuccess](https://github.com/user-attachments/assets/6713d7d4-4e6c-47e8-a50c-a78fb80fddbd)

![createjoboutputs](https://github.com/user-attachments/assets/aa5e6737-dac9-4a1d-9266-b5940b53259c)

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*