### PR TITLE
feat: P4 Sync improvements

### DIFF
--- a/src/deadline/unreal_perforce_utils/perforce.py
+++ b/src/deadline/unreal_perforce_utils/perforce.py
@@ -86,7 +86,7 @@ class PerforceConnection:
         return client_root
 
     def get_latest_changelist_number(self) -> Optional[int]:
-        changes = self.p4.run("changes", "-c", self.p4.client, "-m", 1, "#have")
+        changes = self.p4.run("changes", "-m", 1, "#have")
         if changes:
             return int(changes[0]["change"])
         return None

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -873,11 +873,11 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             client=conn_settings["workspace"],
         )
 
-        _latest_changelist_number = str(p4.get_latest_changelist_number() or "latest")
+        latest_changelist_number = str(p4.get_latest_changelist_number() or "latest")
         parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
             job_parameter_values=parameter_values,
             job_parameter_name=OpenJobParameterNames.PERFORCE_CHANGELIST_NUMBER,
-            job_parameter_value=_latest_changelist_number,
+            job_parameter_value=latest_changelist_number,
         )
 
         parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
@@ -919,9 +919,12 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         # Render node. So we can't sync them and their dependencies until we don't know their paths
         job_dependencies_descriptor = common.create_deadline_cloud_temp_file(
             file_prefix=OpenJobParameterNames.UNREAL_MRQ_JOB_DEPENDENCIES_DESCRIPTOR,
-            file_data={"job_dependencies": self._get_mrq_job_dependency_depot_paths(_latest_changelist_number)},
+            file_data={
+                "job_dependencies": self._get_mrq_job_dependency_depot_paths(
+                    latest_changelist_number,
+                )
+            },
             file_ext=".json",
-
         )
         parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
             job_parameter_values=parameter_values,
@@ -1099,12 +1102,19 @@ class RenderUnrealOpenJob(UnrealOpenJob):
 
         return os_dependencies
 
-    def _get_mrq_job_dependency_depot_paths(self, latest_changelist_number: Optional[str] = None) -> list[str]:
+    def _get_mrq_job_dependency_depot_paths(
+        self, changelist_number: Optional[str] = None
+    ) -> list[str]:
         """
         Collects the dependencies if Level and LevelSequence of MRQ Job and returns paths
         converted from UE relative (i.e. /Game/...) to Perforce Depot (//MyProject/Mainline/...).
         Using depot file paths allow to sync in any locations other than User's ones.
 
+        If `changelist_number` is provided, append it to the end of each path with
+        "@" prefix, i.e. //MyProject/Mainline/Assets/MyAsset.uasset@12345
+
+        :param changelist_number: Perforce changelist number
+        :type changelist_number: Optional[str]
         :return: List of the dependency depot paths
         :rtype: list[str]
         """
@@ -1119,9 +1129,8 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         )
         depot_dependencies = p4_conn.get_depot_file_paths(local_dependencies)
 
-        if latest_changelist_number and latest_changelist_number != "latest":
-            changelist_postfix = f"@{latest_changelist_number}"
-            depot_dependencies = [f"{path}{changelist_postfix}" for path in depot_dependencies]
+        if changelist_number and changelist_number != "latest":
+            depot_dependencies = [f"{path}@{changelist_number}" for path in depot_dependencies]
 
         return depot_dependencies
 

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -1081,7 +1081,12 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             level_path, filter_method=DependencyFilters.dependency_in_game_folder
         )
 
-        return level_sequence_dependencies + level_dependencies + [level_sequence_path, level_path]
+        all_dependencies = (
+            level_sequence_dependencies + level_dependencies + [level_sequence_path, level_path]
+        )
+        unique_dependencies = list(set(all_dependencies))
+
+        return unique_dependencies
 
     def _get_mrq_job_dependency_paths(self):
         """

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -873,10 +873,11 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             client=conn_settings["workspace"],
         )
 
+        _latest_changelist_number = str(p4.get_latest_changelist_number() or "latest")
         parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
             job_parameter_values=parameter_values,
             job_parameter_name=OpenJobParameterNames.PERFORCE_CHANGELIST_NUMBER,
-            job_parameter_value=str(p4.get_latest_changelist_number() or "latest"),
+            job_parameter_value=_latest_changelist_number,
         )
 
         parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
@@ -918,8 +919,9 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         # Render node. So we can't sync them and their dependencies until we don't know their paths
         job_dependencies_descriptor = common.create_deadline_cloud_temp_file(
             file_prefix=OpenJobParameterNames.UNREAL_MRQ_JOB_DEPENDENCIES_DESCRIPTOR,
-            file_data={"job_dependencies": self._get_mrq_job_dependency_depot_paths()},
+            file_data={"job_dependencies": self._get_mrq_job_dependency_depot_paths(_latest_changelist_number)},
             file_ext=".json",
+
         )
         parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
             job_parameter_values=parameter_values,
@@ -1097,7 +1099,7 @@ class RenderUnrealOpenJob(UnrealOpenJob):
 
         return os_dependencies
 
-    def _get_mrq_job_dependency_depot_paths(self) -> list[str]:
+    def _get_mrq_job_dependency_depot_paths(self, latest_changelist_number: Optional[str] = None) -> list[str]:
         """
         Collects the dependencies if Level and LevelSequence of MRQ Job and returns paths
         converted from UE relative (i.e. /Game/...) to Perforce Depot (//MyProject/Mainline/...).
@@ -1116,6 +1118,10 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             client=conn_settings["workspace"],
         )
         depot_dependencies = p4_conn.get_depot_file_paths(local_dependencies)
