### PR TITLE
feat: MRQ Job validation error messages fixes

### DIFF
--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.cpp
@@ -132,7 +132,6 @@ void SDeadlineCloudFilePathWidget::Construct(const FArguments& InArgs)
 								.ClearKeyboardFocusOnCommit(true)
 								.OnTextCommitted(this, &SDeadlineCloudFilePathWidget::HandleTextBoxTextCommitted)
 								.OnTextChanged(this, &SDeadlineCloudFilePathWidget::OnTextChanged)
-								.OnVerifyTextChanged(IsValidInput)
 								.SelectAllTextOnCommit(false)
 								.IsReadOnly(InArgs._IsReadOnly)
 						]
@@ -222,12 +221,37 @@ FText SDeadlineCloudFilePathWidget::HandleTextBoxText() const
 
 void SDeadlineCloudFilePathWidget::OnTextChanged(const FText& InText)
 {
+	if (IsValidInput.IsBound())
+	{
+		FText Error = FText::GetEmpty();
+		IsValidInput.Execute(InText, Error);
+		TextBox->SetError(Error);
+	}
+
 	TextBox->SetText(InText);
 }
 
 void SDeadlineCloudFilePathWidget::HandleTextBoxTextCommitted(const FText& NewText, ETextCommit::Type CommitInfo)
 {
-	OnPathPicked(NewText.ToString());
+	if (IsValidInput.IsBound())
+	{
+		FText Error = FText::GetEmpty();
+		IsValidInput.Execute(NewText, Error);
+
+		if (!Error.IsEmpty())
+		{
+			TextBox->SetText(HandleTextBoxText());
+		}
+		else
+		{
+			OnPathPicked(NewText.ToString());
+		}
+		TextBox->SetError(FText::GetEmpty());
+	}
+	else
+	{
+		OnPathPicked(NewText.ToString());
+	}
 }
 
 void SDeadlineCloudFilePathWidget::OnPathPickedFromDialog(const FString& PickedPath)
@@ -288,7 +312,6 @@ public:
 							.Text(this, &SDeadlineCloudStringWidget::GetText)
 							.OnTextCommitted(this, &SDeadlineCloudStringWidget::OnTextCommitted)
 							.OnTextChanged(this, &SDeadlineCloudStringWidget::OnTextChanged)
-							.OnVerifyTextChanged(IsValidInput)
 					]
 			];
 
@@ -304,11 +327,35 @@ private:
 
 	void OnTextChanged(const FText& InText)
 	{
+		if (IsValidInput.IsBound())
+		{
+			Error = FText::GetEmpty();
+			IsValidInput.Execute(InText, Error);
+			TextBox->SetError(Error);
+		}
 	}
 
 	void OnTextCommitted(const FText& InText, ETextCommit::Type InCommitType)
 	{
-		StringProperty->SetValue(InText.ToString());
+		if (IsValidInput.IsBound())
+		{
+			Error = FText::GetEmpty();
+			IsValidInput.Execute(InText, Error);
+			if (Error.IsEmpty())
+			{
+				StringProperty->SetValue(InText.ToString());
+			}
+			else
+			{
+				TextBox->SetText(GetText());
+			}
+
+			TextBox->SetError(FText::GetEmpty());
+		}
+		else
+		{
+			StringProperty->SetValue(InText.ToString());
+		}
 	}
 
 	FText GetText() const


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Different behavior of the UI on the MRQ Job parameters with non-valid value during:
1. Focus change - The value rolled back to previous valid data but UI error message remained
2. Press "Enter" - The value rolled back to previous valid data, UI error message dissappeared

bad UX and this creates the impression that the job is submitted with non-valid data

### What was the solution? (How)

Make UI error dissapper on focus change the same as when you press enter, because the data actually changed

### What is the impact of this change?

Better UX, more clear UI notifications

### How was this change tested?

1. Create MRQ Job
4. Type non-valid value in some parameter (e.g. Job Name with spaces or integers in the beginning)
5. Error message should be displayed
6. When you click to submit, values should be changed to previous valid value and error message should be dropped

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

No, because it is a bug fix and we achieve the expected behavior.

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*