### PR TITLE
fix: Error message in  field: Contains empty elements or more than 50 of them with UE 5.5.4 (#154)

### DIFF
--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.cpp
@@ -161,6 +161,77 @@ void FDeadlineCloudAttachmentDetailsCustomization::CustomizeHeader(
         ];
 }
 
+TSharedRef<SWidget> FDeadlineCloudAttachmentDetailsCustomization::BuildPathsValidationWidget(
+    TSharedRef<IPropertyHandle> PathsHandle)
+{
+    return SNew(SVerticalBox)
+
+        // Empty paths
+        + SVerticalBox::Slot()
+        .AutoHeight()
+        [
+            SNew(STextBlock)
+                .Text(LOCTEXT("EmptyPathsError", "The list contains empty elements"))
+                .Font(IDetailLayoutBuilder::GetDetailFont())
+                .ColorAndOpacity(FLinearColor(1.0f, 0.756f, 0.027f)) // #FFC107
+                .Visibility_Lambda([PathsHandle, this]() {
+                return GetPathsEmptyWidgetVisibility(PathsHandle);
+                    })
+        ]
+
+    // Too many paths
+    + SVerticalBox::Slot()
+        .AutoHeight()
+        [
+            SNew(STextBlock)
+                .Text(LOCTEXT("ExceedPathsNumberError", "The list must not contain more than 50 paths"))
+                .Font(IDetailLayoutBuilder::GetDetailFont())
+                .ColorAndOpacity(FLinearColor(1.0f, 0.756f, 0.027f))
+                .Visibility_Lambda([PathsHandle, this]() {
+                return GetPathsNumberExceededWidgetVisibility(PathsHandle);
+                    })
+        ];
+}
+
+void FDeadlineCloudAttachmentDetailsCustomization::CustomizePathsRow(
+    IDetailPropertyRow& Row,
+    TSharedRef<IPropertyHandle> PathsHandle,
+    bool bCheckPaths)
+{
+    TSharedPtr<SWidget> NameWidget;
+    TSharedPtr<SWidget> ValueWidget;
+    Row.GetDefaultWidgets(NameWidget, ValueWidget);
+
+    Row.CustomWidget(true)
+        .NameContent()
+        [
+            NameWidget.ToSharedRef()
+        ]
+        .ValueContent()
+        [
+            SNew(SHorizontalBox)
+                // Only add the validation widget if bCheckPaths is true
+                + SHorizontalBox::Slot()
+                .HAlign(HAlign_Left)
+                .VAlign(VAlign_Center)
+                .Padding(4, 0)
+                [
+                    bCheckPaths ? BuildPathsValidationWidget(PathsHandle) : SNullWidget::NullWidget
+                ]
+                + SHorizontalBox::Slot()
+                .AutoWidth()
+                .HAlign(HAlign_Left)
+                .VAlign(VAlign_Center)
+                [
+                    SNew(SOverlay)
+                        + SOverlay::Slot()
+                        [
+                            ValueWidget.ToSharedRef()
+                        ]
+                ]
+        ];
+}
+
 void FDeadlineCloudAttachmentDetailsCustomization::CustomizeChildren(
     TSharedRef<IPropertyHandle> StructHandle, IDetailChildrenBuilder& ChildBuilder,
     IPropertyTypeCustomizationUtils& CustomizationUtils)
@@ -192,86 +263,11 @@ void FDeadlineCloudAttachmentDetailsCustomization::CustomizeChildren(
                     }));
     }
     else