+
+        if latest_changelist_number and latest_changelist_number != "latest":
+            changelist_postfix = f"@{latest_changelist_number}"
+            depot_dependencies = [f"{path}{changelist_postfix}" for path in depot_dependencies]
 
         return depot_dependencies
 

--- a/src/unreal_plugin/Content/Python/init_unreal.py
+++ b/src/unreal_plugin/Content/Python/init_unreal.py
@@ -2,9 +2,80 @@
 
 import os
 import json
+import sys
 import unreal
 from pathlib import Path
-import sys
+from typing import Optional
+
+
+def get_ue_path(in_path: str) -> Optional[str]:
+    """
+    Convert given path to unreal path by replacing substring that ends with /content/ to /Game/.
+    If it can't convert, return None
+
+    :param in_path: Path to convert
+    :type in_path: str
+    :return: Converted path or None
+    :rtype: str
+    """
+
+    keyword = "/content/"
+    idx = in_path.lower().find(keyword)
+    if idx == -1:
+        unreal.log_error(f"Depot path doesn't contain /Content/: {in_path}")
+        return None
+
+    ue_path = "/Game/" + in_path[idx + len(keyword) :]
+    return ue_path
+
+
+def sync_mrq_dependencies(dependencies_descriptor_path: str) -> None:
+    """
+    Read given dependencies descriptor, try to sync them with unreal source control and
+    scan modified assets
+
+    :param dependencies_descriptor_path: Path to the dependencies JSON descriptor file
+    :type dependencies_descriptor_path: str
+    """
+
+    if not os.path.exists(dependencies_descriptor_path):
+        unreal.log_error(
+            f"MrqJobDependenciesDescriptor file does not exist: {dependencies_descriptor_path}"
+        )
+        return
+
+    with open(dependencies_descriptor_path, "r", encoding="utf8") as f:
+        job_dependencies_descriptor = json.load(f)
+
+    job_dependencies = job_dependencies_descriptor.get("job_dependencies", [])
+    if not job_dependencies:
+        unreal.log_error(f"Job dependencies list is empty: {dependencies_descriptor_path}")
+        return
+
+    synced = unreal.SourceControl.sync_files(job_dependencies)
+    if not synced:
+        unreal.log_error(
+            f"Failed to sync job dependencies: {dependencies_descriptor_path}. "
+            f"Sync error message: {unreal.SourceControl.last_error_msg()}"
+        )
+        return
+
+    ue_paths = []
+    for job_dependency in job_dependencies:
+        # Trim changelist number if any
+        content_path = job_dependency.split("@")[0].replace("\\", "/")
+        ue_path = get_ue_path(content_path)
+        if ue_path:
+            ue_paths.append(ue_path)
+
+    if not ue_paths:
+        unreal.log_error("No UE paths converted from input paths. Nothing to scan.")
+        return
+
+    asset_registry = unreal.AssetRegistryHelpers().get_asset_registry()
+    asset_registry.scan_modified_asset_files(ue_paths)
+    asset_registry.scan_paths_synchronous(ue_paths, True, True)
+
 
 remote_execution = os.getenv("REMOTE_EXECUTION", "False")
 if remote_execution != "True":
@@ -51,6 +122,7 @@ if remote_execution != "True":
     logger.info("DEADLINE CLOUD INITIALIZED")
 
 else:
+
     tokens, switchers, cmd_parameters = unreal.SystemLibrary.parse_command_line(
         unreal.SystemLibrary.get_command_line()
     )
@@ -66,33 +138,4 @@ else:
     asset_registry.wait_for_completion()
 
     if "MrqJobDependenciesDescriptor" in cmd_parameters:
