### PR TITLE
test: Fixing e2e tests to use new DeadlineCloud namespace

### DIFF
--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -588,7 +588,7 @@ def run_unreal_test(request, reusable_queue_fleet_association) -> Callable:
         rather than relying on the process return code.
 
         Args:
-            test_path: Automation test path (e.g. "Deadline.Integration.CreateJob")
+            test_path: Automation test path (e.g. "DeadlineCloud.Integration.CreateJob")
             uproject_file: Path to the uproject file
             deadlineargs: Optional arguments to pass to Deadline, defaults to basic settings if None
 

--- a/test/end_to_end/test_create_job.py
+++ b/test/end_to_end/test_create_job.py
@@ -12,7 +12,7 @@ def test_create_job(deadline_client, build_plugin, create_readonly_test_project,
     _, uproject_file = create_readonly_test_project
 
     logger.info(f"Creating job from project {uproject_file}")
-    success, output_lines = run_unreal_test("Deadline.Integration.CreateJob", uproject_file)
+    success, output_lines = run_unreal_test("DeadlineCloud.Integration.CreateJob", uproject_file)
     assert success, "Create job test failed"
 
     # Extract job ID and farm ID from the output

--- a/test/end_to_end/test_worker_agent.py
+++ b/test/end_to_end/test_worker_agent.py
@@ -24,7 +24,7 @@ def test_create_job_with_worker_agent(
     _, uproject_file = create_readonly_test_project
 
     logger.info(f"Creating job from project {uproject_file}")
-    success, output_lines = run_unreal_test("Deadline.Integration.CreateJob", uproject_file)
+    success, output_lines = run_unreal_test("DeadlineCloud.Integration.CreateJob", uproject_file)
     assert success, "Create job test failed"
 
     # Extract job ID and farm ID from the output


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
#145 moved the CreateJob test over from Deadline to the DeadlineCloud namespace, but our references to it in our e2e tests weren't updated.

### What was the solution? (How)
Update the namespaces

### What is the impact of this change?
e2e tests should work again

### How was this change tested?
Ran the e2e tests

### Have you run a render job successfully with these changes?
Yes in the e2e tests

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*