### PR TITLE
fix: Updating docs to reflect new version compatibility

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,7 +62,7 @@ When making changes to the Python submitter you'll need to rebuild and install y
 // Install hatch if not yet installed
 pip install hatch
 hatch build
-"C:\Program Files\Epic Games\UE_5.4\Engine\Binaries\ThirdParty\Python3\Win64\python" -m pip install dist\deadline_cloud_for_unreal_engine-0.2.2.post21-py3-none-any.whl --target "C:\Program Files\Epic Games\UE_5.4\Engine\Plugins\UnrealDeadlineCloudService\Content\Python\libraries"
+"C:\Program Files\Epic Games\UE_5.5\Engine\Binaries\ThirdParty\Python3\Win64\python" -m pip install dist\deadline_cloud_for_unreal_engine-0.2.2.post21-py3-none-any.whl --target "C:\Program Files\Epic Games\UE_5.5\Engine\Plugins\UnrealDeadlineCloudService\Content\Python\libraries"
 ```
 
 When making adaptor changes, the same .whl can either be transferred to your worker or built on the worker off the same changes.

--- a/SETUP_SUBMITTER_CMF.md
+++ b/SETUP_SUBMITTER_CMF.md
@@ -10,7 +10,7 @@ These instructions are updated along with the corresponding code and scripts fai
 
 If you’re setting up on a brand new Windows EC2 Instance as your submitter, a g5.2xlarge instance with 200 GB of storage will likely be reasonable minimum:
 
-1. Download the Epic Installer and install a version of Unreal between versions 5.2 and 5.4. With 5.5 a bug has been observed that may prevent headless rendering on Deadline Cloud - we recommend using version 5.4.x at latest currently.
+1. Download the Epic Installer and install a version of Unreal between versions 5.2 and 5.5.  Note that on version 5.5 with DirectX 11 there's a crash bug which can affect projects rendered using the Deadline Cloud plugin which has been fixed in Unreal's source and can be tracked [here](https://issues.unrealengine.com/issue/UE-276282).  Projects in Deadline Cloud should use DirectX 12 with UE 5.5.
 1. NVIDIA GRID drivers - Follow Windows instructions - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html#nvidia-GRID-driver
 
 ## Windows Long Paths
@@ -41,7 +41,7 @@ Deadline Cloud Monitor is used to both manage your credentials for submitting jo
 
 - The path to your Python Installation (C:\Program Files\Python312 for example)
 - The path to your Python Scripts folder (C:\Program Files\Python312\scripts for example)
-- The path to your Unreal binaries (C:\Program Files\Epic Games\UE_5.4\Engine\Binaries\Win64)
+- The path to your Unreal binaries (C:\Program Files\Epic Games\UE_5.5\Engine\Binaries\Win64)
 
 ## Deadline Software Installation
 
@@ -76,11 +76,11 @@ Adjust the first two paths below based on where your installation of Unreal live
 From the Unreal Install Batchfiles Folder (Note the ‘package’ parameter can be any new directory, however you’ll want it to be called “UnrealDeadlineCloudService” later):
 
 ```
-cd C:\Program Files\Epic Games\UE_5.4\Engine\Build\BatchFiles
+cd C:\Program Files\Epic Games\UE_5.5\Engine\Build\BatchFiles
 runuat.bat BuildPlugin -plugin="C:\deadline\deadline-cloud-for-unreal-engine\src\unreal_plugin\UnrealDeadlineCloudService.uplugin" -package="C:\UnrealDeadlineCloudService"
 ```
 
-- Copy the “package” folder above to your Unreal installation’s Plugins folder (C:\Program Files\Epic Games\UE_5.4\Engine\Plugins\UnrealDeadlineCloudService for example)
+- Copy the “package” folder above to your Unreal installation’s Plugins folder (C:\Program Files\Epic Games\UE_5.5\Engine\Plugins\UnrealDeadlineCloudService for example)
 
 ## Python Dependencies
 
@@ -89,10 +89,10 @@ There are 4 ways to install the required Python dependencies.
 1. If you've built and installed the plugin from the release branch above, you can simply install from pip. Use the following install command, adjusting the paths to your Unreal installation:
 
 ```
