### PR TITLE
chore: Add script for dependency artifact generation.

### DIFF
--- a/scripts/create_adaptor_packaging_artifact.sh
+++ b/scripts/create_adaptor_packaging_artifact.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+set -xeou pipefail
+
+APP=unrealengine
+APP_WITH_HYPEN=unreal-engine
+ADAPTOR_NAME=deadline-cloud-for-$APP_WITH_HYPEN
+
+# This script generates an tar.gz artifact from $ADAPTOR_NAME and its dependencies
+# that can be used to create a package for running the adaptor.
+
+SCRIPTDIR=$(realpath $(dirname $0))
+
+SOURCE=0
+# Python 3.11 is for https://vfxplatform.com/ CY2024
+PYTHON_VERSION=3.11
+CONDA_PLATFORM=win-64
+TAR_BASE=
+
+while [ $# -gt 0 ]; do
+    case "${1}" in
+    --source) SOURCE=1 ; shift ;;
+    --platform) CONDA_PLATFORM="$2" ; shift 2 ;;
+    --python) PYTHON_VERSION="$2" ; shift 2 ;;
+    --tar-base) TAR_BASE="$2" ; shift 2 ;;
+    *) echo "Unexpected option: $1"; exit 1 ;;
+  esac
+done
+
+if [ "$CONDA_PLATFORM" = "linux-64" ]; then
+    PYPI_PLATFORM=manylinux2014_x86_64
+elif [ "$CONDA_PLATFORM" = "win-64" ]; then
+    PYPI_PLATFORM=win_amd64
+elif [ "$CONDA_PLATFORM" = "osx-64" ]; then
+    PYPI_PLATFORM=macosx_10_9_x86_64
+else
+    echo "Unknown Conda operating system option --platform $CONDA_PLATFORM"
+    exit 1
+fi
+
+if [ "$TAR_BASE" = "" ]; then
+    TAR_BASE=$SCRIPTDIR/../$APP-openjd-py$PYTHON_VERSION-$CONDA_PLATFORM
+fi
+
+# Create a temporary prefix
+WORKDIR=$(mktemp -d adaptor-pkg.XXXXXXXXXX)
+function cleanup_workdir {
+    echo "Cleaning up $WORKDIR"
+    rm -rf $WORKDIR
+}
+trap cleanup_workdir EXIT
+
+PREFIX=$WORKDIR/prefix
+
+if [ "$CONDA_PLATFORM" = "win-64" ]; then
+    BINDIR=$PREFIX/Library/bin
+    PACKAGEDIR=$PREFIX/Library/opt/$ADAPTOR_NAME
+else
+    BINDIR=$PREFIX/bin
+    PACKAGEDIR=$PREFIX/opt/$ADAPTOR_NAME
+fi
+
+
+mkdir -p $PREFIX
+mkdir -p $PACKAGEDIR
+mkdir -p $BINDIR
+
+# Install the adaptor into the virtual env
+if [ $SOURCE = 1 ]; then
+    # In source mode, openjd-adaptor-runtime-for-python must be alongside this adaptor source
+    RUNTIME_INSTALLABLE=$SCRIPTDIR/../../openjd-adaptor-runtime-for-python
+    ADAPTOR_INSTALLABLE=$SCRIPTDIR/..
+
+    if [ "$CONDA_PLATFORM" = "win-64" ]; then
+        DEPS="pyyaml jsonschema pywin32"
+    else
+        DEPS="pyyaml jsonschema"
+    fi
+
+    for DEP in $DEPS; do
+        pip install \
+            --target $PACKAGEDIR \
+            --platform $PYPI_PLATFORM \
+            --python-version $PYTHON_VERSION \
+            --ignore-installed \
+            --only-binary=:all: \
+            $DEP
+    done
+
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --no-deps \
+        $RUNTIME_INSTALLABLE
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --only-binary=:all: \
+        $ADAPTOR_INSTALLABLE
+else
+    # In PyPI mode, PyPI and/or a CodeArtifact must have these packages
+    RUNTIME_INSTALLABLE=openjd-adaptor-runtime
+    ADAPTOR_INSTALLABLE=$ADAPTOR_NAME
+
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --no-deps \
+        $RUNTIME_INSTALLABLE
+    pip install \
+        --target $PACKAGEDIR \
+        --platform $PYPI_PLATFORM \
+        --python-version $PYTHON_VERSION \
+        --ignore-installed \
+        --only-binary=:all: \
+        $ADAPTOR_INSTALLABLE
+fi
+
+
+# Remove the submitter code
+rm -r $PACKAGEDIR/deadline/*_submitter
+
+# Remove the bin dir if there is one
+if [ -d $PACKAGEDIR/bin ]; then
+    rm -r $PACKAGEDIR/bin
+fi
+
+# Everything between the first "-" and the next "+" is the package version number
+PACKAGEVER=$(cd $PACKAGEDIR; echo deadline_cloud_for*)
+PACKAGEVER=${PACKAGEVER#*-}
+PACKAGEVER=${PACKAGEVER%+*}
+echo "Package version number is $PACKAGEVER"
+
+# Create the tar artifact
+GIT_TIMESTAMP="$(env TZ=UTC git log -1 --date=iso-strict-local --format="%ad")"
+pushd $PREFIX
+# See https://reproducible-builds.org/docs/archives/ for information about
+# these options
+#tar --mtime=$GIT_TIMESTAMP \
+#     --sort=name \
+#     --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+#    --owner=0 --group=0 --numeric-owner \
+#    -cf $TAR_BASE .
+# TODO Switch to the above command once the build environment has tar version > 1.28
+tar --owner=0 --group=0 --numeric-owner \
+    -cf $TAR_BASE-$PACKAGEVER.tar.gz .
+sha256sum $TAR_BASE-$PACKAGEVER.tar.gz
+popd


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We needed a script that could create a packaging artifact similar to other repositories for exporting the code with all their dependencies. We have similar scripts in other packages as well. 

### What was the solution? (How)

Created a script for Unreal Engine based off of a script from Cinema 4D. https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/scripts/create_adaptor_packaging_artifact.sh 

### What is the impact of this change?

Packaging script for building an artifact with all the code and dependencies. 

### How was this change tested?

Created conda packages and tested that it works. 

### Have you run a render job successfully with these changes?

Yes

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*