### PR TITLE
test: Created an e2e test which can run through hatch which wraps the…

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -5,7 +5,8 @@ pre-install-commands = [
 
 [envs.default.scripts]
 sync = "pip install -r requirements-testing.txt"
-test = "pytest --cov-config pyproject.toml {args:test}"
+test = "pytest test/ --cov-config pyproject.toml --ignore=test/end_to_end {args}"
+e2e = "pytest test/end_to_end --no-cov {args}"
 typing = "mypy {args:src test}"
 style = [
   "ruff check {args:.}",

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -418,9 +418,9 @@ def check_configuration_warnings(engine_root: str):
 
 
 def build_and_install(
-    engine_root: str = None,
-    uplugin_path: str = None,
-    output_folder: str = None,
+    engine_root: str = "",
+    uplugin_path: str = "",
+    output_folder: str = "",
     install: bool = False,
     worker: bool = False,
     binaries: bool = True,

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
@@ -341,16 +341,11 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
         extra_cmd_str = re.sub(r'(-execcmds=["\'][^"\']*["\'])', "", extra_cmd_str)
 
         client_path = self.unreal_client_path.replace("\\", "/")
-        log_args = [
-            "-log",
-            "-unattended",
-            "-stdout",
-            "-allowstdoutlogverbosity",
-        ]
+        log_args = ["-log", "-unattended", "-stdout", "-allowstdoutlogverbosity", "-nozen"]
 
         remote_execution = os.getenv("REMOTE_EXECUTION", "True")
         if remote_execution == "True":
-            log_args += ["-NoLoadingScreen", "-NoScreenMessages", "-RenderOffscreen"]
+            log_args += ["-NoLoadingScreen", "-NoScreenMessages", "-RenderOffscreen", "-nozen"]
 
         extra_cmd_args = extra_cmd_str.split(" ")
 

--- a/src/deadline/unreal_submitter/common.py
+++ b/src/deadline/unreal_submitter/common.py
@@ -5,7 +5,7 @@ import re
 import glob
 import json
 import unreal
-from typing import Any
+from typing import Any, Optional
 from pathlib import Path
 
 from deadline.unreal_logger import get_logger
@@ -178,6 +178,22 @@ def get_path_context_from_mrq_job(mrq_job: unreal.MoviePipelineExecutorJob) -> P
     return path_context
 
 
+def extract_deadline_args(startup_args: str) -> Optional[str]:
+    """
+    Case insensitive pattern matching -deadlineargs= followed by quote-delimited content
+    :param startup_args: Full argument string given to process at launch
+    :return: argument string passed in -deadlineargs argument, if found
+    """
+
+    pattern = re.compile(r'(?i)-deadlineargs=([\'"])(.*?)\1', re.IGNORECASE)
+    match = pattern.search(startup_args)
+
+    if match:
+        return match.group(2)  # Return the content between quotes
+    else:
+        return None  # No match found
+
+
 def get_in_process_executor_cmd_args() -> list[str]:
     """
     Get inherited and additional command line arguments from
@@ -195,8 +211,20 @@ def get_in_process_executor_cmd_args() -> list[str]:
     )
 
     inherited_cmds: str = in_process_executor_settings.inherited_command_line_arguments
-    inherited_cmds = re.sub(pattern='(-execcmds="[^"]*")', repl="", string=inherited_cmds)
-    inherited_cmds = re.sub(pattern="(-execcmds='[^']*')", repl="", string=inherited_cmds)
+    inherited_cmds = re.sub(
+        pattern='(-execcmds="[^"]*")', repl="", string=inherited_cmds, flags=re.IGNORECASE
+    )
+    inherited_cmds = re.sub(
+        pattern="(-execcmds='[^']*')", repl="", string=inherited_cmds, flags=re.IGNORECASE
+    )
+
+    # Optional override for cases where the arguments used to launch the current instance of Unreal are known
+    # to not match the arguments we want to send to the renderers.
+    deadline_args = extract_deadline_args(inherited_cmds)
+    if deadline_args is not None:
+        logger.info(f"Found deadline args {deadline_args}")
+        inherited_cmds = deadline_args
+
     cmd_args.extend(inherited_cmds.split(" "))
 
     additional_cmds: str = in_process_executor_settings.additional_command_line_arguments

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -1025,12 +1025,14 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         if extra_cmd_args_param:
             extra_cmd_args = str(extra_cmd_args_param.value)
             cleared_extra_cmds_args = re.sub(
-                pattern='(-execcmds="[^"]*")', repl="", string=extra_cmd_args
+                pattern='(-execcmds="[^"]*")', repl="", string=extra_cmd_args, flags=re.IGNORECASE
             )
             cleared_extra_cmds_args = re.sub(
-                pattern="(-execcmds='[^']*')", repl="", string=cleared_extra_cmds_args
+                pattern="(-execcmds='[^']*')",
+                repl="",
+                string=cleared_extra_cmds_args,
+                flags=re.IGNORECASE,
             )
-
             logger.warning(
                 "Appearance of custom '-execcmds' argument on the Render node can cause unpredictable "
                 "issues. Argument '-execcmds' of Unreal Open Job's "

--- a/test/deadline_submitter_for_unreal/unit/test_common.py
+++ b/test/deadline_submitter_for_unreal/unit/test_common.py
@@ -3,7 +3,7 @@
 import sys
 import pytest
 from unittest.mock import MagicMock
-
+from unittest import mock
 
 unreal_mock = MagicMock()
 sys.modules["unreal"] = unreal_mock
@@ -49,3 +49,103 @@ class TestCommon:
         with pytest.raises(exceptions.PathContainsNonValidCharacters):
             # WHEN
             common.validate_path_does_not_contain_non_valid_chars(path)
+
+    @pytest.mark.parametrize(
+        "deadline_args",
+        [
+            "-somearg=1",
+            "-somearg=1 -Otherarg=1",
+            "-somearg=1 -Otherarg=1 -thirdarg",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "argstring",
+        [
+            '-arg1 -arg2 -deadlineargs="<DEADLINEARGS>" -arg3=4',
+            '-Deadlineargs="<DEADLINEARGS>" -arg3=4 -arg3=5',
+            '-arg1 -arg2 -deadlineargs="<DEADLINEARGS>"',
+            "-arg1 -arg2 -deadlineArgs='<DEADLINEARGS>' -arg3=4",
+            "-deadlineargs='<DEADLINEARGS>' -arg3=4 -arg3=5",
+            "-arg1 -arg2 -deadlineargs='<DEADLINEARGS>'",
+        ],
+    )
+    def test_extract_deadline_args(self, deadline_args: str, argstring: str):
+        input_str = argstring.replace("<DEADLINEARGS>", deadline_args)
+
+        assert common.extract_deadline_args(input_str) == deadline_args
+
+    @pytest.mark.parametrize(
+        "inherited_args,additional_args,expected_result",
+        [
+            # Basic case with no special args
+            (
+                "-arg1 -arg2=value",
+                "-add1 -add2=val",
+                ["-arg1", "-arg2=value", "-add1", "-add2=val"],
+            ),
+        ],
+    )
+    def test_get_in_process_executor_cmd_args(
+        self, inherited_args, additional_args, expected_result
+    ):
+        with mock.patch.object(common, "unreal") as mock_unreal:
+            mock_settings = mock.MagicMock()
+            mock_settings.inherited_command_line_arguments = inherited_args
+            mock_settings.additional_command_line_arguments = additional_args
+            mock_unreal.get_default_object.return_value = mock_settings
+
+            result = common.get_in_process_executor_cmd_args()
+            assert result == expected_result
+
+    @pytest.mark.parametrize(
+        "inherited_args,deadline_args,additional_args,expected_result",
+        [
+            # Explicit deadline args test cases
+            (
+                '-arg1 -arg2 -deadlineargs="-specific1 -specific2" -arg3',
+                "-specific1 -specific2",
+                "-add1 -add2",
+                ["-specific1", "-specific2", "-add1", "-add2"],
+            ),
+            # Mixed case and spacing variations
+            (
+                '-arg1 -DeAdLiNeArGs="-option1=value -option2" -arg2',
+                "-option1=value -option2",
+                "-add1",
+                ["-option1=value", "-option2", "-add1"],
+            ),
+            # Single quotes
+            (
+                "-arg1 -deadlineargs='-flag1 -flag2=test' -arg2",
+                "-flag1 -flag2=test",
+                "-add1 -add2=val",
+                ["-flag1", "-flag2=test", "-add1", "-add2=val"],
+            ),
+            # Multiple flags and nested quotes
+            (
+                """-arg1 -deadlineargs="-a=1 -b=\"quoted value\" -c" -arg2""",
+                """-a=1 -b="quoted value" -c""",
+                "-add1",
+                ["-a=1", '-b="quoted', 'value"', "-c", "-add1"],
+            ),
+            # Empty deadline args
+            ('-arg1 -deadlineargs="" -arg2', "", "-add1", ["", "-add1"]),
+        ],
+    )
+    def test_deadline_args_override(
+        self, inherited_args, deadline_args, additional_args, expected_result
+    ):
+        with mock.patch.object(common, "unreal") as mock_unreal:
+            mock_settings = mock.MagicMock()
+            mock_settings.inherited_command_line_arguments = inherited_args
+            mock_settings.additional_command_line_arguments = additional_args
+            mock_unreal.get_default_object.return_value = mock_settings
+
+            with mock.patch(
+                "deadline.unreal_submitter.common.extract_deadline_args", return_value=deadline_args
+            ):
+                with mock.patch("deadline.unreal_submitter.common.logger.info") as mock_logger:
+                    result = common.get_in_process_executor_cmd_args()
+                    assert result == expected_result
+
+                    mock_logger.assert_called_once_with(f"Found deadline args {deadline_args}")

--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -1,0 +1,113 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import json
+import pytest
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../.."))
+
+from scripts.build_plugin import find_engine_root
+
+
+def get_source_root() -> str:
+    """
+    Return the path of the root of the deadline-cloud-for-unreal-engine source.  Assumes it's 2 folders up from the directory this
+    file lives in, which is in a "/scripts/" subfolder off the root
+    """
+
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+
+    # Get the parent directory
+    parent_dir = os.path.dirname(current_dir)
+    root_dir = os.path.dirname(parent_dir)
+    return root_dir
+
+
+def get_build_script_args() -> list[str]:
+    """
+    Return the arguments to pass to the build script for a test installation
+    """
+
+    return ["--install", "--test", "--worker"]
+
+
+def add_plugins_to_project(project_path: str, plugins: list[str]):
+    """
+    Add the provided list of plugins to the uproject at the given project_path
+
+    :param project_path: path to .uproject file to add plugins to
+    :param plugins: List of string names of plugins to add to the project
+    """
+
+    # Read the current .uproject file
+    with open(project_path, "r") as f:
+        project_data = json.load(f)
+
+    # Make sure Plugins list exists
+    if "Plugins" not in project_data:
+        project_data["Plugins"] = []
+
+    # Add each plugin if not already present
+    for plugin_name in plugins:
+        plugin_entry = {"Name": plugin_name, "Enabled": True}
+        if plugin_entry not in project_data["Plugins"]:
+            project_data["Plugins"].append(plugin_entry)
+
+    # Write back the modified file
+    with open(project_path, "w") as f:
+        json.dump(project_data, f, indent=2)
+
+
+@pytest.fixture(scope="session")
+def build_plugin():
+    # A fixture to run the scripts/build_plugin.py script at most once per test session to guarantee
+    # the latest version of the code has been built and installed.  We run the script as a subprocess
+    # rather than importing and running the methods directly to simulate how customers will execute it
+
+    # build_plugin.py lives in the scripts subfolder relative to the root of the repository
+    # which is two folders up from this folder
+    script_path = os.path.join(get_source_root(), "scripts", "build_plugin.py")
+    if not os.path.exists(script_path):
+        pytest.fail(f"Could not find build_plugin.py at {script_path}")
+
+    build_args = ["python", script_path]
+    build_args.extend(get_build_script_args())
+    # Run the script and capture the output
+    result = subprocess.run(build_args, text=True)
+    assert result.returncode == 0
+
+
+@pytest.fixture(scope="session")
+def create_readonly_test_project():
+    project_base = os.path.expanduser("~/Documents/UnrealProjects/TestProjects")
+    os.makedirs(project_base, exist_ok=True)
+
+    # Create a directory with a unique name under the project base folder
+    # Using a default temporary directory will cause Unreal build failures
+    temp_dir = tempfile.TemporaryDirectory(dir=project_base).name
+    print(f"Created project folder: {temp_dir}")
+
+    engine_root = find_engine_root()
+    # Source path for the template
+    source_path = os.path.join(engine_root, "Templates\TP_DMXBP")
+    if not os.path.exists(source_path):
+        pytest.fail(f"Could not find source template at {source_path}")
+
+    # Destination will be temp_dir/TP_DMXBP
+    dest_path = os.path.abspath(os.path.join(temp_dir, "TP_DMXBP"))
+
+    # Recursively copy the directory
+    shutil.copytree(source_path, dest_path)
+    print(f"Created project dir {dest_path}")
+
+    # Add our plugins
+    project_path = os.path.join(dest_path, "TP_DMXBP.uproject")
+    add_plugins_to_project(project_path, ["UnrealDeadlineCloudService", "MovieRenderPipeline"])
+
+    yield dest_path, project_path

--- a/test/end_to_end/test_create_job.py
+++ b/test/end_to_end/test_create_job.py
@@ -1,0 +1,31 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import subprocess
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def test_create_job(build_plugin, create_readonly_test_project):
+    """Run CreateJob automation test from within Unreal"""
+
+    _, uproject_file = create_readonly_test_project
+
+    logger.info(f"Creating job from project {uproject_file}")
+    create_job_args = [
+        "UnrealEditor-Cmd.exe",
+        uproject_file,
+        "-ExecCmds=Automation RunTests Deadline.Integration.CreateJob",
+        "-stdout",
+        "-unattended",
+        "-nullrhi",
+        "-nosplash",
+        "-nosound",
+        "-nocontentbrowser",
+        "-nopause",
+        "-testexit=Automation Test Queue Empty",
+        "-deadlineargs=-NoLoadingScreen -FixedSeed -log -Unattended -MRQInstance -deterministicaudio -audiomixer",
+    ]
+    logger.info(f"Calling subprocess with args {create_job_args}")
+    result = subprocess.run(create_job_args, text=True)
+    assert result.returncode == 0


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to be able to run end to end tests that validate that changes to code still build, on the submitter side still allow us to submit a job, and on the adapter side still successfully render the job.

### What was the solution? (How)
Create additional test support and an e2e test in pytest which can be run through hatch run e2e which uses our build script to build and install the binaries as well as both the submitter and adapter, creates a temporary project from an MRQ compatible template and configures it with the necessary plugins, and runs the CreateJob test from the command line.

Future changes will create deadline resources (Farm/queue/fleet/etc) for the purposes of the test, start a local worker agent using those resources, submit to that queue, and validate outputs.

### What is the impact of this change?
Much easier to validate changes.

### How was this change tested?
Ran test successfully against local worker agent, observed job completed successfully.

![e2ecreatejob](https://github.com/user-attachments/assets/a838b884-46f5-4f81-a0ed-7f596cc0d7bf)

### Have you run a render job successfully with these changes?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*