-"C:\Program Files\Epic Games\UE_5.4\Engine\Binaries\ThirdParty\Python3\Win64\python" -m pip install deadline-cloud-for-unreal-engine --target "C:\Program Files\Epic Games\UE_5.4\Engine\Plugins\UnrealDeadlineCloudService\Content\Python\libraries"
+"C:\Program Files\Epic Games\UE_5.5\Engine\Binaries\ThirdParty\Python3\Win64\python" -m pip install deadline-cloud-for-unreal-engine --target "C:\Program Files\Epic Games\UE_5.5\Engine\Plugins\UnrealDeadlineCloudService\Content\Python\libraries"
 ```
 
-2.  Alternatively in your .uplugin file (In the above steps this would live at C:\Program Files\Epic Games\UE_5.4\Engine\Plugins\UnrealDeadlineCloudService\UnrealDeadlineCloudService.uplugin) you can add a "PythonRequirements" section which matches the latest release of deadline-cloud-for-unreal-engine in GitHub/PyPi, for example:
+2.  Alternatively in your .uplugin file (In the above steps this would live at C:\Program Files\Epic Games\UE_5.5\Engine\Plugins\UnrealDeadlineCloudService\UnrealDeadlineCloudService.uplugin) you can add a "PythonRequirements" section which matches the latest release of deadline-cloud-for-unreal-engine in GitHub/PyPi, for example:
 
 ```
 	"PythonRequirements":
@@ -116,7 +116,7 @@ Note that you may wish to disable the "strict hash" feature in Unreal's Python s
 // Install hatch if not yet installed
 pip install hatch
 hatch build
-"C:\Program Files\Epic Games\UE_5.4\Engine\Binaries\ThirdParty\Python3\Win64\python" -m pip install dist\deadline_cloud_for_unreal_engine-0.2.2.post21-py3-none-any.whl --target "C:\Program Files\Epic Games\UE_5.4\Engine\Plugins\UnrealDeadlineCloudService\Content\Python\libraries"
+"C:\Program Files\Epic Games\UE_5.5\Engine\Binaries\ThirdParty\Python3\Win64\python" -m pip install dist\deadline_cloud_for_unreal_engine-0.2.2.post21-py3-none-any.whl --target "C:\Program Files\Epic Games\UE_5.5\Engine\Plugins\UnrealDeadlineCloudService\Content\Python\libraries"
 ```
 
 4.  Lastly, Python dependencies can be installed by the submitter installer.  NOTE - these may be out of date with your code above from the release or mainline branch, and this method should not currently be preferred.
@@ -159,7 +159,7 @@ The Unreal Plugin currently must be compiled locally.
 
 - The path to your Python Installation (C:\Program Files\Python312 for example)
 - The path to your Python Scripts folder (C:\Program Files\Python312\scripts for example)
-- The path to your Unreal binaries (C:\Program Files\Epic Games\UE_5.4\Engine\Binaries\Win64)
+- The path to your Unreal binaries (C:\Program Files\Epic Games\UE_5.5\Engine\Binaries\Win64)
 
 ## Deadline Software Installation
 
@@ -225,18 +225,18 @@ Adjust the first two paths below based on where your installation of Unreal live
 From the Unreal Install Batchfiles Folder (Note the ‘package’ parameter can be any new directory, however you’ll want it to be called “UnrealDeadlineCloudService” later):
 
 ```
-cd C:\Program Files\Epic Games\UE_5.4\Engine\Build\BatchFiles
+cd C:\Program Files\Epic Games\UE_5.5\Engine\Build\BatchFiles
 runuat.bat BuildPlugin -plugin="C:\deadline\deadline-cloud-for-unreal-engine\src\unreal_plugin\UnrealDeadlineCloudService.uplugin" -package="C:\UnrealDeadlineCloudService"
 ```
 
-- Copy the “package” folder above to your Unreal installation’s Plugins folder (C:\Program Files\Epic Games\UE_5.4\Engine\Plugins\UnrealDeadlineCloudService for example)
+- Copy the “package” folder above to your Unreal installation’s Plugins folder (C:\Program Files\Epic Games\UE_5.5\Engine\Plugins\UnrealDeadlineCloudService for example)
 
 ## pywin32
 
 Unreal’s version of python will need pywin32. Pip install using copy of Unreal’s 3rd Party python installation:
 
 ```
