### PR TITLE
feat: Developer Settings refactor

### DIFF
--- a/src/unreal_plugin/Content/Python/init_unreal.py
+++ b/src/unreal_plugin/Content/Python/init_unreal.py
@@ -111,7 +111,7 @@ if remote_execution != "True":
     # These unused imports are REQUIRED!!!
     # Unreal Engine loads any init_unreal.py it finds in its search paths.
     # These imports finish the setup for the plugin.
-    from settings import DeadlineCloudDeveloperSettingsImplementation  # noqa: F401
+    from settings import DeadlineCloudSettingsLibraryImplementation  # noqa: F401
     from job_library import DeadlineCloudJobBundleLibraryImplementation  # noqa: F401
     from open_job_template_api import (  # noqa: F401
         PythonYamlLibraryImplementation,

--- a/src/unreal_plugin/Content/Python/settings.py
+++ b/src/unreal_plugin/Content/Python/settings.py
@@ -58,12 +58,33 @@ class DeadlineCloudSettingsLibraryImplementation(unreal.DeadlineCloudSettingsLib
         self.init_from_python()
 
     @unreal.ufunction(override=True)
-    def get_aws_config_setting(self, setting_name: str) -> str:
-        return config.get_setting(setting_name)
+    def get_aws_string_config_setting(self, setting_name: str) -> str:
+        try:
+            result = config.get_setting(setting_name)
+            logger.info(f"try get aws string config setting {setting_name} type: {type(result)}")
+            logger.info(f"try get aws string config setting {setting_name} value: {result}")
+
+            if isinstance(result, list):
+                logger.warning(f"{setting_name} is a list: {result}")
+                result = result[0]
+
+            return str(result)
+
+        except Exception as e:
+            logger.error(f"Error in get_aws_string_config_setting: {str(e)}")
+            return ""
 
     @unreal.ufunction(override=True)
-    def set_aws_config_setting(self, setting_name: str, setting_value: str) -> None:
-        config.set_setting(setting_name, setting_value)
+    def set_aws_string_config_setting(self, setting_name: str, setting_value: str) -> None:
+        try:
+            current_setting = config.get_setting(setting_name)
+            if setting_value != current_setting:
+                logger.info(f"set aws string config setting {setting_name} value: {setting_value}")
+                config.set_setting(setting_name, setting_value)
+            else:
+                logger.info(f"{setting_name} unchanged (already {setting_value}), skipping update")
+        except Exception as e:
+            logger.error(f"Error in set_aws_string_config_setting: {str(e)}")
 
     @unreal.ufunction(override=True)
     def get_farms(self) -> list:

--- a/src/unreal_plugin/Content/Python/settings.py
+++ b/src/unreal_plugin/Content/Python/settings.py
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import sys
-import threading
 import unreal
 
 import boto3
@@ -18,27 +17,11 @@ from deadline.unreal_logger import get_logger
 logger = get_logger()
 
 
-@unreal.ustruct()
-class UnrealAwsEntity(unreal.StructBase):
-    id = unreal.uproperty(str)
-    name = unreal.uproperty(str)
-
-    @staticmethod
-    def create(entity_dict, id_field):
-        """
-        Create a new AwsEntity instance.
-
-        :param entity_dict: A dictionary containing the entity data.
-        :type entity_dict: dict
-        :param id_field: The name of the field that represents the entity's ID.
-        :type id_field: str
-        :return: The newly created AwsEntity instance.
-        :rtype: AwsEntity
-        """
-        aws_entity = UnrealAwsEntity()
-        aws_entity.id = entity_dict[id_field]
-        aws_entity.name = entity_dict["displayName"]
-        return aws_entity
+def create_aws_entity(entity_dict, id_field):
+    aws_entity = unreal.UnrealAwsEntity()
+    aws_entity.id = entity_dict[id_field]
+    aws_entity.name = entity_dict["displayName"]
+    return aws_entity
 
 
 # TODO handling config parameter in api calls
@@ -56,125 +39,45 @@ def _get_current_os() -> str:
 
 
 @unreal.uclass()
-class DeadlineCloudDeveloperSettingsImplementation(unreal.DeadlineCloudDeveloperSettings):
-    farms_cache_list = unreal.uproperty(unreal.Array(UnrealAwsEntity), meta=dict(Category="Cache"))
-    queues_cache_list = unreal.uproperty(unreal.Array(UnrealAwsEntity), meta=dict(Category="Cache"))
-    storage_profile_cache_list = unreal.uproperty(
-        unreal.Array(UnrealAwsEntity), meta=dict(Category="Cache")
-    )
+class DeadlineCloudSettingsLibraryImplementation(unreal.DeadlineCloudSettingsLibrary):
 
     def _post_init(self):
-        self.refresh_from_default_profile()
-        self.refresh_state()
+        self.init_from_python()
 
-    def refresh_from_default_profile(self):
-        t = threading.Thread(target=self.__refresh_deadline_settings, daemon=True)
-        t.start()
+    @unreal.ufunction(override=True)
+    def get_aws_config_setting(self, setting_name: str) -> str:
+        return config.get_setting(setting_name)
 
-    def __refresh_deadline_settings(self):
-        # TODO handle case when user is not logged in
-        try:
-            aws_profile_name = config.get_setting("defaults.aws_profile_name")
-            logger.info(f"aws_profile_name type: {type(aws_profile_name)}")
-            logger.info(f"aws_profile_name value: {aws_profile_name}")
+    @unreal.ufunction(override=True)
+    def set_aws_config_setting(self, setting_name: str, setting_value: str) -> None:
+        config.set_setting(setting_name, setting_value)
 
-            if isinstance(aws_profile_name, list):
-                # Handle the case where it's a list instead of a string
-                logger.warning(f"aws_profile_name is a list: {aws_profile_name}")
-                # Use the first item if available, otherwise use a default
-                aws_profile_name = aws_profile_name[0] if aws_profile_name else "(default)"
-
-            if aws_profile_name in ["(default)", "default", ""]:
-                aws_profile_name = "(default)"
-
-            self.work_station_configuration.global_settings.aws_profile = aws_profile_name
-
-            self.work_station_configuration.profile.job_history_dir.path = config.get_setting(
-                "settings.job_history_dir"
-            ).replace("\\", "/")
-
-            farm_id = config.get_setting("defaults.farm_id")
-            farm_entity = self.find_farm_by_id(farm_id)
-
-            if farm_entity is not None:
-                self.work_station_configuration.profile.default_farm = farm_entity.name
-
-            queue_id = config.get_setting("defaults.queue_id")
-            queue_entity = self.find_queue_by_id(queue_id)
-            if queue_entity is not None:
-                self.work_station_configuration.farm.default_queue = queue_entity.name
-
-            storage_profile_id = config.get_setting("settings.storage_profile_id")
-            storage_profile_entity = self.find_storage_profile_by_id(storage_profile_id)
-            if storage_profile_entity is not None:
-                self.work_station_configuration.farm.default_storage_profile = (
-                    storage_profile_entity.name
-                )
-
-            self.work_station_configuration.farm.job_attachment_filesystem_options = (
-                config.get_setting("defaults.job_attachments_file_system")
-            )
-
-            self.work_station_configuration.general.auto_accept_confirmation_prompts = (
-                config.get_setting("settings.auto_accept") == "true"
-            )
-
-            self.work_station_configuration.general.conflict_resolution_option = config.get_setting(
-                "settings.conflict_resolution"
-            )
-
-            self.work_station_configuration.general.current_logging_level = config.get_setting(
-                "settings.log_level"
-            )
-        except Exception as e:
-            # Add comprehensive error logging
-            logger.error(f"Error in __refresh_deadline_settings: {str(e)}")
-            logger.error(f"Error type: {type(e).__name__}")
-            import traceback
-
-            logger.error(f"Traceback: {traceback.format_exc()}")
-            # Continue with default values if there's an error
-            self.work_station_configuration.global_settings.aws_profile = "(default)"
-
-    @unreal.ufunction(ret=unreal.Array(str))
-    def get_aws_profiles(self):
-        session = boto3.Session()
-        aws_profile_names = list(session._session.full_config["profiles"].keys())
-        for i in range(len(aws_profile_names)):
-            if aws_profile_names[i] in ["default", "(defaults)", ""]:
-                aws_profile_names[i] = "(default)"
-        return aws_profile_names
-
-    @unreal.ufunction(ret=unreal.Array(str))
-    def get_farms(self):
+    @unreal.ufunction(override=True)
+    def get_farms(self) -> list:
         try:
             response = api.list_farms()
-            self.farms_cache_list = [
-                UnrealAwsEntity.create(item, "farmId") for item in response["farms"]
-            ]
+            farms_list = [create_aws_entity(item, "farmId") for item in response["farms"]]
         # TODO: do proper exception handling
         except Exception:
             return []
-        return [farm.name for farm in self.farms_cache_list]
+        return farms_list
 
-    @unreal.ufunction(ret=unreal.Array(str))
-    def get_queues(self):
+    @unreal.ufunction(override=True)
+    def get_queues(self) -> list:
         default_farm_id = config_file.get_setting("defaults.farm_id")
         if default_farm_id:
             try:
                 response = api.list_queues(farmId=default_farm_id)
-                self.queues_cache_list = [
-                    UnrealAwsEntity.create(item, "queueId") for item in response["queues"]
-                ]
+                queues_list = [create_aws_entity(item, "queueId") for item in response["queues"]]
             # TODO: do proper exception handling
             except Exception:
-                self.queues_cache_list = []
+                queues_list = []
         else:
-            self.queues_cache_list = []
-        return [queue.name for queue in self.queues_cache_list]
+            queues_list = []
+        return queues_list
 
-    @unreal.ufunction(ret=unreal.Array(str))
-    def get_storage_profiles(self):
+    @unreal.ufunction(override=True)
+    def get_storage_profiles(self) -> list:
         default_farm_id = config_file.get_setting("defaults.farm_id")
         default_queue_id = config_file.get_setting("defaults.queue_id")
         if default_farm_id and default_queue_id:
@@ -191,228 +94,39 @@ class DeadlineCloudDeveloperSettingsImplementation(unreal.DeadlineCloudDeveloper
                         "osFamily": _get_current_os(),
                     }
                 )
-                self.storage_profile_cache_list = [
-                    UnrealAwsEntity.create(item, "storageProfileId") for item in items
+                storage_profile_list = [
+                    create_aws_entity(item, "storageProfileId") for item in items
                 ]
             # TODO: do proper exception handling
             except Exception:
-                self.storage_profile_cache_list = []
-            return [storage_profile.name for storage_profile in self.storage_profile_cache_list]
+                storage_profile_list = []
+            return storage_profile_list
         else:
-            self.storage_profile_cache_list = []
-        return self.storage_profile_cache_list
-
-    @unreal.ufunction(ret=unreal.Array(str))
-    def get_job_attachment_modes(self):
-        return ["COPIED", "VIRTUAL"]
-
-    @unreal.ufunction(ret=unreal.Array(str))
-    def get_conflict_resolution_options(self):
-        return [option.name for option in FileConflictResolution]
-
-    @unreal.ufunction(ret=unreal.Array(str))
-    def get_logging_levels(self):
-        return ["ERROR", "WARNING", "INFO", "DEBUG"]
+            storage_profile_list = []
+        return storage_profile_list
 
     @unreal.ufunction(override=True)
-    def refresh_state(self):
-        t = threading.Thread(target=self.__refresh_deadline_status, daemon=True)
-        t.start()
-
-    def __refresh_deadline_status(self):
+    def get_api_status(self) -> unreal.DeadlineCloudStatus:
         config_parser = config_file.read_config()
-        self.work_station_configuration.state.creds_type = api.get_credentials_source(
-            config=config_parser
-        ).name
+        state = unreal.DeadlineCloudStatus()
+        state.creds_type = api.get_credentials_source(config=config_parser).name
 
         creds_status = api.check_authentication_status(config=config_parser)
-        self.work_station_configuration.state.creds_status = creds_status.name
+        state.creds_status = creds_status.name
 
         if creds_status == AwsAuthenticationStatus.AUTHENTICATED:
-            self.work_station_configuration.state.api_availability = (
+            state.api_availability = (
                 "AUTHORIZED"
                 if api.check_deadline_api_available(config=config_parser)
                 else "NOT AUTHORIZED"
             )
         else:
-            self.work_station_configuration.state.api_availability = "NOT AUTHORIZED"
+            state.api_availability = "NOT AUTHORIZED"
+
+        return state
 
     @unreal.ufunction(override=True)
-    def on_settings_modified(self, property_name):
-        """
-        TODO refresh config
-        1. When we change an "aws profile" we need to pull Job history dir and default farm
-        2. When we change "default farm" we need to pull default queue,
-           default storage profile, and job attachment fs options
-        """
-        logger.info(f"Changed property: {property_name}")
-
-        # This means we need to change default profile
-        # If the default profile is changed then we update it in the config first
-        # after that we need to save this setting first and read settings for all other values
-        if property_name == "AWS_Profile":
-            config.set_setting(
-                "defaults.aws_profile_name",
-                self.work_station_configuration.global_settings.aws_profile,
-            )
-            self.refresh_from_default_profile()
-            return
-
-        if property_name == "DefaultFarm":
-            farm_value = self.work_station_configuration.profile.default_farm
-            logger.info(f"Farm value: {farm_value}")
-
-            farm = self.find_farm_by_name(farm_value)
-            if farm is not None:
-                # Found by name, use the ID
-                current_farm_id = config.get_setting("defaults.farm_id")
-                if current_farm_id != farm.id:
-                    logger.info(f"Found farm with name {farm_value}, setting ID: {farm.id}")
-                    config.set_setting("defaults.farm_id", farm.id)
-                else:
-                    logger.info(f"Farm ID unchanged (already {farm.id}), skipping update")
-            else:
-                logger.warning(f"Could not find farm with name: {farm_value}")
-
-            self.refresh_from_default_profile()
-            return
-
-        # Handle DefaultQueue property similarly to farm
-        if property_name == "DefaultQueue":
-            queue_value = self.work_station_configuration.farm.default_queue
-            logger.info(f"Queue value: {queue_value}")
-
-            queue = self.find_queue_by_name(queue_value)
-            if queue is not None:
-                # Found by name, use the ID
-                current_queue_id = config.get_setting("defaults.queue_id")
-                if current_queue_id != queue.id:
-                    logger.info(f"Found queue with name {queue_value}, setting ID: {queue.id}")
-                    config.set_setting("defaults.queue_id", queue.id)
-                else:
-                    logger.info(f"Queue ID unchanged (already {queue.id}), skipping update")
-            else:
-                logger.warning(f"Could not find queue with name: {queue_value}")
-            return
-
-        self.save_to_file()
-
-    @unreal.ufunction(override=True)
-    def get_farm_name_by_id(self, farm_id):
-        farm = self.find_farm_by_id(farm_id)
-        return farm.name if farm is not None else ""
-
-    @unreal.ufunction(override=True)
-    def get_queue_name_by_id(self, queue_id):
-        queue = self.find_queue_by_id(queue_id)
-        return queue.name if queue is not None else ""
-
-    def find_farm_by_id(self, farm_id):
-        _ = self.get_farms()
-        farm = next((farm for farm in self.farms_cache_list if farm.id == farm_id), None)
-        return farm
-
-    def find_queue_by_id(self, queue_id):
-        _ = self.get_queues()
-        queue = next((queue for queue in self.queues_cache_list if queue.id == queue_id), None)
-        return queue
-
-    def find_storage_profile_by_id(self, storage_profile_id):
-        _ = self.get_storage_profiles()
-        storage_profile = next(
-            (
-                storage_profile
-                for storage_profile in self.storage_profile_cache_list
-                if storage_profile.id == storage_profile_id
-            ),
-            None,
-        )
-        return storage_profile
-
-    def find_farm_by_name(self, farm_name):
-        # response = api.list_farms()
-        farm = next((farm for farm in self.farms_cache_list if farm.name == farm_name), None)
-        return farm
-
-    def find_queue_by_name(self, queue_name):
-        # default_farm_id = config_file.get_setting("defaults.farm_id")
-        # response = api.list_queues(farmId=default_farm_id)
-        queue = next((queue for queue in self.queues_cache_list if queue.name == queue_name), None)
-        return queue
-
-    def find_storage_by_name(self, storage_profile_name):
-        storage_profile = next(
-            (item for item in self.storage_profile_cache_list if item.name == storage_profile_name),
-            None,
-        )
-        return storage_profile
-
-    def save_to_file(self):
-        config_parser = config_file.read_config()
-        config.set_setting(
-            "defaults.aws_profile_name",
-            self.work_station_configuration.global_settings.aws_profile,
-            config=config_parser,
-        )
-
-        config.set_setting(
-            "settings.job_history_dir",
-            self.work_station_configuration.profile.job_history_dir.path,
-            config=config_parser,
-        )
-
-        farm = self.find_farm_by_name(self.work_station_configuration.profile.default_farm)
-        if farm is not None:
-            logger.info(f"Update default farm: {farm.id} -- {farm.name}")
-            config.set_setting("defaults.farm_id", farm.id, config=config_parser)
-
-        queue = self.find_queue_by_name(self.work_station_configuration.farm.default_queue)
-        if queue is not None:
-            logger.info(f"Update default queue: {queue.id} -- {queue.name}")
-            config.set_setting("defaults.queue_id", queue.id, config=config_parser)
-
-        storage_profile = self.find_storage_by_name(
-            self.work_station_configuration.farm.default_storage_profile
-        )
-        if storage_profile is not None:
-            logger.info(
-                f"Update default storage profile: {storage_profile.id} "
-                f"-- {storage_profile.name}"
-            )
-            config.set_setting(
-                "settings.storage_profile_id", storage_profile.id, config=config_parser
-            )
-
-        # farm.job_attachment_filesystem_options (defaults.job_attachments_file_system)
-        config.set_setting(
-            "defaults.job_attachments_file_system",
-            self.work_station_configuration.farm.job_attachment_filesystem_options,
-            config=config_parser,
-        )
-
-        if self.work_station_configuration.general.auto_accept_confirmation_prompts:
-            config.set_setting("settings.auto_accept", "true", config=config_parser)
-        else:
-            config.set_setting("settings.auto_accept", "false", config=config_parser)
-
-        # general.conflict_resolution_option (settings.conflict_resolution)
-        config.set_setting(
-            "settings.conflict_resolution",
-            self.work_station_configuration.general.conflict_resolution_option,
-            config=config_parser,
-        )
-
-        # general.current_logging_level
-        config.set_setting(
-            "settings.log_level",
-            self.work_station_configuration.general.current_logging_level,
-            config=config_parser,
-        )
-
-        config_file.write_config(config_parser)
-
-    @unreal.ufunction(override=True)
-    def login(self):
+    def login(self) -> bool:
         logger.info("login")
 
         def on_pending_authorization(**kwargs):
@@ -436,12 +150,109 @@ class DeadlineCloudDeveloperSettingsImplementation(unreal.DeadlineCloudDeveloper
             unreal.EditorDialog.show_message(
                 "Deadline Cloud", success_message, unreal.AppMsgType.OK, unreal.AppReturnType.OK
             )
-            self.refresh_from_default_profile()
-            self.refresh_state()
+            return True
+
+        return False
 
     @unreal.ufunction(override=True)
-    def logout(self):
+    def logout(self) -> None:
         logger.info("Deadline Cloud logout")
         api.logout()
-        self.refresh_from_default_profile()
-        self.refresh_state()
+
+    @unreal.ufunction(override=True)
+    def get_aws_profiles(self) -> list:
+        session = boto3.Session()
+        aws_profile_names = list(session._session.full_config["profiles"].keys())
+        for i in range(len(aws_profile_names)):
+            if aws_profile_names[i] in ["default", "(defaults)", ""]:
+                aws_profile_names[i] = "(default)"
+        return aws_profile_names
+
+    @unreal.ufunction(override=True)
+    def get_conflict_resolution_options(self) -> list:
+        return [option.name for option in FileConflictResolution]
+
+    @unreal.ufunction(override=True)
+    def get_job_attachment_modes(self) -> list:
+        return ["COPIED", "VIRTUAL"]
+
+    @unreal.ufunction(override=True)
+    def get_logging_levels(self) -> list:
+        return ["ERROR", "WARNING", "INFO", "DEBUG"]
+
+    @staticmethod
+    def find_entity_by_name(name, objects_list: unreal.UnrealAwsEntity):
+        result_object = next(
+            (result_object for result_object in objects_list if result_object.name == name), None
+        )
+        return result_object
+
+    @unreal.ufunction(override=True)
+    def save_to_aws_config(
+        self,
+        settings: unreal.DeadlineCloudPluginSettings,
+        cache: unreal.DeadlineCloudPluginSettingsCache,
+    ) -> None:
+        config_parser = config_file.read_config()
+        config.set_setting(
+            "defaults.aws_profile_name",
+            settings.global_settings.aws_profile,
+            config=config_parser,
+        )
+
+        config.set_setting(
+            "settings.job_history_dir",
+            settings.profile.job_history_dir.path,
+            config=config_parser,
+        )
+
+        farm = self.find_entity_by_name(settings.profile.default_farm, cache.farms_cache_list)
+        if farm is not None:
+            logger.info(f"Update default farm: {farm.id} -- {farm.name}")
+            config.set_setting("defaults.farm_id", farm.id, config=config_parser)
+
+        queue = self.find_entity_by_name(settings.farm.default_queue, cache.queues_cache_list)
+        if queue is not None:
+            logger.info(f"Update default queue: {queue.id} -- {queue.name}")
+            config.set_setting("defaults.queue_id", queue.id, config=config_parser)
+
+        storage_profile = self.find_entity_by_name(
+            settings.farm.default_storage_profile, cache.storage_profiles_cache_list
+        )
+
+        if storage_profile is not None:
+            logger.info(
+                f"Update default storage profile: {storage_profile.id} "
+                f"-- {storage_profile.name}"
+            )
+            config.set_setting(
+                "settings.storage_profile_id", storage_profile.id, config=config_parser
+            )
+
+        # farm.job_attachment_filesystem_options (defaults.job_attachments_file_system)
+        config.set_setting(
+            "defaults.job_attachments_file_system",
+            settings.farm.job_attachment_filesystem_options,
+            config=config_parser,
+        )
+
+        if settings.general.auto_accept_confirmation_prompts:
+            config.set_setting("settings.auto_accept", "true", config=config_parser)
+        else:
+            config.set_setting("settings.auto_accept", "false", config=config_parser)
+
+        # general.conflict_resolution_option (settings.conflict_resolution)
+        config.set_setting(
+            "settings.conflict_resolution",
+            settings.general.conflict_resolution_option,
+            config=config_parser,
+        )
+
+        # general.current_logging_level
+        config.set_setting(
+            "settings.log_level",
+            settings.general.current_logging_level,
+            config=config_parser,
+        )
+
+        config_file.write_config(config_parser)

--- a/src/unreal_plugin/Content/Python/settings.py
+++ b/src/unreal_plugin/Content/Python/settings.py
@@ -2,6 +2,7 @@
 
 import sys
 import unreal
+from typing import Any
 
 import boto3
 import deadline.client.config as config
@@ -17,10 +18,22 @@ from deadline.unreal_logger import get_logger
 logger = get_logger()
 
 
-def create_aws_entity(entity_dict, id_field):
+def create_aws_entity(entity_descriptor: dict[str, Any], id_field: str) -> unreal.UnrealAwsEntity:
+    """
+    Create and return instance of UnrealAwsEntity
+
+    :param entity_descriptor: Dictionary descriptor of the entity
+    :type entity_descriptor: dict[str, Any]
+    :param id_field: ID key name of the entity property to get from descriptor and store
+                     in UnrealAwsEntity.id
+    :type id_field: str
+    :return: UnrealAwsEntity object
+    :rtype: unreal.UnrealAwsEntity
+    """
+
     aws_entity = unreal.UnrealAwsEntity()
-    aws_entity.id = entity_dict[id_field]
-    aws_entity.name = entity_dict["displayName"]
+    aws_entity.id = entity_descriptor[id_field]
+    aws_entity.name = entity_descriptor["displayName"]
     return aws_entity
 
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.cpp
@@ -3,19 +3,103 @@
 
 #include "DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h"
 
+namespace DeadlineSettingsKeys
+{
+    const FString AwsProfileName = TEXT("defaults.aws_profile_name");
+    const FString FarmId = TEXT("defaults.farm_id");
+    const FString QueueId = TEXT("defaults.queue_id");
+    const FString StorageProfileId = TEXT("settings.storage_profile_id");
+    const FString JobHistoryDir = TEXT("settings.job_history_dir");
+    const FString JobAttachmentsFileSystem = TEXT("defaults.job_attachments_file_system");
+    const FString AutoAccept = TEXT("settings.auto_accept");
+    const FString ConflictResolution = TEXT("settings.conflict_resolution");
+    const FString LogLevel = TEXT("settings.log_level");
+}
 
 UDeadlineCloudDeveloperSettings::UDeadlineCloudDeveloperSettings()
 {
-    // UE_LOG(LogTemp, Log, TEXT("UDeadlineCloudDeveloperSettings::UDeadlineCloudDeveloperSettings()"));
-    // if (const auto SettingsLib = UDeadlineCloudSettingsLibrary::Get())
-    // {
-    //     WorkStationConfiguration.Global.AWS_Profile = SettingsLib->GetProfile();
-    //     UE_LOG(LogTemp, Log, TEXT("Update setting AWS profile: %s"), *WorkStationConfiguration.Global.AWS_Profile);
-    // }
-    OnSettingChanged().AddLambda([this](UObject*, const FPropertyChangedEvent& PropertyChangedEvent)
-    {
-        this->OnSettingsModified(PropertyChangedEvent.GetPropertyName().ToString());
-    });
+}
+
+TArray<FString> UDeadlineCloudDeveloperSettings::GetFarmsList()
+{
+	UpdateFarmsCacheList();
+
+	TArray<FString> Farms;
+	for (const auto& Farm : WorkStationConfigurationCache.FarmsCacheList)
+	{
+		Farms.Add(Farm.Name);
+	}
+
+	return Farms;
+}
+
+TArray<FString> UDeadlineCloudDeveloperSettings::GetAWSProfilesList()
+{
+	TArray<FString> AWSProfiles;
+	if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+	{
+		AWSProfiles = Library->GetAWSProfiles();
+	}
+
+	return AWSProfiles;
+}
+
+TArray<FString> UDeadlineCloudDeveloperSettings::GetLoggingLevels()
+{
+	TArray<FString> LoggingLevels;
+	if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+	{
+		LoggingLevels = Library->GetLoggingLevels();
+	}
+
+	return LoggingLevels;
+}
+
+TArray<FString> UDeadlineCloudDeveloperSettings::GetConflictResolutionOptions()
+{
+	TArray<FString> ConflictResolutionOptions;
+	if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+	{
+		ConflictResolutionOptions = Library->GetConflictResolutionOptions();
+	}
+
+	return ConflictResolutionOptions;
+}
+
+TArray<FString> UDeadlineCloudDeveloperSettings::GetStorageProfilesList()
+{
+	UpdateStorageProfilesCacheList();
+
+	TArray<FString> StorageProfiles;
+	for (const auto& StorageProfile : WorkStationConfigurationCache.StorageProfilesCacheList)
+	{
+		StorageProfiles.Add(StorageProfile.Name);
+	}
+
+	return StorageProfiles;
+}
+
+TArray<FString> UDeadlineCloudDeveloperSettings::GetJobAttachmentModes()
+{
+	TArray<FString> JobAttachmentModes;
+	if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+	{
+		JobAttachmentModes = Library->GetJobAttachmentModes();
+	}
+
+	return JobAttachmentModes;
+}
+
+TArray<FString> UDeadlineCloudDeveloperSettings::GetQueuesList()
+{
+	UpdateQueuesCacheList();
+
+	TArray<FString> Queues;
+	for (const auto& Queue : WorkStationConfigurationCache.QueuesCacheList)
+	{
+		Queues.Add(Queue.Name);
+	}
+	return Queues;
 }
 
 FText UDeadlineCloudDeveloperSettings::GetSectionText() const
@@ -28,19 +112,221 @@ FName UDeadlineCloudDeveloperSettings::GetSectionName() const
     return TEXT("DeadlineCloud");
 }
 
-
-// TArray<FString> UDeadlineCloudDeveloperSettings::GetAwsProfiles()
-// {
-//     if (const auto SettingsLib = UDeadlineCloudSettingsLibrary::Get())
-//     {
-//     	return SettingsLib->GetProfiles();
-// 	}
-// 	return TArray<FString>();
-// }
-
-/*
-void UDeadlineCloudDeveloperSettings::SaveConfig(uint64 Flags, const TCHAR* Filename, FConfigCacheIni* Config, bool bAllowCopyToDefaultObject)
+void UDeadlineCloudDeveloperSettings::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
 {
-	UE_LOG(LogTemp, Log, TEXT("Don't do anything"))
+	Super::PostEditChangeProperty(PropertyChangedEvent);
+
+	if (PropertyChangedEvent.Property)
+	{
+		if (PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(UDeadlineCloudDeveloperSettings, WorkStationConfiguration.GlobalSettings.AWS_Profile))
+		{
+			if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+			{
+				Library->SetAWSConfigSetting(DeadlineSettingsKeys::AwsProfileName, WorkStationConfiguration.GlobalSettings.AWS_Profile);
+			}
+
+			RefreshFromDefaultProfile();
+		}
+		else if (PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(UDeadlineCloudDeveloperSettings, WorkStationConfiguration.Profile.DefaultFarm))
+		{
+			FUnrealAwsEntity Farm = FindFarmById(WorkStationConfiguration.Profile.DefaultFarm, true);
+			if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+			{
+				Library->SetAWSConfigSetting(DeadlineSettingsKeys::FarmId, Farm.Id);
+			}
+
+			RefreshFromDefaultProfile();
+		}
+		else
+		{
+			SaveToFile();
+		}
+	}
 }
-*/
+
+void UDeadlineCloudDeveloperSettings::PostInitProperties()
+{
+	Super::PostInitProperties();
+}
+
+void UDeadlineCloudDeveloperSettings::Refresh()
+{
+    RefreshFromDefaultProfile();
+    RefreshState();
+}
+
+void UDeadlineCloudDeveloperSettings::RefreshState()
+{
+	Async(EAsyncExecution::Thread, [this]()
+		{
+			RefreshStateInternal();
+		});
+}
+
+void UDeadlineCloudDeveloperSettings::RefreshStateInternal()
+{
+	if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+	{
+		WorkStationConfiguration.State = Library->GetApiStatus();
+	}
+}
+
+void UDeadlineCloudDeveloperSettings::RefreshFromDefaultProfile()
+{
+	Async(EAsyncExecution::Thread, [this]()
+		{
+			RefreshFromDefaultProfileInternal();
+		});
+}
+
+void UDeadlineCloudDeveloperSettings::RefreshFromDefaultProfileInternal()
+{
+    if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+    {
+		FString AWSProfileName = Library->GetAWSConfigSetting(DeadlineSettingsKeys::AwsProfileName);
+        if (AWSProfileName.IsEmpty() || AWSProfileName == TEXT("default") || AWSProfileName == TEXT("(default)"))
+        {
+            AWSProfileName = TEXT("(default)");
+        }
+
+		WorkStationConfiguration.GlobalSettings.AWS_Profile = AWSProfileName;
+
+		FString JobHistoryDir = Library->GetAWSConfigSetting(DeadlineSettingsKeys::JobHistoryDir);
+        JobHistoryDir.ReplaceInline(TEXT("\\"), TEXT("/"));
+
+		WorkStationConfiguration.Profile.JobHistoryDir.Path = JobHistoryDir;
+
+        FString FarmId = Library->GetAWSConfigSetting(DeadlineSettingsKeys::FarmId);
+
+		FUnrealAwsEntity Farm = FindFarmById(FarmId, true);
+		if (Farm.IsValid())
+		{
+			WorkStationConfiguration.Profile.DefaultFarm = Farm.Name;
+		}
+
+		FString QueueId = Library->GetAWSConfigSetting(DeadlineSettingsKeys::QueueId);
+		FUnrealAwsEntity Queue = FindQueueById(QueueId, true);
+		if (Queue.IsValid())
+		{
+			WorkStationConfiguration.Farm.DefaultQueue = Queue.Name;
+		}
+
+		FString StorageProfileId = Library->GetAWSConfigSetting(DeadlineSettingsKeys::StorageProfileId);
+		FUnrealAwsEntity StorageProfile = FindStorageProfileById(StorageProfileId, true);
+		if (StorageProfile.IsValid())
+		{
+			WorkStationConfiguration.Farm.DefaultStorageProfile = StorageProfile.Name;
+		}
+
+		FString JobAttachmentFilesystemOptions = Library->GetAWSConfigSetting(DeadlineSettingsKeys::JobAttachmentsFileSystem);
+		WorkStationConfiguration.Farm.JobAttachmentFilesystemOptions = JobAttachmentFilesystemOptions;
+
+		FString AutoAcceptConfirmationPrompts = Library->GetAWSConfigSetting(DeadlineSettingsKeys::AutoAccept);
+		WorkStationConfiguration.General.AutoAcceptConfirmationPrompts = AutoAcceptConfirmationPrompts == TEXT("true");
+
+		FString ConflictResolutionOption = Library->GetAWSConfigSetting(DeadlineSettingsKeys::ConflictResolution);
+		WorkStationConfiguration.General.ConflictResolutionOption = ConflictResolutionOption;
+
+		FString CurrentLoggingLevel = Library->GetAWSConfigSetting(DeadlineSettingsKeys::LogLevel);
+		WorkStationConfiguration.General.CurrentLoggingLevel = CurrentLoggingLevel;
+    }
+}
+
+void UDeadlineCloudDeveloperSettings::Login()
+{
+	if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+	{
+		if (Library->Login())
+		{
+			Refresh();
+		}
+	}
+}
+
+void UDeadlineCloudDeveloperSettings::Logout()
+{
+	if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+	{
+		Library->Logout();
+		Refresh();
+	}
+}
+
+void UDeadlineCloudDeveloperSettings::SaveToFile()
+{
+	if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+	{
+		Library->SaveToAWSConfig(WorkStationConfiguration, WorkStationConfigurationCache);
+	}
+}
+
+void UDeadlineCloudDeveloperSettings::UpdateFarmsCacheList()
+{
+	WorkStationConfigurationCache.FarmsCacheList.Reset();
+	if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+	{
+		WorkStationConfigurationCache.FarmsCacheList = Library->GetFarms();
+	}
+}
+
+FUnrealAwsEntity UDeadlineCloudDeveloperSettings::FindFarmById(const FString& FarmId, bool bUpdateFarmsList)
+{
+	if (bUpdateFarmsList)
+	{
+		UpdateFarmsCacheList();
+	}
+
+	return FindAwsEntityById(FarmId, WorkStationConfigurationCache.FarmsCacheList);
+}
+
+void UDeadlineCloudDeveloperSettings::UpdateStorageProfilesCacheList()
+{
+	WorkStationConfigurationCache.StorageProfilesCacheList.Reset();
+	if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+	{
+		WorkStationConfigurationCache.StorageProfilesCacheList = Library->GetStorageProfiles();
+	}
+}
+
+FUnrealAwsEntity UDeadlineCloudDeveloperSettings::FindStorageProfileById(const FString& StorageProfileId, bool bUpdateStorageProfilesList)
+{
+	if (bUpdateStorageProfilesList)
+	{
+		UpdateStorageProfilesCacheList();
+	}
+
+	return FindAwsEntityById(StorageProfileId, WorkStationConfigurationCache.StorageProfilesCacheList);
+
+}
+
+void UDeadlineCloudDeveloperSettings::UpdateQueuesCacheList()
+{
+	WorkStationConfigurationCache.QueuesCacheList.Reset();
+	if (auto Library = UDeadlineCloudSettingsLibrary::Get())
+	{
+		WorkStationConfigurationCache.QueuesCacheList = Library->GetQueues();
+	}
+}
+
+FUnrealAwsEntity UDeadlineCloudDeveloperSettings::FindQueueById(const FString& QueueId, bool bUpdateQueuesList)
+{
+	if (bUpdateQueuesList)
+	{
+		UpdateQueuesCacheList();
+	}
+
+	return FindAwsEntityById(QueueId, WorkStationConfigurationCache.QueuesCacheList);
+}
+
+FUnrealAwsEntity UDeadlineCloudDeveloperSettings::FindAwsEntityById(const FString& Id, const TArray<FUnrealAwsEntity>& EntityList)
+{
+	for (const auto& Entity : EntityList)
+	{
+		if (Entity.Id == Id)
+		{
+			return Entity;
+		}
+	}
+
+	return FUnrealAwsEntity();
+}

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.cpp
@@ -122,7 +122,7 @@ void UDeadlineCloudDeveloperSettings::PostEditChangeProperty(FPropertyChangedEve
 		{
 			if (auto Library = UDeadlineCloudSettingsLibrary::Get())
 			{
-				Library->SetAWSConfigSetting(DeadlineSettingsKeys::AwsProfileName, WorkStationConfiguration.GlobalSettings.AWS_Profile);
+				Library->SetAWSStringConfigSetting(DeadlineSettingsKeys::AwsProfileName, WorkStationConfiguration.GlobalSettings.AWS_Profile);
 			}
 
 			RefreshFromDefaultProfile();
@@ -132,7 +132,7 @@ void UDeadlineCloudDeveloperSettings::PostEditChangeProperty(FPropertyChangedEve
 			FUnrealAwsEntity Farm = FindFarmById(WorkStationConfiguration.Profile.DefaultFarm, true);
 			if (auto Library = UDeadlineCloudSettingsLibrary::Get())
 			{
-				Library->SetAWSConfigSetting(DeadlineSettingsKeys::FarmId, Farm.Id);
+				Library->SetAWSStringConfigSetting(DeadlineSettingsKeys::FarmId, Farm.Id);
 			}
 
 			RefreshFromDefaultProfile();
@@ -183,7 +183,7 @@ void UDeadlineCloudDeveloperSettings::RefreshFromDefaultProfileInternal()
 {
     if (auto Library = UDeadlineCloudSettingsLibrary::Get())
     {
-		FString AWSProfileName = Library->GetAWSConfigSetting(DeadlineSettingsKeys::AwsProfileName);
+		FString AWSProfileName = Library->GetAWSStringConfigSetting(DeadlineSettingsKeys::AwsProfileName);
         if (AWSProfileName.IsEmpty() || AWSProfileName == TEXT("default") || AWSProfileName == TEXT("(default)"))
         {
             AWSProfileName = TEXT("(default)");
@@ -191,12 +191,12 @@ void UDeadlineCloudDeveloperSettings::RefreshFromDefaultProfileInternal()
 
 		WorkStationConfiguration.GlobalSettings.AWS_Profile = AWSProfileName;
 
-		FString JobHistoryDir = Library->GetAWSConfigSetting(DeadlineSettingsKeys::JobHistoryDir);
+		FString JobHistoryDir = Library->GetAWSStringConfigSetting(DeadlineSettingsKeys::JobHistoryDir);
         JobHistoryDir.ReplaceInline(TEXT("\\"), TEXT("/"));
 
 		WorkStationConfiguration.Profile.JobHistoryDir.Path = JobHistoryDir;
 
-        FString FarmId = Library->GetAWSConfigSetting(DeadlineSettingsKeys::FarmId);
+        FString FarmId = Library->GetAWSStringConfigSetting(DeadlineSettingsKeys::FarmId);
 
 		FUnrealAwsEntity Farm = FindFarmById(FarmId, true);
 		if (Farm.IsValid())
@@ -204,30 +204,30 @@ void UDeadlineCloudDeveloperSettings::RefreshFromDefaultProfileInternal()
 			WorkStationConfiguration.Profile.DefaultFarm = Farm.Name;
 		}
 
-		FString QueueId = Library->GetAWSConfigSetting(DeadlineSettingsKeys::QueueId);
+		FString QueueId = Library->GetAWSStringConfigSetting(DeadlineSettingsKeys::QueueId);
 		FUnrealAwsEntity Queue = FindQueueById(QueueId, true);
 		if (Queue.IsValid())
 		{
 			WorkStationConfiguration.Farm.DefaultQueue = Queue.Name;
 		}
 
-		FString StorageProfileId = Library->GetAWSConfigSetting(DeadlineSettingsKeys::StorageProfileId);
+		FString StorageProfileId = Library->GetAWSStringConfigSetting(DeadlineSettingsKeys::StorageProfileId);
 		FUnrealAwsEntity StorageProfile = FindStorageProfileById(StorageProfileId, true);
 		if (StorageProfile.IsValid())
 		{
 			WorkStationConfiguration.Farm.DefaultStorageProfile = StorageProfile.Name;
 		}
 
-		FString JobAttachmentFilesystemOptions = Library->GetAWSConfigSetting(DeadlineSettingsKeys::JobAttachmentsFileSystem);
+		FString JobAttachmentFilesystemOptions = Library->GetAWSStringConfigSetting(DeadlineSettingsKeys::JobAttachmentsFileSystem);
 		WorkStationConfiguration.Farm.JobAttachmentFilesystemOptions = JobAttachmentFilesystemOptions;
 
-		FString AutoAcceptConfirmationPrompts = Library->GetAWSConfigSetting(DeadlineSettingsKeys::AutoAccept);
+		FString AutoAcceptConfirmationPrompts = Library->GetAWSStringConfigSetting(DeadlineSettingsKeys::AutoAccept);
 		WorkStationConfiguration.General.AutoAcceptConfirmationPrompts = AutoAcceptConfirmationPrompts == TEXT("true");
 
-		FString ConflictResolutionOption = Library->GetAWSConfigSetting(DeadlineSettingsKeys::ConflictResolution);
+		FString ConflictResolutionOption = Library->GetAWSStringConfigSetting(DeadlineSettingsKeys::ConflictResolution);
 		WorkStationConfiguration.General.ConflictResolutionOption = ConflictResolutionOption;
 
-		FString CurrentLoggingLevel = Library->GetAWSConfigSetting(DeadlineSettingsKeys::LogLevel);
+		FString CurrentLoggingLevel = Library->GetAWSStringConfigSetting(DeadlineSettingsKeys::LogLevel);
 		WorkStationConfiguration.General.CurrentLoggingLevel = CurrentLoggingLevel;
     }
 }

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.cpp
@@ -118,7 +118,7 @@ void UDeadlineCloudDeveloperSettings::PostEditChangeProperty(FPropertyChangedEve
 
 	if (PropertyChangedEvent.Property)
 	{
-		if (PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(UDeadlineCloudDeveloperSettings, WorkStationConfiguration.GlobalSettings.AWS_Profile))
+		if (PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(FDeadlineCloudGlobalPluginSettings, AWS_Profile))
 		{
 			if (auto Library = UDeadlineCloudSettingsLibrary::Get())
 			{
@@ -127,9 +127,9 @@ void UDeadlineCloudDeveloperSettings::PostEditChangeProperty(FPropertyChangedEve
 
 			RefreshFromDefaultProfile();
 		}
-		else if (PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(UDeadlineCloudDeveloperSettings, WorkStationConfiguration.Profile.DefaultFarm))
+		else if (PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(FDeadlineCloudProfilePluginSettings, DefaultFarm))
 		{
-			FUnrealAwsEntity Farm = FindFarmById(WorkStationConfiguration.Profile.DefaultFarm, true);
+			FUnrealAwsEntity Farm = FindFarmByName(WorkStationConfiguration.Profile.DefaultFarm, true);
 			if (auto Library = UDeadlineCloudSettingsLibrary::Get())
 			{
 				Library->SetAWSStringConfigSetting(DeadlineSettingsKeys::FarmId, Farm.Id);
@@ -279,6 +279,16 @@ FUnrealAwsEntity UDeadlineCloudDeveloperSettings::FindFarmById(const FString& Fa
 	return FindAwsEntityById(FarmId, WorkStationConfigurationCache.FarmsCacheList);
 }
 
+FUnrealAwsEntity UDeadlineCloudDeveloperSettings::FindFarmByName(const FString& FarmName, bool bUpdateFarmsList)
+{
+	if (bUpdateFarmsList)
+	{
+		UpdateFarmsCacheList();
+	}
+
+	return FindAwsEntityByName(FarmName, WorkStationConfigurationCache.FarmsCacheList);
+}
+
 void UDeadlineCloudDeveloperSettings::UpdateStorageProfilesCacheList()
 {
 	WorkStationConfigurationCache.StorageProfilesCacheList.Reset();
@@ -297,6 +307,16 @@ FUnrealAwsEntity UDeadlineCloudDeveloperSettings::FindStorageProfileById(const F
 
 	return FindAwsEntityById(StorageProfileId, WorkStationConfigurationCache.StorageProfilesCacheList);
 
+}
+
+FUnrealAwsEntity UDeadlineCloudDeveloperSettings::FindStorageProfileByName(const FString& StorageProfileName, bool bUpdateStorageProfilesList)
+{
+	if (bUpdateStorageProfilesList)
+	{
+		UpdateStorageProfilesCacheList();
+	}
+
+	return FindAwsEntityByName(StorageProfileName, WorkStationConfigurationCache.StorageProfilesCacheList);
 }
 
 void UDeadlineCloudDeveloperSettings::UpdateQueuesCacheList()
@@ -318,11 +338,34 @@ FUnrealAwsEntity UDeadlineCloudDeveloperSettings::FindQueueById(const FString& Q
 	return FindAwsEntityById(QueueId, WorkStationConfigurationCache.QueuesCacheList);
 }
 
+FUnrealAwsEntity UDeadlineCloudDeveloperSettings::FindQueueByName(const FString& QueueName, bool bUpdateQueuesList)
+{
+	if (bUpdateQueuesList)
+	{
+		UpdateQueuesCacheList();
+	}
+
+	return FindAwsEntityByName(QueueName, WorkStationConfigurationCache.QueuesCacheList);
+}
+
 FUnrealAwsEntity UDeadlineCloudDeveloperSettings::FindAwsEntityById(const FString& Id, const TArray<FUnrealAwsEntity>& EntityList)
 {
 	for (const auto& Entity : EntityList)
 	{
 		if (Entity.Id == Id)
+		{
+			return Entity;
+		}
+	}
+
+	return FUnrealAwsEntity();
+}
+
+FUnrealAwsEntity UDeadlineCloudDeveloperSettings::FindAwsEntityByName(const FString& Name, const TArray<FUnrealAwsEntity>& EntityList)
+{
+	for (const auto& Entity : EntityList)
+	{
+		if (Entity.Name == Name)
 		{
 			return Entity;
 		}

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudSettingsDetails.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudSettingsDetails.cpp
@@ -2,6 +2,7 @@
 
 #include "DeadlineCloudJobSettings/DeadlineCloudSettingsDetails.h"
 #include "DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h"
+#include "PythonAPILibraries/DeadlineCloudSettingsLibrary.h"
 #include "DetailLayoutBuilder.h"
 #include "DetailWidgetRow.h"
 #include "Widgets/Input/SButton.h"
@@ -26,10 +27,11 @@ void FDeadlineCloudSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& Detai
     TArray<TWeakObjectPtr<UObject>> ObjectsBeingCustomized;
     DetailBuilder.GetObjectsBeingCustomized(ObjectsBeingCustomized);
     Settings = Cast<UDeadlineCloudDeveloperSettings>(ObjectsBeingCustomized[0].Get());
+	//Settings->Refresh();
     DeadlineCloudStatusHandler = MakeUnique<FDeadlineCloudStatusHandler>(Settings.Get());
     DeadlineCloudStatusHandler->StartDirectoryWatch();
 
-    IDetailCategoryBuilder& LoginCategory = DetailBuilder.EditCategory("Login DeadlineCloud");
+    IDetailCategoryBuilder& LoginCategory = DetailBuilder.EditCategory("Login DeadlineCloud", FText::GetEmpty(), ECategoryPriority::Important);
     LoginCategory.AddCustomRow(LOCTEXT("DeadlineCloudLogin", "DeadlineCloudLogin"))
         .ValueContent()
     	[
@@ -43,7 +45,7 @@ void FDeadlineCloudSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& Detai
 				.ToolTipText(LOCTEXT("DeadlineCloudLogin_Tooltip", "Login"))
 				.OnClicked_Lambda([this]()
 				{
-					if (const auto LoginLib = UDeadlineCloudDeveloperSettings::Get())
+					if (auto LoginLib = UDeadlineCloudDeveloperSettings::GetMutable())
 					{
 						LoginLib->Login();
 					}
@@ -59,7 +61,7 @@ void FDeadlineCloudSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& Detai
 				.ToolTipText(LOCTEXT("DeadlineCloudLogout_Tooltip", "Logout"))
 				.OnClicked_Lambda([this]()
 				{
-					if (const auto LoginLib = UDeadlineCloudDeveloperSettings::Get())
+					if (auto LoginLib = UDeadlineCloudDeveloperSettings::GetMutable())
 					{
 						LoginLib->Logout();
 					}
@@ -70,7 +72,8 @@ void FDeadlineCloudSettingsDetails::CustomizeDetails(IDetailLayoutBuilder& Detai
 	
 	DetailBuilder.HideCategory(TEXT("cache"));
 
-	IDetailCategoryBuilder& StatusCategory = DetailBuilder.EditCategory("DeadlineCloud Status");
+	IDetailCategoryBuilder& StatusCategory = DetailBuilder.EditCategory("DeadlineCloud Status", FText::GetEmpty(), ECategoryPriority::TypeSpecific);
+
 	StatusCategory.AddCustomRow(LOCTEXT("DeadlineCloudStatus", "DeadlineCloudStatus"))
 		.ValueContent()
 		[

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/PythonAPILibraries/DeadlineCloudSettingsLibrary.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/PythonAPILibraries/DeadlineCloudSettingsLibrary.cpp
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#include "PythonAPILibraries/DeadlineCloudSettingsLibrary.h"
+#include "DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h"
+
+void UDeadlineCloudSettingsLibrary::InitFromPython()
+{
+	if (!bInitialized)
+	{
+		bInitialized = true;
+		UDeadlineCloudDeveloperSettings* Settings = UDeadlineCloudDeveloperSettings::GetMutable();
+		if (Settings)
+		{
+			Settings->Refresh();
+		}
+	}
+}

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
@@ -145,6 +145,66 @@ private:
 class FSettingsHelper
 {
 public:
+    static FProperty* ResolvePropertyByPath(UObject* RootObject, const FString& PropertyPath)
+    {
+	    if (!RootObject)
+	    {
+		    UE_LOG(LogCreateJobTest, Error, TEXT("RootObject is null"));
+		    return nullptr;
+	    }
+
+	    TArray<FString> PathSegments;
+	    PropertyPath.ParseIntoArray(PathSegments, TEXT("."));
+	    if (PathSegments.Num() == 0)
+	    {
+		    UE_LOG(LogCreateJobTest, Error, TEXT("Property path is empty"));
+		    return nullptr;
+	    }
+
+	    UStruct* CurrentStruct = RootObject->GetClass();
+	    void* CurrentContainer = RootObject;
+
+	    for (int32 i = 0; i < PathSegments.Num(); ++i)
+	    {
+		    const FName SegmentName(*PathSegments[i]);
+		    FProperty* FoundProperty = CurrentStruct->FindPropertyByName(SegmentName);
+		    if (!FoundProperty)
+		    {
+			    UE_LOG(LogCreateJobTest, Error, TEXT("Property '%s' not found in '%s'"), *SegmentName.ToString(), *CurrentStruct->GetName());
+			    return nullptr;
+		    }
+
+		    if (i == PathSegments.Num() - 1)
+		    {
+			    return FoundProperty;
+		    }
+
+		    if (FStructProperty* StructProp = CastField<FStructProperty>(FoundProperty))
+		    {
+			    CurrentContainer = StructProp->ContainerPtrToValuePtr<void>(CurrentContainer);
+			    CurrentStruct = StructProp->Struct;
+		    }
+		    else if (FObjectProperty* ObjectProp = CastField<FObjectProperty>(FoundProperty))
+		    {
+			    UObject* InnerObject = ObjectProp->GetObjectPropertyValue_InContainer(CurrentContainer);
+			    if (!InnerObject)
+			    {
+				    UE_LOG(LogCreateJobTest, Error, TEXT("Nested object '%s' is null"), *SegmentName.ToString());
+				    return nullptr;
+			    }
+			    CurrentContainer = InnerObject;
+			    CurrentStruct = InnerObject->GetClass();
+		    }
+		    else
+		    {
+			    UE_LOG(LogCreateJobTest, Error, TEXT("Unsupported property '%s' (not struct or object)"), *SegmentName.ToString());
+			    return nullptr;
+		    }
+	    }
+
+	    return nullptr;
+    }
+
     static void ApplyTestSettings()
     {
         UE_LOG(LogCreateJobTest, Display, TEXT("Applying test settings"));
@@ -155,7 +215,7 @@ public:
             UE_LOG(LogCreateJobTest, Error, TEXT("Failed to get Python implementation of settings"));
             return;
         }
-
+        
         // Cache original values
         OriginalFarmId = Settings->WorkStationConfiguration.Profile.DefaultFarm;
         OriginalQueueId = Settings->WorkStationConfiguration.Farm.DefaultQueue;
@@ -313,7 +373,9 @@ public:
                     *Settings->WorkStationConfiguration.Profile.DefaultFarm, *OriginalFarmId);
                 Settings->WorkStationConfiguration.Profile.DefaultFarm = OriginalFarmId;
                 Settings->SaveConfig();
-                FPropertyChangedEvent PropertyEvent(Settings->GetClass()->FindPropertyByName(TEXT("WorkStationConfiguration.Profile.DefaultFarm")));
+
+                FProperty* Property = ResolvePropertyByPath(Settings, TEXT("WorkStationConfiguration.Profile.DefaultFarm"));
+                FPropertyChangedEvent PropertyEvent(Property);
 				Settings->PostEditChangeProperty(PropertyEvent);
             }
             else
@@ -328,7 +390,9 @@ public:
                     *Settings->WorkStationConfiguration.Farm.DefaultQueue, *OriginalQueueId);
                 Settings->WorkStationConfiguration.Farm.DefaultQueue = OriginalQueueId;
                 Settings->SaveConfig();
-				FPropertyChangedEvent PropertyEvent(Settings->GetClass()->FindPropertyByName(TEXT("WorkStationConfiguration.Farm.DefaultQueue")));
+
+				FProperty* Property = ResolvePropertyByPath(Settings, TEXT("WorkStationConfiguration.Farm.DefaultQueue"));
+                FPropertyChangedEvent PropertyEvent(Property);
 				Settings->PostEditChangeProperty(PropertyEvent);
             }
             else

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
@@ -345,14 +345,16 @@ public:
             if (farmChanged)
             {
                 UE_LOG(LogCreateJobTest, Display, TEXT("Triggering OnSettingsModified for DefaultFarm"));
-				FPropertyChangedEvent PropertyEvent(Settings->GetClass()->FindPropertyByName(TEXT("WorkStationConfiguration.Profile.DefaultFarm")));
+				FProperty* Property = ResolvePropertyByPath(Settings, TEXT("WorkStationConfiguration.Profile.DefaultFarm"));
+                FPropertyChangedEvent PropertyEvent(Property);
                 Settings->PostEditChangeProperty(PropertyEvent);
             }
 
             if (queueChanged)
             {
                 UE_LOG(LogCreateJobTest, Display, TEXT("Triggering OnSettingsModified for DefaultQueue"));
-				FPropertyChangedEvent PropertyEvent(Settings->GetClass()->FindPropertyByName(TEXT("WorkStationConfiguration.Farm.DefaultQueue")));
+				FProperty* Property = ResolvePropertyByPath(Settings, TEXT("WorkStationConfiguration.Farm.DefaultQueue"));
+                FPropertyChangedEvent PropertyEvent(Property);
                 Settings->PostEditChangeProperty(PropertyEvent);
             }
         }

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
@@ -149,7 +149,7 @@ public:
     {
         UE_LOG(LogCreateJobTest, Display, TEXT("Applying test settings"));
         // Get settings
-        UDeadlineCloudDeveloperSettings* Settings = UDeadlineCloudDeveloperSettings::Get();
+        UDeadlineCloudDeveloperSettings* Settings = UDeadlineCloudDeveloperSettings::GetMutable();
         if (!Settings)
         {
             UE_LOG(LogCreateJobTest, Error, TEXT("Failed to get Python implementation of settings"));
@@ -205,7 +205,7 @@ public:
                         UE_LOG(LogCreateJobTest, Display, TEXT("Converting farm ID '%s' to name"), *Value);
 
                         // Look up the farm name from the ID using the Settings object
-                        FString FoundName = Settings->GetFarmNameById(Value);
+                        FString FoundName = Settings->FindFarmById(Value, true).Name;
                         if (!FoundName.IsEmpty())
                         {
                             FarmName = FoundName;
@@ -246,7 +246,7 @@ public:
                         UE_LOG(LogCreateJobTest, Display, TEXT("Converting queue ID '%s' to name"), *Value);
 
                         // Look up the queue name from the ID using the Settings object
-                        FString FoundName = Settings->GetQueueNameById(Value);
+                        FString FoundName = Settings->FindQueueById(Value, true).Name;
                         if (!FoundName.IsEmpty())
                         {
                             QueueName = FoundName;
@@ -285,13 +285,15 @@ public:
             if (farmChanged)
             {
                 UE_LOG(LogCreateJobTest, Display, TEXT("Triggering OnSettingsModified for DefaultFarm"));
-                Settings->OnSettingsModified("DefaultFarm");
+				FPropertyChangedEvent PropertyEvent(Settings->GetClass()->FindPropertyByName(TEXT("WorkStationConfiguration.Profile.DefaultFarm")));
+                Settings->PostEditChangeProperty(PropertyEvent);
             }
 
             if (queueChanged)
             {
                 UE_LOG(LogCreateJobTest, Display, TEXT("Triggering OnSettingsModified for DefaultQueue"));
-                Settings->OnSettingsModified("DefaultQueue");
+				FPropertyChangedEvent PropertyEvent(Settings->GetClass()->FindPropertyByName(TEXT("WorkStationConfiguration.Farm.DefaultQueue")));
+                Settings->PostEditChangeProperty(PropertyEvent);
             }
         }
     }
@@ -299,7 +301,7 @@ public:
     static void RestoreOriginalSettings()
     {
         // Restore original settings
-        UDeadlineCloudDeveloperSettings* Settings = UDeadlineCloudDeveloperSettings::Get();
+        UDeadlineCloudDeveloperSettings* Settings = UDeadlineCloudDeveloperSettings::GetMutable();
         if (Settings)
         {
             UE_LOG(LogCreateJobTest, Display, TEXT("Restoring settings, original farm %s queue %s"), *OriginalFarmId, *OriginalQueueId);
@@ -311,7 +313,8 @@ public:
                     *Settings->WorkStationConfiguration.Profile.DefaultFarm, *OriginalFarmId);
                 Settings->WorkStationConfiguration.Profile.DefaultFarm = OriginalFarmId;
                 Settings->SaveConfig();
-                Settings->OnSettingsModified("DefaultFarm");
+                FPropertyChangedEvent PropertyEvent(Settings->GetClass()->FindPropertyByName(TEXT("WorkStationConfiguration.Profile.DefaultFarm")));
+				Settings->PostEditChangeProperty(PropertyEvent);
             }
             else
             {
@@ -325,7 +328,8 @@ public:
                     *Settings->WorkStationConfiguration.Farm.DefaultQueue, *OriginalQueueId);
                 Settings->WorkStationConfiguration.Farm.DefaultQueue = OriginalQueueId;
                 Settings->SaveConfig();
-                Settings->OnSettingsModified("DefaultQueue");
+				FPropertyChangedEvent PropertyEvent(Settings->GetClass()->FindPropertyByName(TEXT("WorkStationConfiguration.Farm.DefaultQueue")));
+				Settings->PostEditChangeProperty(PropertyEvent);
             }
             else
             {

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h
@@ -162,26 +162,6 @@ public:
 	/** Saves settings to a file. */
 	void SaveToFile();
 
-protected:
-	FDeadlineCloudPluginSettingsCache WorkStationConfigurationCache;
-
-	/** Updates the queues cache list. */
-	void UpdateQueuesCacheList();
-
-	/** Updates the storage profiles cache list. */
-	void UpdateStorageProfilesCacheList();
-
-	/** Updates the farms cache list. */
-	void UpdateFarmsCacheList();
-
-	/** 
-	* Finds an AWS entity by its ID.
-	* @param Id The ID of the entity to find.
-	* @param EntityList The list of entities to search.
-	* @return The found AWS entity.
-	*/
-	static FUnrealAwsEntity FindAwsEntityById(const FString& Id, const TArray<FUnrealAwsEntity>& EntityList);
-
 	/** 
 	* Finds a farm by its ID.
 	* @param FarmId The ID of the farm to find.
@@ -205,4 +185,26 @@ protected:
 	* @return The found queue entity.
 	*/
 	FUnrealAwsEntity FindQueueById(const FString& QueueId, bool bUpdateQueuesList = false);
+
+protected:
+	FDeadlineCloudPluginSettingsCache WorkStationConfigurationCache;
+
+	/** Updates the queues cache list. */
+	void UpdateQueuesCacheList();
+
+	/** Updates the storage profiles cache list. */
+	void UpdateStorageProfilesCacheList();
+
+	/** Updates the farms cache list. */
+	void UpdateFarmsCacheList();
+
+	/** 
+	* Finds an AWS entity by its ID.
+	* @param Id The ID of the entity to find.
+	* @param EntityList The list of entities to search.
+	* @return The found AWS entity.
+	*/
+	static FUnrealAwsEntity FindAwsEntityById(const FString& Id, const TArray<FUnrealAwsEntity>& EntityList);
+
+
 };

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h
@@ -169,6 +169,7 @@ public:
 	* @return The found farm entity.
 	*/
 	FUnrealAwsEntity FindFarmById(const FString& FarmId, bool bUpdateFarmsList = false);
+	FUnrealAwsEntity FindFarmByName(const FString& FarmName, bool bUpdateFarmsList = false);
 
 	/** 
 	* Finds a storage profile by its ID.
@@ -177,6 +178,7 @@ public:
 	* @return The found storage profile entity.
 	*/
 	FUnrealAwsEntity FindStorageProfileById(const FString& StorageProfileId, bool bUpdateStorageProfilesList = false);
+	FUnrealAwsEntity FindStorageProfileByName(const FString& StorageProfileName, bool bUpdateStorageProfilesList = false);
 
 	/** 
 	* Finds a queue by its ID.
@@ -185,7 +187,7 @@ public:
 	* @return The found queue entity.
 	*/
 	FUnrealAwsEntity FindQueueById(const FString& QueueId, bool bUpdateQueuesList = false);
-
+	FUnrealAwsEntity FindQueueByName(const FString& QueueName, bool bUpdateQueuesList = false);
 protected:
 	FDeadlineCloudPluginSettingsCache WorkStationConfigurationCache;
 
@@ -206,5 +208,5 @@ protected:
 	*/
 	static FUnrealAwsEntity FindAwsEntityById(const FString& Id, const TArray<FUnrealAwsEntity>& EntityList);
 
-
+	static FUnrealAwsEntity FindAwsEntityByName(const FString& Name, const TArray<FUnrealAwsEntity>& EntityList);
 };

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h
@@ -3,216 +3,206 @@
 #pragma once
 #include "CoreMinimal.h"
 #include "Engine/DeveloperSettings.h"
-#include "PythonAPILibraries/PythonAPILibrary.h"
+#include "PythonAPILibraries/DeadlineCloudSettingsLibrary.h"
 #include "DeadlineCloudDeveloperSettings.generated.h"
 
 /**
- * Container for Deadline Cloud global settings 
+ * Deadline Cloud Workstation Configuration settings located in Project -> Settings.
  */
-USTRUCT(BlueprintType)
-struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudGlobalPluginSettings
-{
-	GENERATED_BODY()
-
-	/**
-	 * Selected AWS profile. List of the available profiles is returned by "get_aws_profiles"
-	 * method of DeadlineCloudDeveloperSettingsImplementation
-	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="get_aws_profiles", DisplayPriority=0, Category="Global Settings"))
-	FString AWS_Profile;
-};
-
-/**
- * Container for Deadline cloud profile settings 
- */
-USTRUCT(BlueprintType)
-struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudProfilePluginSettings
-{
-	GENERATED_BODY()
-
-	/**
-	 * Path to directory where all generated Deadline Cloud job bundles will be places
-	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=1, Category="Profile Settings"))
-	FDirectoryPath JobHistoryDir;
-
-	/**
-	 * Selected Deadline cloud farm. List of the available farms is returned by "get_farms"
-	 * method of DeadlineCloudDeveloperSettingsImplementation
-	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="get_farms", DisplayPriority=2, Category="Profile Settings"))
-	FString DefaultFarm;
-};
-
-/**
- * Container for Deadline cloud farm settings
- */
-USTRUCT(BlueprintType)
-struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudFarmPluginSettings
-{
-	GENERATED_BODY()
-
-	/**
-	 * Selected Deadline cloud queue. List of the available queues is returned by "get_queues"
-	 * method of DeadlineCloudDeveloperSettingsImplementation
-	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="get_queues", DisplayPriority=3, Category="Farm Settings"))
-	FString DefaultQueue;
-
-	/**
-	 * Selected Deadline cloud storage profiles. List of the available storage profiles is returned by "get_storage_profiles"
-	 * method of DeadlineCloudDeveloperSettingsImplementation
-	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="get_storage_profiles", DisplayPriority=4, Category="Farm Settings"))
-	FString DefaultStorageProfile; 
-
-	/**
-	 * Selected Deadline cloud job attachment mode. List of the available job attachment modes is returned by "get_job_attachment_modes"
-	 * method of DeadlineCloudDeveloperSettingsImplementation
-	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="get_job_attachment_modes", DisplayPriority=5, Category="Farm Settings"))
-	FString JobAttachmentFilesystemOptions;
-};
-
-/**
- * Container for Deadline cloud general settings
- */
-USTRUCT(BlueprintType)
-struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudGeneralPluginSettings
-{
-	GENERATED_BODY()
-
-	/**
-	 * Deadline Cloud auto accept confirmation prompts setting
-	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=6, Category="General Settings"))
-	bool AutoAcceptConfirmationPrompts = false;
-
-	/**
-	 * Selected files conflict resolution strategy. List of the available strategies is returned by "get_conflict_resolution_options"
-	 * method of DeadlineCloudDeveloperSettingsImplementation
-	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="get_conflict_resolution_options", DisplayPriority=7, Category="General Settings"))
-	FString ConflictResolutionOption;
-
-	/**
-	 * Selected Deadline cloud logging level. List of the available strategies is returned by "get_conflict_resolution_options"
-	 * method of DeadlineCloudDeveloperSettingsImplementation
-	 */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="get_logging_levels", DisplayPriority=8, Category="General Settings"))
-	FString CurrentLoggingLevel;
-
-};
-
-/**
- * Deadline cloud status indicators (read-only)
- */
-USTRUCT(BlueprintType)
-struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudStatus
-{
-	GENERATED_BODY()
-
-	/** AwsCredentialsSource: NOT_VALID, HOST_PROVIDED, DEADLINE_CLOUD_MONITOR_LOGIN */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="cache")
-	FString CredsType;
-
-	/** AwsAuthenticationStatus: CONFIGURATION_ERROR, AUTHENTICATED, NEEDS_LOGIN */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="cache")
-	FString CredsStatus;
-
-	/** AWS API availability status: AUTHORIZED, NOT AUTHORIZED */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="cache")
-	FString ApiAvailability;
-};
-
-/**
- * Container for Deadline Cloud Workstation Configuration settings
- */
-USTRUCT(BlueprintType)
-struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudPluginSettings
-{
-	GENERATED_BODY()
-
-	/** Global settings */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="Global Settings", DisplayPriority=0))
-	FDeadlineCloudGlobalPluginSettings GlobalSettings;
-
-	/** Profile settings */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="Profile Settings", DisplayPriority=1))
-	FDeadlineCloudProfilePluginSettings Profile;
-
-	/** Farm settings */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="Farm Settings", DisplayPriority=2))
-	FDeadlineCloudFarmPluginSettings Farm;
-
-	/** General settings */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="General Settings", DisplayPriority=3))
-	FDeadlineCloudGeneralPluginSettings General;
-
-	/** Status (read-only) */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="cache", DisplayPriority=3))
-	FDeadlineCloudStatus State;
-};
-
-/**
- * Deadline Cloud Workstation Configuration settings located in Project -> Settings. The class is abstract and implemented in Python.
- * Python implementation DeadlineCloudDeveloperSettingsImplementation can be found in Plugin's Content/Python/settings.py
- */
-UCLASS(BlueprintType, Abstract, HideCategories="cache")
-class UNREALDEADLINECLOUDSERVICE_API UDeadlineCloudDeveloperSettings : public UDeveloperSettings, public TPythonAPILibraryBase<UDeadlineCloudDeveloperSettings>
+UCLASS(BlueprintType, HideCategories="cache")
+class UNREALDEADLINECLOUDSERVICE_API UDeadlineCloudDeveloperSettings : public UDeveloperSettings
 {
 	GENERATED_BODY()
 
 public:
-	/** Deadline Cloud Workstation Configuration settings container */
+
+	/** 
+	* Constructor for UDeadlineCloudDeveloperSettings.
+	*/
+	UDeadlineCloudDeveloperSettings();
+
+	/** 
+	* Gets the default instance of UDeadlineCloudDeveloperSettings.
+	* @return The default settings instance.
+	*/
+	static const UDeadlineCloudDeveloperSettings* Get() { return GetDefault<UDeadlineCloudDeveloperSettings>(); }
+
+	/** 
+	* Gets a mutable instance of UDeadlineCloudDeveloperSettings.
+	* @return A mutable settings instance.
+	*/
+	static UDeadlineCloudDeveloperSettings* GetMutable() { return GetMutableDefault<UDeadlineCloudDeveloperSettings>(); }
+
+	/** 
+	* Deadline Cloud Workstation Configuration settings container.
+	*/
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="Deadline Cloud Workstation Configuration", DisplayPriority=2))
 	FDeadlineCloudPluginSettings WorkStationConfiguration;
 
-	/** @return Plugin settings main menu option */
+	/** 
+	* @return Plugin settings main menu option.
+	*/
 	virtual FName GetContainerName() const override { return FName("Project"); }
 	
-	/** @return Plugin settings category */
+	/** 
+	* @return Plugin settings category.
+	*/
 	virtual FName GetCategoryName() const override { return FName("Plugins"); }
 
+	/** 
+	* Retrieves the list of farms.
+	* @return An array of farm names.
+	*/
+	UFUNCTION(Category = DeadlineCloudSettings)
+	TArray<FString> GetFarmsList();
+
+	/** 
+	* Retrieves the list of AWS profiles.
+	* @return An array of AWS profile names.
+	*/
+	UFUNCTION(Category = DeadlineCloudSettings)
+	TArray<FString> GetAWSProfilesList();
+
+	/** 
+	* Retrieves the available logging levels.
+	* @return An array of logging level names.
+	*/
+	UFUNCTION(Category = DeadlineCloudSettings)
+	TArray<FString> GetLoggingLevels();
+
+	/** 
+	* Retrieves the conflict resolution options.
+	* @return An array of conflict resolution option names.
+	*/
+	UFUNCTION(Category = DeadlineCloudSettings)
+	TArray<FString> GetConflictResolutionOptions();
+
+	/** 
+	* Retrieves the list of storage profiles.
+	* @return An array of storage profile names.
+	*/
+	UFUNCTION(Category = DeadlineCloudSettings)
+	TArray<FString> GetStorageProfilesList();
+
+	/** 
+	* Retrieves the job attachment modes.
+	* @return An array of job attachment mode names.
+	*/
+	UFUNCTION(Category = DeadlineCloudSettings)
+	TArray<FString> GetJobAttachmentModes();
+
+	/** 
+	* Retrieves the list of queues.
+	* @return An array of queue names.
+	*/
+	UFUNCTION(Category = DeadlineCloudSettings)
+	TArray<FString> GetQueuesList();
+
 	/**
-	 * Override Settings Section name
-	 */
+	* Override Settings Section name.
+	*/
 #if WITH_EDITOR
+	/** 
+	* @return The section text for the settings.
+	*/
 	virtual FText GetSectionText() const override;
+
+	/** 
+	* @return The section name for the settings.
+	*/
 	virtual FName GetSectionName() const override;
+
+	/** 
+	* Handles property changes in the editor.
+	* @param PropertyChangedEvent The event that describes the property change.
+	*/
+	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
+
+	/** 
+	* Initializes properties after construction.
+	*/
+	virtual void PostInitProperties() override;
 #endif
 
-	/** Registers OnSettingsModified method as delegate for setting values changes in the UI */
-	UDeadlineCloudDeveloperSettings();
+	/** Refreshes the settings. */
+	UFUNCTION(Category = DeadlineCloudSettings)
+	void Refresh();
 
-	/**
-	 * Delegate method which is called on each property value change in UI.
-	 * Method is implemented in Python, see "on_settings_modified" in DeadlineCloudDeveloperSettingsImplementation
-	 * @param PropertyPath path to modified property in Unreal reflection system properties naming format.
-	 */
-	UFUNCTION(BlueprintImplementableEvent, Category = DeadlineCloud)
-	void OnSettingsModified(const FString& PropertyPath);
-
-	/**
-	 * Delegate method which is called on each external Deadline Cloud settings directory update.
-	 * Settings directory update is handled by FDeadlineCloudStatusHandler
-	 */
-	UFUNCTION(BlueprintImplementableEvent, Category = DeadlineCloud)
+	/** 
+	* Delegate method called on each external Deadline Cloud settings directory update.
+	* Settings directory update is handled by FDeadlineCloudStatusHandler.
+	*/
+	UFUNCTION(Category = DeadlineCloudSettings)
 	void RefreshState();
 
-	/** Deadline cloud login */
-	UFUNCTION(BlueprintImplementableEvent, Category = DeadlineCloud)
+	/** Internal method to refresh state. */
+	void RefreshStateInternal();
+
+	/** 
+	* Refreshes settings from the default profile.
+	*/
+	UFUNCTION(Category = DeadlineCloudSettings)
+	void RefreshFromDefaultProfile();
+
+	/** Internal method to refresh from the default profile. */
+	void RefreshFromDefaultProfileInternal();
+
+	/** 
+	* Logs in to the Deadline Cloud.
+	*/
+	UFUNCTION(Category = DeadlineCloudSettings)
 	void Login();
 
-	/** Deadline cloud logout */
-	UFUNCTION(BlueprintImplementableEvent, Category = DeadlineCloud)
+	/** 
+	* Logs out of the Deadline Cloud.
+	*/
+	UFUNCTION(Category = DeadlineCloudSettings)
 	void Logout();
 
-	/** Get farm name by its ID */
-	UFUNCTION(BlueprintImplementableEvent, Category = DeadlineCloud)
-	FString GetFarmNameById(const FString& FarmId);
+	/** Saves settings to a file. */
+	void SaveToFile();
 
-	/** Get queue name by its ID */
-	UFUNCTION(BlueprintImplementableEvent, Category = DeadlineCloud)
-	FString GetQueueNameById(const FString& QueueId);
+protected:
+	FDeadlineCloudPluginSettingsCache WorkStationConfigurationCache;
+
+	/** Updates the queues cache list. */
+	void UpdateQueuesCacheList();
+
+	/** Updates the storage profiles cache list. */
+	void UpdateStorageProfilesCacheList();
+
+	/** Updates the farms cache list. */
+	void UpdateFarmsCacheList();
+
+	/** 
+	* Finds an AWS entity by its ID.
+	* @param Id The ID of the entity to find.
+	* @param EntityList The list of entities to search.
+	* @return The found AWS entity.
+	*/
+	static FUnrealAwsEntity FindAwsEntityById(const FString& Id, const TArray<FUnrealAwsEntity>& EntityList);
+
+	/** 
+	* Finds a farm by its ID.
+	* @param FarmId The ID of the farm to find.
+	* @param bUpdateFarmsList Whether to update the farms list.
+	* @return The found farm entity.
+	*/
+	FUnrealAwsEntity FindFarmById(const FString& FarmId, bool bUpdateFarmsList = false);
+
+	/** 
+	* Finds a storage profile by its ID.
+	* @param StorageProfileId The ID of the storage profile to find.
+	* @param bUpdateStorageProfilesList Whether to update the storage profiles list.
+	* @return The found storage profile entity.
+	*/
+	FUnrealAwsEntity FindStorageProfileById(const FString& StorageProfileId, bool bUpdateStorageProfilesList = false);
+
+	/** 
+	* Finds a queue by its ID.
+	* @param QueueId The ID of the queue to find.
+	* @param bUpdateQueuesList Whether to update the queues list.
+	* @return The found queue entity.
+	*/
+	FUnrealAwsEntity FindQueueById(const FString& QueueId, bool bUpdateQueuesList = false);
 };

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudSettingsLibrary.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudSettingsLibrary.h
@@ -217,7 +217,7 @@ public:
     /**
 	* Called after python initialization to set up the library and update settings.
     */
-    UFUNCTION(BlueprintCallable)
+    UFUNCTION(BlueprintCallable, Category = "DeadlineCloudSettingsLibrary")
     void InitFromPython();
 
     /** 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudSettingsLibrary.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudSettingsLibrary.h
@@ -1,0 +1,314 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "PythonAPILibrary.h"
+#include "UObject/Object.h"
+#include "DeadlineCloudSettingsLibrary.generated.h"
+
+/**
+ * Structure representing an AWS entity with an ID and Name.
+ */
+USTRUCT(BlueprintType)
+struct UNREALDEADLINECLOUDSERVICE_API FUnrealAwsEntity
+{
+    GENERATED_BODY()
+
+    /** Unique identifier for the AWS entity. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AWS")
+    FString Id;
+
+    /** Name of the AWS entity. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AWS")
+    FString Name;
+
+    /** 
+     * Validates the AWS entity by checking if both Id and Name are not empty.
+     * @return True if valid, otherwise false.
+     */
+    bool IsValid()
+    {
+        return !Id.IsEmpty() && !Name.IsEmpty();
+    }
+};
+
+/**
+ * Container for Deadline Cloud global settings 
+ */
+USTRUCT(BlueprintType)
+struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudGlobalPluginSettings
+{
+	GENERATED_BODY()
+
+	/**
+	 * Selected AWS profile. List of the available profiles is returned by "get_aws_profiles"
+	 * method of DeadlineCloudDeveloperSettingsImplementation
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="GetAWSProfilesList", DisplayPriority=0, Category="Global Settings"))
+	FString AWS_Profile;
+};
+
+/**
+ * Container for Deadline cloud profile settings 
+ */
+USTRUCT(BlueprintType)
+struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudProfilePluginSettings
+{
+	GENERATED_BODY()
+
+	/**
+	 * Path to directory where all generated Deadline Cloud job bundles will be places
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=1, Category="Profile Settings"))
+	FDirectoryPath JobHistoryDir;
+
+	/**
+	 * Selected Deadline cloud farm. List of the available farms is returned by "get_farms"
+	 * method of DeadlineCloudDeveloperSettingsImplementation
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="GetFarmsList", DisplayPriority=2, Category="Profile Settings"))
+	FString DefaultFarm;
+};
+
+/**
+ * Container for Deadline cloud farm settings
+ */
+USTRUCT(BlueprintType)
+struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudFarmPluginSettings
+{
+	GENERATED_BODY()
+
+	/**
+	 * Selected Deadline cloud queue. List of the available queues is returned by "get_queues"
+	 * method of DeadlineCloudDeveloperSettingsImplementation
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="GetQueuesList", DisplayPriority=3, Category="Farm Settings"))
+	FString DefaultQueue;
+
+	/**
+	 * Selected Deadline cloud storage profiles. List of the available storage profiles is returned by "get_storage_profiles"
+	 * method of DeadlineCloudDeveloperSettingsImplementation
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="GetStorageProfilesList", DisplayPriority=4, Category="Farm Settings"))
+	FString DefaultStorageProfile; 
+
+	/**
+	 * Selected Deadline cloud job attachment mode. List of the available job attachment modes is returned by "get_job_attachment_modes"
+	 * method of DeadlineCloudDeveloperSettingsImplementation
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="GetJobAttachmentModes", DisplayPriority=5, Category="Farm Settings"))
+	FString JobAttachmentFilesystemOptions;
+};
+
+/**
+ * Container for Deadline cloud general settings
+ */
+USTRUCT(BlueprintType)
+struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudGeneralPluginSettings
+{
+	GENERATED_BODY()
+
+	/**
+	 * Deadline Cloud auto accept confirmation prompts setting
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayPriority=6, Category="General Settings"))
+	bool AutoAcceptConfirmationPrompts = false;
+
+	/**
+	 * Selected files conflict resolution strategy. List of the available strategies is returned by "get_conflict_resolution_options"
+	 * method of DeadlineCloudDeveloperSettingsImplementation
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="GetConflictResolutionOptions", DisplayPriority=7, Category="General Settings"))
+	FString ConflictResolutionOption;
+
+	/**
+	 * Selected Deadline cloud logging level. List of the available strategies is returned by "get_conflict_resolution_options"
+	 * method of DeadlineCloudDeveloperSettingsImplementation
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="GetLoggingLevels", DisplayPriority=8, Category="General Settings"))
+	FString CurrentLoggingLevel;
+
+};
+
+/**
+ * Deadline cloud status indicators (read-only)
+ */
+USTRUCT(BlueprintType)
+struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudStatus
+{
+	GENERATED_BODY()
+
+	/** AwsCredentialsSource: NOT_VALID, HOST_PROVIDED, DEADLINE_CLOUD_MONITOR_LOGIN */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="cache")
+	FString CredsType;
+
+	/** AwsAuthenticationStatus: CONFIGURATION_ERROR, AUTHENTICATED, NEEDS_LOGIN */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="cache")
+	FString CredsStatus;
+
+	/** AWS API availability status: AUTHORIZED, NOT AUTHORIZED */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="cache")
+	FString ApiAvailability;
+};
+
+/**
+ * Container for Deadline Cloud Workstation Configuration settings
+ */
+USTRUCT(BlueprintType)
+struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudPluginSettings
+{
+	GENERATED_BODY()
+
+	/** Global settings */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="Global Settings", DisplayPriority=0))
+	FDeadlineCloudGlobalPluginSettings GlobalSettings;
+
+	/** Profile settings */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="Profile Settings", DisplayPriority=1))
+	FDeadlineCloudProfilePluginSettings Profile;
+
+	/** Farm settings */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="Farm Settings", DisplayPriority=2))
+	FDeadlineCloudFarmPluginSettings Farm;
+
+	/** General settings */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="General Settings", DisplayPriority=3))
+	FDeadlineCloudGeneralPluginSettings General;
+
+	/** Status (read-only) */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="cache", DisplayPriority=3))
+	FDeadlineCloudStatus State;
+};
+
+/*
+* 
+*/
+USTRUCT(BlueprintType)
+struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudPluginSettingsCache
+{
+	GENERATED_BODY()
+
+    /** Cache list of farms. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="cache"))
+	TArray<FUnrealAwsEntity> FarmsCacheList;
+
+	/** Cache list of queues. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="cache"))
+	TArray<FUnrealAwsEntity> QueuesCacheList;
+
+	/** Cache list of storage profiles. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(Category="cache"))
+	TArray<FUnrealAwsEntity> StorageProfilesCacheList;
+};
+
+/**
+ * Library class for managing Deadline Cloud settings.
+ */
+UCLASS()
+class UNREALDEADLINECLOUDSERVICE_API UDeadlineCloudSettingsLibrary: public UObject, public TPythonAPILibraryBase<UDeadlineCloudSettingsLibrary>
+{
+    GENERATED_BODY()
+
+public:
+
+    bool bInitialized = false;
+
+    /**
+	* Called after python initialization to set up the library and update settings.
+    */
+    UFUNCTION(BlueprintCallable)
+    void InitFromPython();
+
+    /** 
+     * Retrieves a specific AWS configuration setting by name.
+     * @param SettingName The name of the setting to retrieve.
+     * @return The value of the specified setting.
+     */
+    UFUNCTION(BlueprintImplementableEvent)
+    FString GetAWSConfigSetting(const FString& SettingName);
+
+    /** 
+     * Sets a specific AWS configuration setting by name.
+     * @param SettingName The name of the setting to set.
+     * @param SettingValue The value to set for the specified setting.
+     */
+    UFUNCTION(BlueprintImplementableEvent)
+    void SetAWSConfigSetting(const FString& SettingName, const FString& SettingValue);
+
+    /** 
+     * Retrieves a list of available AWS profiles.
+     * @return An array of AWS profile names.
+     */
+    UFUNCTION(BlueprintImplementableEvent)
+    TArray<FString> GetAWSProfiles();
+
+    /** 
+     * Retrieves a list of available conflict resolution options.
+     * @return An array of conflict resolution option names.
+     */
+    UFUNCTION(BlueprintImplementableEvent)
+    TArray<FString> GetConflictResolutionOptions();
+
+    /** 
+     * Retrieves a list of available job attachment modes.
+     * @return An array of job attachment mode names.
+     */
+    UFUNCTION(BlueprintImplementableEvent)
+    TArray<FString> GetJobAttachmentModes();
+
+    /** 
+     * Retrieves a list of available logging levels.
+     * @return An array of logging level names.
+     */
+    UFUNCTION(BlueprintImplementableEvent)
+    TArray<FString> GetLoggingLevels();
+
+    /** 
+     * Retrieves a list of available farms.
+     * @return An array of UnrealAwsEntity representing the farms.
+     */
+    UFUNCTION(BlueprintImplementableEvent)
+    TArray<FUnrealAwsEntity> GetFarms();
+
+    /** 
+     * Retrieves a list of available queues.
+     * @return An array of UnrealAwsEntity representing the queues.
+     */
+    UFUNCTION(BlueprintImplementableEvent)
+    TArray<FUnrealAwsEntity> GetQueues();
+
+    /** 
+     * Retrieves a list of available storage profiles.
+     * @return An array of UnrealAwsEntity representing the storage profiles.
+     */
+    UFUNCTION(BlueprintImplementableEvent)
+    TArray<FUnrealAwsEntity> GetStorageProfiles();
+
+	/**
+	* Retrieves the current status of the API.
+	* @return The current API status as a FDeadlineCloudStatus structure.
+	*/
+    UFUNCTION(BlueprintImplementableEvent)
+	FDeadlineCloudStatus GetApiStatus();
+
+    /** 
+     * Initiates a login process for AWS.
+     */
+    UFUNCTION(BlueprintImplementableEvent)
+    bool Login();
+
+    /** 
+     * Initiates a logout process for AWS.
+     */
+    UFUNCTION(BlueprintImplementableEvent)
+    void Logout();
+
+    /** 
+     * Saves the provided settings to the AWS configuration.
+     * @param Settings The settings to save.
+     */
+    UFUNCTION(BlueprintImplementableEvent)
+    void SaveToAWSConfig(FDeadlineCloudPluginSettings Settings, FDeadlineCloudPluginSettingsCache Cache);
+};
+	

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudSettingsLibrary.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudSettingsLibrary.h
@@ -226,7 +226,7 @@ public:
      * @return The value of the specified setting.
      */
     UFUNCTION(BlueprintImplementableEvent)
-    FString GetAWSConfigSetting(const FString& SettingName);
+    FString GetAWSStringConfigSetting(const FString& SettingName);
 
     /** 
      * Sets a specific AWS configuration setting by name.
@@ -234,7 +234,7 @@ public:
      * @param SettingValue The value to set for the specified setting.
      */
     UFUNCTION(BlueprintImplementableEvent)
-    void SetAWSConfigSetting(const FString& SettingName, const FString& SettingValue);
+    void SetAWSStringConfigSetting(const FString& SettingName, const FString& SettingValue);
 
     /** 
      * Retrieves a list of available AWS profiles.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Developer Settings in Project Settings -> Deadline Cloud can be not loaded for some reasons. It happens because they are implemented on Python side and if UE fails to run init_unreal.py, settings missed. It can be caused by very specific cases. One of them that we noticed is:
1. Launch Unreal Editor
2. Go to Project Settings and open it
3. Close the Unreal Editor
4. On the next launch UE already know that you close the Editor with opened Project Settings window and open it as soon as possible (UI state saved). But init_unreal.py is not run yet. This possibly can cause the issues

### What was the solution? (How)

Move initialization of the Developer Settings to Slate to make it independent from Python initialization process.
Leave on Python side only the functional library to fetch farm info

### What is the impact of this change?

Developer Settings are always available to open and check the current state. If any errors occured, at least the UI is loaded.

### How was this change tested?

QA regress session

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

Yes

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*