+    { 
         PropertyOverrideHandler->DisableRowInDataAsset(AutoDetectedPathsRow);
-
-    TSharedPtr<SWidget> PathsNameWidget;
-    TSharedPtr<SWidget> PathsValueWidget;
-    PathsRow.GetDefaultWidgets(PathsNameWidget, PathsValueWidget);
-    PathsRow.CustomWidget(true)
-        .NameContent()
-        [
-            PathsNameWidget.ToSharedRef()
-        ]
-        .ValueContent()
-        [
-            SNew(SHorizontalBox)
-                + SHorizontalBox::Slot()
-                .HAlign(HAlign_Left)
-                .VAlign(VAlign_Center)
-                .Padding(4, 0)
-                [
-                    SNew(STextBlock)
-                        .Text(LOCTEXT("PathsError", "Contains empty elements or more than 50 of them"))
-                        .Font(IDetailLayoutBuilder::GetDetailFont())
-                        .ColorAndOpacity(FLinearColor::Red)
-                        .Visibility(TAttribute<EVisibility>::Create(
-                            TAttribute<EVisibility>::FGetter::CreateSPLambda(
-                                this, [this, PathsHandle]() {
-                                    return GetPathsErrorWidgetVisibility(PathsHandle);
-                                })))
-                ]
-                + SHorizontalBox::Slot()
-                .AutoWidth()
-                .HAlign(HAlign_Left)
-                .VAlign(VAlign_Center)
-                [
-                    SNew(SOverlay)
-                        + SOverlay::Slot()
-                        [
-                            PathsValueWidget.ToSharedRef()
-                        ]
-                ]
-        ];
-
-    TSharedPtr<SWidget> AutoDetectedPathsNameWidget;
-    TSharedPtr<SWidget> AutoDetectedPathsValueWidget;
-    AutoDetectedPathsRow.GetDefaultWidgets(AutoDetectedPathsNameWidget, AutoDetectedPathsValueWidget);
-    AutoDetectedPathsRow.CustomWidget(true)
-        .NameContent()
-        [
-            AutoDetectedPathsNameWidget.ToSharedRef()
-        ]
-        .ValueContent()
-        [
-            SNew(SHorizontalBox)
-                + SHorizontalBox::Slot()
-                .HAlign(HAlign_Left)
-                .VAlign(VAlign_Center)
-                .Padding(4, 0)
-                [
-                    SNew(STextBlock)
-                        .Text(LOCTEXT("AutoDetectedPathsError", "Contains empty elements or more than 50 of them"))
-                        .Font(IDetailLayoutBuilder::GetDetailFont())
-                        .ColorAndOpacity(FLinearColor::Red)
-                        .Visibility(TAttribute<EVisibility>::Create(
-                            TAttribute<EVisibility>::FGetter::CreateSPLambda(
-                                this, [this, AutoDetectedPathsHandle]() {
-                                    return GetPathsErrorWidgetVisibility(AutoDetectedPathsHandle);
-                                })))
-                ]
-                + SHorizontalBox::Slot()
-                .AutoWidth()
-                .HAlign(HAlign_Left)
-                .VAlign(VAlign_Center)
-                [
-                    SNew(SOverlay)
-                        + SOverlay::Slot()
-                        [
-                            AutoDetectedPathsValueWidget.ToSharedRef()
-                        ]
-                ]
-        ];
-
+    }
+        CustomizePathsRow(PathsRow, PathsHandle.ToSharedRef(), true);
+        CustomizePathsRow(AutoDetectedPathsRow, AutoDetectedPathsHandle.ToSharedRef(), false);
 
     // Since we updating auto-detected files mostly to show them in the UI. We don't want to put it into job initialization methods
     if (OuterJob && StructHandle->GetProperty()->GetName() == "InputFiles")
@@ -280,7 +276,7 @@ void FDeadlineCloudAttachmentDetailsCustomization::CustomizeChildren(
     }
 }
 
