### PR TITLE
fix: Resolve deprecation warnings

### DIFF
--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/DeadlineCloudStepBaseSetting.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/DeadlineCloudStepBaseSetting.cpp
@@ -17,11 +17,11 @@ TArray<FString> GetStepOptionsImplementation(UObject* Object)
 		for (const auto Setting : Config->GetAllSettings())
 		{
 			const auto SettingClass = Setting->GetClass();
-			if (const auto DeadlineCloudSetting = Cast<UDeadlineCloudStepBaseSetting>(SettingClass->ClassDefaultObject))
+			if (const auto DeadlineCloudSetting = Cast<UDeadlineCloudStepBaseSetting>(SettingClass->GetDefaultObject()))
 			{
 				DeadlineCloudStepOptions.Add(DeadlineCloudSetting->GetDisplayText().ToString());
 			}
-			else if (const auto _ = Cast<UDeadlineCloudCompositeStepBaseSetting>(SettingClass->ClassDefaultObject))
+			else if (const auto _ = Cast<UDeadlineCloudCompositeStepBaseSetting>(SettingClass->GetDefaultObject()))
 			{
 				// Iterate through containers to find struct properties
 				for (TFieldIterator<FArrayProperty> ItProp(SettingClass, EFieldIterationFlags::IncludeAll); ItProp; ++ItProp)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

During plugin compilation, a deprecation warning appears: `UClass::ClassDeafultObject`: ClassDeafult object will be made private in the next release

### What was the solution? (How)

Replace `ClassDefaultObject` with `GetDefaultObject()`

### What is the impact of this change?

Warnings don't appear during compilation

### How was this change tested?

*delete text starting here*
See [DEVELOPMENT.md](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/blob/mainline/DEVELOPMENT.md) for information on running tests.

- Have you run the unit tests?
*delete text ending here*

### Have you run a render job successfully with these changes?

*delete text starting here*
See the "Submit a Test Render" section of [this guide](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/blob/mainline/SETUP_SUBMITTER_CMF.md#submit-a-test-render-optional)
*delete text ending here*

### Was this change documented?

*delete text starting here*
- Did you update all relevant docstrings for Python functions that you modified?
- Should the README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory be updated along with your change?
- Should the schema files for the adaptor's init-data or run-data be updated?
*delete text ending here*

### Is this a breaking change?

*delete text starting here*
A breaking change is one that modifies a public contract in some way or otherwise changes functionality of this application in a way
that is not backwards compatible. Examples of changes that are breaking include:

1. Adding a new required value to the init-data or run-data of the adaptor;
2. Deleting or renaming a value in the init-data or run-data of the adaptor; and
3. Otherwise modifying the interface of the adaptor such that a job submitted with an older version of the Unreal submitter plug-in
   will not work with a version of the adaptor that includes your modification.

If so, then please describe the changes that users of this package must make to update their scripts, or Python applications. Also,
please ensure that the title of your commit follows our conventional commit guidelines in
[CONTRIBUTING.md](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/blob/mainline/CONTRIBUTING.md#conventional-commits) for breaking changes.
*delete text ending here*

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*