-"C:\Program Files\Epic Games\UE_5.4\Engine\Binaries\ThirdParty\Python3\Win64\python" -m pip install pywin32
+"C:\Program Files\Epic Games\UE_5.5\Engine\Binaries\ThirdParty\Python3\Win64\python" -m pip install pywin32
 ```
 
 ## Submit a Test Render (Optional)

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 from collections import OrderedDict
 from dataclasses import dataclass, asdict
 
+from openjd.model import parse_model
 from openjd.model.v2023_09 import JobTemplate
 
 from deadline.client.job_bundle.submission import AssetReferences
@@ -202,7 +203,8 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             data_asset.job_preset_struct.host_requirements
         )
         for step in steps:
-            step.host_requirements = host_requirements
+            if host_requirements is not None:
+                step.host_requirements = host_requirements
 
         shared_settings = data_asset.job_preset_struct.job_shared_settings
 
@@ -364,18 +366,20 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         :rtype: JobTemplate
         """
 
-        job_template = self.template_class(
-            specificationVersion=settings.JOB_TEMPLATE_VERSION,
-            name=self.name,
-            parameterDefinitions=[
+        template_dict = {
+            "specificationVersion": settings.JOB_TEMPLATE_VERSION,
+            "name": self.name,
+            "parameterDefinitions": [
                 PARAMETER_DEFINITION_MAPPING[param["type"]].job_parameter_openjd_class(**param)
                 for param in self.get_template_object()["parameterDefinitions"]
             ],
-            steps=[s.build_template() for s in self._steps],
-            jobEnvironments=(
-                [e.build_template() for e in self._environments] if self._environments else None
-            ),
-        )
+            "steps": [s.build_template() for s in self._steps],
+        }
+
+        if self._environments:
+            template_dict["jobEnvironments"] = [e.build_template() for e in self._environments]
+
+        job_template = parse_model(model=self.template_class, obj=template_dict)
         return job_template
 
     def get_asset_references(self) -> AssetReferences:
@@ -545,24 +549,38 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         self._update_steps_settings_from_mrq_job(self._mrq_job)
         self._update_environments_settings_from_mrq_job(self._mrq_job)
 
-        if self._mrq_job.parameter_definition_overrides.parameters:
+        if (
+            self._mrq_job is not None
+            and self._mrq_job.parameter_definition_overrides is not None
+            and self._mrq_job.parameter_definition_overrides.parameters
+        ):
             self._extra_parameters = [
                 UnrealOpenJobParameterDefinition.from_unreal_param_definition(p)
                 for p in self._mrq_job.parameter_definition_overrides.parameters
             ]
 
-        self.job_shared_settings = JobSharedSettings.from_u_deadline_cloud_job_shared_settings(
-            self._mrq_job.preset_overrides.job_shared_settings
-        )
+        if (
+            self._mrq_job is not None
+            and self._mrq_job.preset_overrides is not None
+            and self._mrq_job.preset_overrides.job_shared_settings is not None
+        ):
+            self.job_shared_settings = JobSharedSettings.from_u_deadline_cloud_job_shared_settings(
+                self._mrq_job.preset_overrides.job_shared_settings
+            )
 
         # Job name set order:
         #   0. Job preset override (high priority)
         #   1. Get from data asset job preset struct
         #   2. Get from YAML template
         #   4. Get from mrq job name (shot name)
-        preset_override_name = self._mrq_job.preset_overrides.job_shared_settings.name
-        if preset_override_name not in ["", "Untitled"]:
-            self._name = preset_override_name
+        if (
+            self._mrq_job is not None
+            and self._mrq_job.preset_overrides is not None
+            and self._mrq_job.preset_overrides.job_shared_settings is not None
+        ):
+            preset_override_name = self._mrq_job.preset_overrides.job_shared_settings.name
+            if preset_override_name not in ["", "Untitled"]:
+                self._name = preset_override_name
 
         if self._name is None:
             self._name = self._mrq_job.job_name
@@ -594,7 +612,8 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         for source_step in data_asset.steps:
             job_step_cls = cls.job_step_map.get(type(source_step), UnrealOpenJobStep)
             job_step = job_step_cls.from_data_asset(source_step)
-            job_step.host_requirements = host_requirements
+            if host_requirements is not None:
+                job_step.host_requirements = host_requirements
             steps.append(job_step)
 
         environments = []
@@ -691,7 +710,8 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         )
         for step in self._steps:
             # update host requirements
-            step.host_requirements = host_requirements
+            if host_requirements is not None:
+                step.host_requirements = host_requirements
 
             # set mrq job to render step
             if isinstance(step, RenderUnrealOpenJobStep):

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from abc import ABC, abstractmethod
 from typing import Type, Union, Literal, Optional
 
+from openjd.model import parse_model
+
 from openjd.model.v2023_09 import (
     JobTemplate,
     StepTemplate,
@@ -145,7 +147,7 @@ class UnrealOpenJobEntity(UnrealOpenJobEntityBase):
         :rtype: Template
         """
         template_object = self.get_template_object()
-        return self.template_class(**template_object)
+        return parse_model(model=self.template_class, obj=template_object)
 
     def _validate_parameters(self) -> bool:
         """

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_environment.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_environment.py
@@ -2,7 +2,11 @@
 
 import unreal
 from typing import Optional, Union
-from openjd.model.v2023_09 import Environment, EnvironmentScript
+from openjd.model import parse_model
+from openjd.model.v2023_09 import (
+    Environment,
+    EnvironmentScript,
+)
 
 from deadline.unreal_submitter import settings
 from deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity import UnrealOpenJobEntity
@@ -100,14 +104,20 @@ class UnrealOpenJobEnvironment(UnrealOpenJobEntity):
         """
         Build Environment OpenJD model with updated name and variables dictionary
         """
-
         environment_template_object = self.get_template_object()
+
+        template_dict = {
+            "name": self.name,
+        }
+
         script = environment_template_object.get("script")
-        return self.template_class(
-            name=self.name,
-            script=EnvironmentScript(**script) if script else None,
-            variables=self._variables if self._variables else None,
-        )
+        if script:
+            template_dict["script"] = parse_model(model=EnvironmentScript, obj=script)
+
+        if self._variables:
+            template_dict["variables"] = self._variables
+
+        return parse_model(model=self.template_class, obj=template_dict)
 
 
 # Launch Unreal Editor Environment

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
@@ -7,6 +7,7 @@ from enum import IntEnum
 from typing import Optional, Any
 from dataclasses import dataclass, field, asdict
 
+from openjd.model import parse_model
 from openjd.model.v2023_09 import (
     StepScript,
     StepTemplate,
@@ -15,6 +16,7 @@ from openjd.model.v2023_09 import (
     TaskParameterList,
     StepParameterSpaceDefinition,
 )
+
 
 from openjd.model.v2023_09._model import StepDependency
 
@@ -287,7 +289,9 @@ class UnrealOpenJobStep(UnrealOpenJobEntity):
             ]
             param_definition_cls = param_descriptor.task_parameter_openjd_class
 
-            step_parameter_definition_list.append(param_definition_cls(**yaml_p))
+            step_parameter_definition_list.append(
+                parse_model(model=param_definition_cls, obj=yaml_p)
+            )
 
         return step_parameter_definition_list
 
@@ -305,33 +309,32 @@ class UnrealOpenJobStep(UnrealOpenJobEntity):
         :rtype: StepTemplate
         """
         step_template_object = self.get_template_object()
-
         step_parameters = self._build_step_parameter_definition_list()
 
-        return self.template_class(
-            name=self.name,
-            script=StepScript(**step_template_object["script"]),
-            parameterSpace=(
-                StepParameterSpaceDefinition(
-                    taskParameterDefinitions=step_parameters,
-                    combination=step_template_object["parameterSpace"].get("combination"),
-                )
-                if step_parameters
-                else None
-            ),
-            stepEnvironments=(
-                [env.build_template() for env in self._environments] if self._environments else None
-            ),
-            dependencies=(
-                [
-                    StepDependency(dependsOn=step_dependency)
-                    for step_dependency in self._step_dependencies
-                ]
-                if self._step_dependencies
-                else None
-            ),
-            hostRequirements=self.host_requirements,
-        )
+        template_dict = {
+            "name": self.name,
+            "script": parse_model(model=StepScript, obj=step_template_object["script"]),
+        }
+
+        if step_parameters:
+            template_dict["parameterSpace"] = StepParameterSpaceDefinition(
+                taskParameterDefinitions=step_parameters,
+                combination=step_template_object["parameterSpace"].get("combination"),
+            )
+
+        if self._environments:
+            template_dict["stepEnvironments"] = [env.build_template() for env in self._environments]
+
+        if self._step_dependencies:
+            template_dict["dependencies"] = [
+                StepDependency(dependsOn=step_dependency)
+                for step_dependency in self._step_dependencies
+            ]
+
+        if self.host_requirements:
+            template_dict["hostRequirements"] = self.host_requirements
+
+        return parse_model(model=self.template_class, obj=template_dict)
 
     def get_asset_references(self):
         """

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
@@ -99,4 +99,4 @@ void FUnrealDeadlineCloudServiceModule::ShutdownModule()
 
 #undef LOCTEXT_NAMESPACE
 
-IMPLEMENT_MODULE(FUnrealDeadlineCloudServiceModule, UnrealDeadlineCloudServiceEditorMode)
+IMPLEMENT_MODULE(FUnrealDeadlineCloudServiceModule, UnrealDeadlineCloudService)

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/DeadlineExecutorImplementationLibrary.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/DeadlineExecutorImplementationLibrary.h
@@ -12,7 +12,6 @@
 #include "MovieRenderPipelineCore/Public/MoviePipelineQueue.h"
 
 #include "Editor.h"
-#include "UnrealEd.h"
 #include "EditorSubsystem.h"
 #include "Subsystems/ImportSubsystem.h"
 #include "Subsystems/AssetEditorSubsystem.h" 

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
@@ -3,6 +3,7 @@
 import sys
 import pytest
 from unittest.mock import patch, Mock, MagicMock
+from openjd.model import parse_model
 from openjd.model.v2023_09 import (
     JobTemplate,
     StepTemplate,
@@ -15,6 +16,7 @@ from openjd.model.v2023_09 import (
     CancelationMethodNotifyThenTerminate,
     CancelationMode,
 )
+
 from deadline.client.job_bundle.submission import AssetReferences
 
 from test.deadline_submitter_for_unreal import fixtures
@@ -333,7 +335,7 @@ class TestUnrealOpenJob:
             job_template_dict["steps"] = steps
         if environments:
             job_template_dict["jobEnvironments"] = environments
-        job_template = JobTemplate(**job_template_dict)
+        job_template = parse_model(model=JobTemplate, obj=job_template_dict)
 
         # WHEN
         serialized = UnrealOpenJob.serialize_template(job_template)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Due to a crash issue we've been experiencing in version 5.5 we've not been able to confirm we support 5.5  After investigating it appears to have been due to a few different issues.  In DirectX 11 there's an issue which has been fixed with a commit listed [here](https://issues.unrealengine.com/issue/UE-276282) which is expected to come out in 5.6 but offers a workaround for DirectX 11 users.  For 5.5 there was a fix pushed in March in 5.5 which appears to resolve the issue for DirectX 12.  On the Deadline Cloud side we can now say we support version 5.5 as the only remaining fix is one we've identified on Unreal's side which has a couple potential workarounds.

Additionally, recent changes in openjd-model which require a context object when initializing FormatString derived classes had broken the plugin when building against latest - switched to instantiating using the parse_model method which will pull the default context from the underlying classes.

Cleaned up some additional linting and build warnings.

### What was the solution? (How)
Test, confirm, update docs

### What is the impact of this change?
Customers can feel confident using 5.5.  The number of users still on DirectX 11 is reported by Epic as "low".

### How was this change tested?
Docs only, but ran a render job to confirm we could say we support 5.5

### Have you run a render job successfully with these changes?
Yes

### Was this change documented?
It is docs

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*