-bool FDeadlineCloudAttachmentDetailsCustomization::IsPathsContainsErrors(TSharedPtr<IPropertyHandle> PropertyHandle) const
+bool FDeadlineCloudAttachmentDetailsCustomization::ExceededPathsNumber(TSharedPtr<IPropertyHandle> PropertyHandle) const
 {
 	if (!PropertyHandle.IsValid())
 	{
@@ -305,6 +301,33 @@ bool FDeadlineCloudAttachmentDetailsCustomization::IsPathsContainsErrors(TShared
         return true;
     }
 
+    return false;
+}
+
+bool FDeadlineCloudAttachmentDetailsCustomization::ContainsEmptyPaths(TSharedPtr<IPropertyHandle> PropertyHandle) const
+{
+    if (!PropertyHandle.IsValid())
+    {
+        return false;
+    }
+    auto Paths = PropertyHandle->GetChildHandle("Paths", false);
+    if (!Paths.IsValid())
+    {
+        return false;
+    }
+
+    auto ArrayHandle = Paths->AsArray();
+    if (!ArrayHandle.IsValid())
+    {
+        return false;
+    }
+
+    uint32 NumChildren = 0;
+    ArrayHandle->GetNumElements(NumChildren);
+    if (NumChildren == 0)
+    {
+        return false;
+    }
     for (uint32 ChildIndex = 0; ChildIndex < NumChildren; ++ChildIndex)
     {
         TSharedPtr<IPropertyHandle> ChildHandle = ArrayHandle->GetElement(ChildIndex);
@@ -321,11 +344,11 @@ bool FDeadlineCloudAttachmentDetailsCustomization::IsPathsContainsErrors(TShared
         }
         else
         {
-			auto Path = ChildHandle->GetChildHandle("Path", false);
-			if (Path.IsValid())
-			{
-				Path->GetValue(Value);
-			}
+            auto Path = ChildHandle->GetChildHandle("Path", false);
+            if (Path.IsValid())
+            {
+                Path->GetValue(Value);
+            }
         }
 
         if (Value.IsEmpty())
@@ -337,15 +360,17 @@ bool FDeadlineCloudAttachmentDetailsCustomization::IsPathsContainsErrors(TShared
     return false;
 }
 
-EVisibility FDeadlineCloudAttachmentDetailsCustomization::GetPathsErrorWidgetVisibility(TSharedPtr<IPropertyHandle> PropertyHandle) const
+EVisibility FDeadlineCloudAttachmentDetailsCustomization::GetPathsNumberExceededWidgetVisibility(TSharedPtr<IPropertyHandle> PropertyHandle) const
 {
-    return IsPathsContainsErrors(PropertyHandle) ? EVisibility::Visible : EVisibility::Collapsed;
+    return ExceededPathsNumber(PropertyHandle) ? EVisibility::Visible : EVisibility::Collapsed;
 }
 
-EVisibility FDeadlineCloudAttachmentDetailsCustomization::GetPathsDefaultWidgetVisibility(TSharedPtr<IPropertyHandle> PropertyHandle) const
+EVisibility FDeadlineCloudAttachmentDetailsCustomization::GetPathsEmptyWidgetVisibility(TSharedPtr<IPropertyHandle> PropertyHandle) const
 {
-    return IsPathsContainsErrors(PropertyHandle) ? EVisibility::Collapsed : EVisibility::Visible;
+    return ContainsEmptyPaths(PropertyHandle) ? EVisibility::Visible : EVisibility::Collapsed;
 }
+
+
 
 bool FDeadlineCloudJobPresetDetailsCustomization::IsPropertyHiddenInMovieRenderQueue(const FName& InPropertyPath)
 {

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -8,6 +8,7 @@
 #include "Misc/Paths.h"
 #include "Interfaces/IPluginManager.h"
 #include "PropertyEditorModule.h"
+#include "AssetRegistry/AssetRegistryModule.h"
 #include "DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.h"
 
 UMoviePipelineDeadlineCloudExecutorJob::UMoviePipelineDeadlineCloudExecutorJob()
@@ -202,8 +203,45 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 	}
 }
 
+ bool UMoviePipelineDeadlineCloudExecutorJob::IsAssetFileValid(const FString& FilePath)
+{
+	// Check file on disk
+	if (!FPaths::FileExists(FilePath))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Dependency file missing: %s"), *FilePath);
+		return false;
+	}
+
+	// Check convert to asset path
+	FString LongPackagePath;
+	if (!FPackageName::TryConvertFilenameToLongPackageName(FilePath, LongPackagePath))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Could not convert to package path: %s"), *FilePath);
+		return false;
+	}
+
+	// Check AssetRegistry
+	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	FAssetData AssetData = AssetRegistryModule.Get().GetAssetByObjectPath(*LongPackagePath);
+
+	if (!AssetData.IsValid())
+	{
+		UE_LOG(LogTemp, Warning, TEXT("AssetRegistry has no info about: %s (from file %s)"), *LongPackagePath, *FilePath);
+		return false;
+	}
+
+	return true;
+}
+
 void UMoviePipelineDeadlineCloudExecutorJob::CollectDependencies()
 {
+
+	if (GEngine)
+	{
+		UE_LOG(LogTemp, Log, TEXT("Running Garbage Collection before dependency update..."));
+		GEngine->ForceGarbageCollection();
+		
+	}
 	UE_LOG(LogTemp, Log, TEXT("MoviePipelineDeadlineCloudExecutorJob :: Collecting dependencies"));
 	PresetOverrides.JobAttachments.InputFiles.AutoDetected.Paths.Empty();
 	AsyncTask(ENamedThreads::GameThread, [this]()
@@ -213,31 +251,26 @@ void UMoviePipelineDeadlineCloudExecutorJob::CollectDependencies()
 			if (auto Library = UDeadlineCloudJobBundleLibrary::Get())
 			{
 				FilePaths = Library->GetJobDependencies(this);
+				for (auto FilePath : FilePaths)
+				{
+					if (!IsAssetFileValid(FilePath))
+					{
+						continue;
+					}
+					FFilePath Item;
+					Item.FilePath = FilePath;
+					DependencyFiles.Add(Item);
+				}
+				
+				UE_LOG(LogTemp, Log, TEXT("Added %d dependency files:"), DependencyFiles.Num());
 			}
 			else
 			{
 				UE_LOG(LogTemp, Error, TEXT("Error get DeadlineCloudJobBundleLibrary"));
 			}
-			for (auto FilePath : FilePaths)
-			{
-				FFilePath Item;
-				Item.FilePath = FilePath;
-				DependencyFiles.Add(Item);
-			}
+
 		});
