### PR TITLE
feat: persistent UI settings

### DIFF
--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -173,6 +173,9 @@ void UMoviePipelineDeadlineCloudExecutorJob::JobPresetChanged()
 
 void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
 {
+	
+	if (PropertyChangedEvent.Property)
+	{
 	// Check if we changed the job Preset an update the override details
 	if (const FName PropertyName = PropertyChangedEvent.GetPropertyName(); PropertyName == "JobPreset")
 	{
@@ -187,6 +190,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 
 	UE_LOG(LogTemp, Log, TEXT("Deadline Cloud job changed: %s"),
 		*PropertyChangedEvent.Property->GetPathName());
+	}
 }
 
 void UMoviePipelineDeadlineCloudExecutorJob::CollectDependencies()

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -421,20 +421,4 @@ void FMoviePipelineDeadlineCloudExecutorJobCustomization::CustomizeDetails(IDeta
 				];
 		}
 	}
-	//Resets MRQ job parameters after switching to another sequence
-	/*
-	TSharedPtr<IPropertyHandle> JobPropertyHandle = DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UMoviePipelineDeadlineCloudExecutorJob, JobPreset));
-	if (!JobPropertyHandle.IsValid()) return;
-
-	if (ObjectsBeingCustomized.Num() > 0)
-	{
-		UObject* CustomizedObject = ObjectsBeingCustomized[0].Get();
-		if (CustomizedObject) {
-			if (UMoviePipelineDeadlineCloudExecutorJob* MyMrq = Cast<UMoviePipelineDeadlineCloudExecutorJob>(CustomizedObject))
-			{
-				FPropertyChangedEvent PropertyChangedEvent(JobPropertyHandle->GetProperty());
-				CustomizedObject->PostEditChangeProperty(PropertyChangedEvent);
-			}
-		}
-	}*/
 }

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -421,7 +421,8 @@ void FMoviePipelineDeadlineCloudExecutorJobCustomization::CustomizeDetails(IDeta
 				];
 		}
 	}
-
+	//Resets MRQ job parameters after switching to another sequence
+	/*
 	TSharedPtr<IPropertyHandle> JobPropertyHandle = DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UMoviePipelineDeadlineCloudExecutorJob, JobPreset));
 	if (!JobPropertyHandle.IsValid()) return;
 
@@ -435,5 +436,5 @@ void FMoviePipelineDeadlineCloudExecutorJobCustomization::CustomizeDetails(IDeta
 				CustomizedObject->PostEditChangeProperty(PropertyChangedEvent);
 			}
 		}
-	}
+	}*/
 }


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

MRQ Slate drops any changes made in MRQ Job if User selected another MRQ Job

### What was the solution? (How)

Remove PostEditChangePropertyevent execution in the customization class.

### What is the impact of this change?

Now Users have an ability to update properties on several jobs in MRQ at the same time without loosing the changes

### How was this change tested?

1. Open MRQ widget
2. Add two or more jobs
3. Set some attribute in Job 1 (for example, Job Name)
4. Select Job 2, set its property too
5. Switch back to Job 1 - Job Name should be the same as User input (no default "Untitled")

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

No, since its a bugfix and this is expected behavior

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*