### PR TITLE
fix: Pinning model dependency to 0.8.x to prevent minor model updates…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "deadline >= 0.49,< 0.51",
     "openjd-adaptor-runtime >= 0.8.1,< 0.10",
-    "openjd-model",
+    "openjd-model >= 0.8, < 0.9",
     "p4python == 2025.1.2767466",
     "psutil >= 5.9.0"
 ]


### PR DESCRIPTION
… from breaking us unexpectedly

### What was the problem/requirement? (What/Why)
Pinning to openjd-model without version restrictions makes it easy for the plugin to break when a new minor version of openjd-model rolls out.

### What was the solution? (How)
Set a minor version restriction

### What is the impact of this change?
The plugin should be less likely to break due to dependency failures

### How was this change tested?
built, installed on both submitter and worker and ran a render job

hatch run test

### Have you run a render job successfully with these changes?
Yes

### Was this change documented?
NA

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*