### PR TITLE
feat: Support MPQ asset as render argument

### DIFF
--- a/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/run_data.schema.json
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/run_data.schema.json
@@ -7,6 +7,7 @@
         "level_sequence_path": { "type": "string" },
         "job_configuration_path": { "type": "string" },
         "queue_manifest_path": { "type": "string" },
+        "queue_path": { "type": "string" },
         "script_path": { "type": "string" },
         "script_args": { "type": "string" },
         "chunk_size": { "type": "integer" },

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_step_mpq.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_step_mpq.yml
@@ -1,0 +1,37 @@
+name: Render
+parameterSpace:
+  taskParameterDefinitions:
+  - name: ChunkId
+    type: INT
+    range: []
+  - name: Handler
+    type: STRING
+    range: []
+  - name: MoviePipelineQueuePath
+    type: PATH
+    range: []
+  - name: ChunkSize
+    type: INT
+    range: [1]
+script:
+  embeddedFiles:
+  - name: runData
+    filename: run-data.yaml
+    type: TEXT
+    data: |
+      handler: {{Task.Param.Handler}}
+      queue_path: {{Task.Param.MoviePipelineQueuePath}}
+      chunk_size: {{Task.Param.ChunkSize}}
+      chunk_id: {{Task.Param.ChunkId}}
+  actions:
+    onRun:
+      command: unreal-engine-openjd
+      args:
+      - daemon
+      - run
+      - --connection-file
+      - '{{Session.WorkingDirectory}}/connection.json'
+      - --run-data
+      - file://{{Task.File.runData}}
+      cancelation:
+        mode: NOTIFY_THEN_TERMINATE


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Support of Movie Pipeline Queue asset as main source of reder environment was added to Adaptor side, but missed in Submitter side. 

### What was the solution? (How)

- Add example of render step template with MPQ path usage
- Add `queue_path` to run_data schema in Adaptor

### What is the impact of this change?

Ability to submit jobs with MPQ asset path instead of Manifest

### How was this change tested?

Smoke tests

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

Yes

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*