-	UE_LOG(LogTemp, Log, TEXT("MoviePipelineDeadlineCloudExecutorJob :: Collecting dependencies"));
-	PresetOverrides.JobAttachments.InputFiles.AutoDetected.Paths.Empty();
-	AsyncTask(ENamedThreads::GameThread, [this]()
-		{
-			auto& DependencyFiles = PresetOverrides.JobAttachments.InputFiles.AutoDetected.Paths;
-			TArray<FString> FilePaths = UDeadlineCloudJobBundleLibrary::Get()->GetJobDependencies(this);
-			for (auto FilePath : FilePaths)
-			{
-				FFilePath Item;
-				Item.FilePath = FilePath;
-				DependencyFiles.Add(Item);
-			}
-		});
+
 }
 
 void UMoviePipelineDeadlineCloudExecutorJob::UpdateInputFilesProperty()

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.h
@@ -121,9 +121,13 @@ protected:
 	/** Handles overridden settings in UI */
 	TSharedPtr<FPropertyAvailabilityHandler> PropertyOverrideHandler;
 
-    bool IsPathsContainsErrors(TSharedPtr<IPropertyHandle> PropertyHandle) const;
-    EVisibility GetPathsErrorWidgetVisibility(TSharedPtr<IPropertyHandle> PropertyHandle) const;
-    EVisibility GetPathsDefaultWidgetVisibility(TSharedPtr<IPropertyHandle> PropertyHandle) const;
+    bool ExceededPathsNumber(TSharedPtr<IPropertyHandle> PropertyHandle) const;
+	bool ContainsEmptyPaths(TSharedPtr<IPropertyHandle> PropertyHandle) const;
+    EVisibility GetPathsNumberExceededWidgetVisibility(TSharedPtr<IPropertyHandle> PropertyHandle) const;
+    EVisibility GetPathsEmptyWidgetVisibility(TSharedPtr<IPropertyHandle> PropertyHandle) const;
+
+	TSharedRef<SWidget> BuildPathsValidationWidget(TSharedRef<IPropertyHandle> PathsHandle);
+	void CustomizePathsRow(IDetailPropertyRow& Row, TSharedRef<IPropertyHandle> PathsHandle, bool bCheckPaths);
 };
 
 /**

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
@@ -105,6 +105,8 @@ public:
     TArray<FDeadlineCloudEnvironmentOverride> EnvironmentsOverrides = TArray<FDeadlineCloudEnvironmentOverride>();
 
     void JobPresetChanged();
+    static bool IsAssetFileValid(const FString& FilePath);
+
 protected:
 
 #if WITH_EDITOR


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`Auto Detected Files` field includes a default validation that limits the list to a maximum of 50 elements. In Unreal, this limit is consistently exceeded. The validation also checks for empty elements, which can result in a misleading error message causing the user to think there are empty entries in the list, even when there aren't

### What was the solution? (How)

- Remove 50 elements limit check for `Auto Detected Files`
- Add separate validations for the maximum number of elements and for empty elements

### What is the impact of this change?

Updated paths list validation logic in UI

### How was this change tested?

QA UI behavior tests for paths lists

### Have you run a render job successfully with these changes?

Submitted test job succeeded

### Was this change documented?

Doesn't require documentation update

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*