### PR TITLE
add a workflow for manually releasing to pypi

### DIFF
--- a/.github/workflows/manual_pypi_release.yml
+++ b/.github/workflows/manual_pypi_release.yml
@@ -1,0 +1,52 @@
+# Perform a manual PyPI release outside of the regular release process
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        default: ""
+        type: string
+
+jobs:
+  ValidateTag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate semantic versioning
+        run: |
+          TAG="${{ inputs.tag }}"
+          if ! [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Tag '$TAG' does not follow semantic versioning format (X.Y.Z)"
+            exit 1
+          fi
+          echo "Tag validation successful"
+                
+  UnitTests:
+    name: Unit Tests
+    uses: ./.github/workflows/code_quality.yml
+    with:
+      tag: ${{ inputs.tag }}
+
+  PublishToPyPI:
+    needs: UnitTests
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: |
+          pip install --upgrade hatch
+      - name: Build
+        run: hatch -v build
+      # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We require a workflow for publishing to pypi in the event there is an issue publishing during the standard release process

### What was the solution? (How)
Add a workflow dispatch workflow for manually releasing a tagged build to pypi

### What is the impact of this change?
We can release to pypi if there is an issue doing so during the release process

### How was this change tested?
Needs to be tested after merge

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*