-        descriptor = cmd_parameters["MrqJobDependenciesDescriptor"]
-
-        if not os.path.exists(descriptor):
-            unreal.log_error(f"MrqJobDependenciesDescriptor file does not exist: {descriptor}")
-        else:
-            with open(descriptor, "r") as f:
-                job_dependencies_descriptor = json.load(f)
-
-            job_dependencies = job_dependencies_descriptor.get("job_dependencies", [])
-            if job_dependencies:
-                synced = unreal.SourceControl.sync_files(job_dependencies)
-                if synced:
-                    content_paths = []
-                    for job_dependence in job_dependencies:
-                        content_path = job_dependence.split("@")[0]
-                        content_path = content_path.replace("\\", "/")
-                        idx = content_path.lower().find("/content/")
-                        if idx == -1:
-                            unreal.log_error(f"Depot path doesn't contain /Content/: {content_path}")
-                        else:
-                            rel_path = content_path[idx + 1:]
-                            content_paths.append(rel_path)
-
-                    asset_registry = unreal.AssetRegistryHelpers().get_asset_registry()
-                    asset_registry.scan_modified_asset_files(
-                        content_paths
-                    )
-                    asset_registry.scan_paths_synchronous(
-                        content_paths, True, True
-                    )
+        sync_mrq_dependencies(cmd_parameters["MrqJobDependenciesDescriptor"])

--- a/src/unreal_plugin/Content/Python/init_unreal.py
+++ b/src/unreal_plugin/Content/Python/init_unreal.py
@@ -74,14 +74,25 @@ else:
             with open(descriptor, "r") as f:
                 job_dependencies_descriptor = json.load(f)
 
-            for job_dependency in job_dependencies_descriptor.get("job_dependencies", []):
-                if os.path.exists(job_dependency):
-                    continue
-                synced = unreal.SourceControl.sync_files([job_dependency])
+            job_dependencies = job_dependencies_descriptor.get("job_dependencies", [])
+            if job_dependencies:
+                synced = unreal.SourceControl.sync_files(job_dependencies)
                 if synced:
-                    unreal.AssetRegistryHelpers().get_asset_registry().scan_modified_asset_files(
-                        [job_dependency]
+                    content_paths = []
+                    for job_dependence in job_dependencies:
+                        content_path = job_dependence.split("@")[0]
+                        content_path = content_path.replace("\\", "/")
+                        idx = content_path.lower().find("/content/")
+                        if idx == -1:
+                            unreal.log_error(f"Depot path doesn't contain /Content/: {content_path}")
+                        else:
+                            rel_path = content_path[idx + 1:]
+                            content_paths.append(rel_path)
+
+                    asset_registry = unreal.AssetRegistryHelpers().get_asset_registry()
+                    asset_registry.scan_modified_asset_files(
+                        content_paths
                     )
-                    unreal.AssetRegistryHelpers().get_asset_registry().scan_paths_synchronous(
-                        [job_dependency], True, True
+                    asset_registry.scan_paths_synchronous(
+                        content_paths, True, True
                     )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1. Changelist number shouldn’t be latest we should take an actual list number on the user machine and pass it to the job
2. Make sure Unreal assets synchronization doesn’t lead to getting the latest assets version from Perforce
3. Make sure we synchronize all of the files at once, not one by one

### What was the solution? (How)

1. Remove `-c <client_name>` from `p4 changes -m 1 #have` command. This will prevent getting the changelists submitted only from the current client.
2. Add wanted changelist number to each file in JSON descriptor with `@` prefix
3. Sync dependencies from JSON descriptor with one command. Convert depot paths from descriptor to UE format, trim changelist number if any and do UE specific scan operations

### What is the impact of this change?

1. Faster sync on the initialize stage
2. MRQ Job dependencies trully synced to the User workspace state

### How was this change tested?

Smoke tests:
1. Create workspace 1 for MeerkatDemo
2. Create workspace 2 for MeerkatDemo
3. Open project in workspace 2
4. create new LVL, SEQ and Actor in MeerkatDemo project.
5. Open LVL and SEQ. Place Actor in the LVL view
6. Set camera, make simple movement on Actor (for example, rotation to right)
7. Save all of the files and submit them. Lets name this changelist 21
8. Change the movement (for example from right rotations of actor to left rotation)
9. Save all of the files and submit them. Lets name this changelist 22
10. Submit P4 render job from workspace 2
11. Sync workspace 1 to changelist 21 in P4V
12. Open project in workspace 1
13. Submit P4 render job from workspace 1

Result: render from workspace 2 was executed on changelist 22, right rotation. Render from workspace 1 was executed on changelist 21, left rotation

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

Yes, in docstrings

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*