### PR TITLE
feat: Support Extra Commandline Arguments several inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ destinations = [
   "src/deadline/unreal_submitter",
   "src/deadline/unreal_logger",
   "src/deadline/unreal_perforce_utils",
+  "src/deadline/unreal_cmd_utils",  
 ]
 
 [tool.hatch.build.targets.sdist]
@@ -117,6 +118,7 @@ addopts = [
     "--cov=src/deadline/unreal_submitter",
     "--cov=src/deadline/unreal_logger",
     "--cov=src/deadline/unreal_perforce_utils",
+    "--cov=src/deadline/unreal_cmd_utils",    
     "--color=yes",
     "--cov-report=html:build/coverage",
     "--cov-report=xml:build/coverage/coverage.xml",
@@ -139,7 +141,8 @@ source_pkgs = [
     "src/deadline/unreal_adaptor",
     "src/deadline/unreal_submitter",
     "src/deadline/unreal_logger",
-    "src/deadline/unreal_perforce_utils"
+    "src/deadline/unreal_perforce_utils",
+    "src/deadline/unreal_cmd_utils",
 ]
 branch = true
 parallel = true

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
@@ -11,6 +11,7 @@ import threading
 import jsonschema
 from typing import Callable, Optional
 
+from deadline.unreal_cmd_utils import merge_cmd_args_with_priority
 from deadline.client.api import get_deadline_cloud_library_telemetry_client, TelemetryClient
 from openjd.adaptor_runtime._version import version as openjd_adaptor_version
 from openjd.adaptor_runtime_client import Action
@@ -19,6 +20,7 @@ from openjd.adaptor_runtime.adaptors import Adaptor, SemanticVersion
 from openjd.adaptor_runtime.app_handlers import RegexCallback, RegexHandler
 from openjd.adaptor_runtime.application_ipc import ActionsQueue, AdaptorServer
 from openjd.adaptor_runtime.adaptors.configuration import AdaptorConfiguration
+
 
 from .._version import version as adaptor_version
 from .common import DataValidation, add_module_to_pythonpath
@@ -322,11 +324,12 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
 
         # Read args from file since it can be too long to pass
         # them to Job parameter (1024 chars limit)
-        extra_cmd_str = ""
+        extra_cmd_str = self.init_data.get("extra_cmd_args", "") or ""
         extra_cmd_args_file = self.init_data.get("extra_cmd_args_file", "")
         if os.path.exists(extra_cmd_args_file):
             with open(extra_cmd_args_file, "r") as f:
-                extra_cmd_str = f.read()
+                extra_cmd_file_str = f.read()
+                extra_cmd_str = merge_cmd_args_with_priority(extra_cmd_str, extra_cmd_file_str)
 
         # Everything between -execcmds=" and " is the value we want to keep
         match = re.search(r'-execcmds=["\']([^"\']*)["\']', extra_cmd_str)

--- a/src/deadline/unreal_cmd_utils/__init__.py
+++ b/src/deadline/unreal_cmd_utils/__init__.py
@@ -1,0 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from .cmd_utils import merge_cmd_args_with_priority, parse_command_line
+
+__all__ = ["merge_cmd_args_with_priority", "parse_command_line"]

--- a/src/deadline/unreal_cmd_utils/cmd_utils.py
+++ b/src/deadline/unreal_cmd_utils/cmd_utils.py
@@ -1,0 +1,126 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from collections import OrderedDict
+from deadline.unreal_logger import get_logger
+
+import shlex
+
+logger = get_logger()
+
+SPECIAL_KEYS = {"dpcvars", "execcmds"}
+NEED_QUOTE_CHARS = set(" ,;")
+
+
+def parse_command_line(cmd_line: str):
+    tokens = []
+    switches = []
+    params = {}
+
+    cmd_line = cmd_line or ""
+    args = shlex.split(cmd_line)
+
+    for arg in args:
+        if arg.startswith("-"):
+            stripped = arg.lstrip("-")
+            if "=" in stripped:
+                key, value = stripped.split("=", 1)
+                value = value.strip('"').strip("'")
+                params[key] = value
+            else:
+                switches.append(stripped)
+        else:
+            tokens.append(arg)
+
+    return tokens, switches, params
+
+
+def merge_cmd_args_with_priority(higher_priority_args: str, lower_priority_args: str) -> str:
+    """
+    Merge two Unreal‑Engine CLI strings, letting *higher_priority_args* win.
+
+    • Positional tokens and flags are deduped (case‑insensitive).
+    • Key‑value pairs: duplicates keep the value from *higher*.
+    • -DPCVars   → lists combined, CVars from *higher* override.
+    • -ExecCmds  → lists concatenated, dups removed by command name.
+    • Values with spaces/commas/, are auto‑quoted.
+
+    Returns the merged command string, on parse failure logs and
+    yields an empty string.
+    """
+
+    def _parse_list(value: str):
+        return [x.strip() for x in value.strip("\"' ").split(",") if x.strip()]
+
+    def _merge_execcmds(v1, v2):
+        def first_word(cmd):
+            return cmd.split()[0].lower() if cmd else ""
+
+        merged = OrderedDict()
+        for cmd in _parse_list(v1) + _parse_list(v2):
+            merged[first_word(cmd)] = cmd
+        return ",".join(merged.values())
+
+    def _merge_dpcvars(v1, v2):
+        def pairs(lst):
+            for item in lst:
+                if "=" in item:
+                    n, val = item.split("=", 1)
+                else:
+                    n, val = item.split(None, 1)
+                yield n.strip().lower(), n.strip(), val.strip()
+
+        merged = OrderedDict()
+        for norm, name, val in pairs(_parse_list(v1) + _parse_list(v2)):
+            merged[norm] = (name, val)
+        return ",".join(f"{name}={val}" for _, (name, val) in merged.items())
+
+    def _quote_if_needed(val: str):
+        if any(c in NEED_QUOTE_CHARS for c in val):
+            escaped = val.replace('"', r"\"")
+            return f'"{escaped}"'
+        return val
+
+    try:
+        t1, s1, kv1 = parse_command_line(lower_priority_args)
+
+    except Exception:
+        logger.error(f"Failed to parse command line arguments: {lower_priority_args}")
+        return ""
+
+    try:
+        t2, s2, kv2 = parse_command_line(higher_priority_args)
+
+    except Exception:
+        logger.error(f"Failed to parse command line arguments: {higher_priority_args}")
+        return ""
+
+    tokens = []
+    seen_tokens = set()
+    for t in t1 + t2:
+        if t.lower() not in seen_tokens:
+            tokens.append(t)
+            seen_tokens.add(t.lower())
+
+    flags = {f.lower(): f for f in s1}
+    flags.update({f.lower(): f for f in s2})
+    switches = list(flags.values())
+
+    out = {}
+    for k, v in kv1.items():
+        out[k.lower()] = (k, v)
+    for k, v in kv2.items():
+        lk = k.lower()
+        if lk in SPECIAL_KEYS and lk in out:
+            v = _merge_dpcvars(out[lk][1], v) if lk == "dpcvars" else _merge_execcmds(out[lk][1], v)
+        out[lk] = (k, v)
+    key_vals = {orig: val for orig, val in out.values()}
+
+    parts = []
+    parts.extend(tokens)
+    parts.extend(f"-{flag}" for flag in switches)
+    for key, val in key_vals.items():
+        if val == "":
+            parts.append(f"-{key}=")
+        else:
+            parts.append(f"-{key}={_quote_if_needed(val)}")
+    return " ".join(parts)

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -5,6 +5,7 @@ import re
 import sys
 import json
 import unreal
+
 from enum import IntEnum
 from typing import Any, Optional
 from collections import OrderedDict
@@ -15,7 +16,7 @@ from openjd.model.v2023_09 import JobTemplate
 
 from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.job_bundle import deadline_yaml_dump, create_job_history_bundle_dir
-
+from deadline.unreal_cmd_utils import merge_cmd_args_with_priority
 from deadline.unreal_submitter import common, exceptions, settings
 from deadline.unreal_submitter.unreal_dependency_collector import (
     DependencyCollector,
@@ -139,8 +140,8 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         steps: Optional[list[UnrealOpenJobStep]] = None,
         environments: Optional[list[UnrealOpenJobEnvironment]] = None,
         extra_parameters: Optional[list[UnrealOpenJobParameterDefinition]] = None,
-        job_shared_settings: JobSharedSettings = JobSharedSettings(),
-        asset_references: AssetReferences = AssetReferences(),
+        job_shared_settings: Optional[JobSharedSettings] = None,
+        asset_references: Optional[AssetReferences] = None,
     ):
         """
         :param file_path: Path to the open job template file
@@ -172,8 +173,8 @@ class UnrealOpenJob(UnrealOpenJobEntity):
 
         self._steps: list[UnrealOpenJobStep] = steps or []
         self._environments: list[UnrealOpenJobEnvironment] = environments or []
-        self._job_shared_settings = job_shared_settings
-        self._asset_references = asset_references
+        self._job_shared_settings = job_shared_settings or JobSharedSettings()
+        self._asset_references = asset_references or AssetReferences()
 
         self._transfer_files_strategy = TransferProjectFilesStrategy.S3
 
@@ -459,8 +460,8 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         steps: Optional[list[UnrealOpenJobStep]] = None,
         environments: Optional[list[UnrealOpenJobEnvironment]] = None,
         extra_parameters: Optional[list[UnrealOpenJobParameterDefinition]] = None,
-        job_shared_settings: JobSharedSettings = JobSharedSettings(),
-        asset_references: AssetReferences = AssetReferences(),
+        job_shared_settings: Optional[JobSharedSettings] = None,
+        asset_references: Optional[AssetReferences] = None,
         mrq_job: Optional[unreal.MoviePipelineExecutorJob] = None,
     ):
         """
@@ -988,7 +989,9 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         unfilled_parameter_values = [
             p
             for p in parameter_values
-            if p["value"] is None or p["name"] == OpenJobParameterNames.UNREAL_EXTRA_CMD_ARGS
+            if p["value"] is None
+            or p["name"] == OpenJobParameterNames.UNREAL_EXTRA_CMD_ARGS
+            or p["name"] == OpenJobParameterNames.UNREAL_EXTRA_CMD_ARGS_FILE
         ]
         filled_parameter_values = [
             p for p in parameter_values if p not in unfilled_parameter_values
@@ -997,19 +1000,37 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         # Unreal Engine can handle long CMD args strings and OpenJD has a limit of 1024 chars.
         # Therefore, we need to write them to file and set ExtraCmdArgs parameter as empty string.
         # Unreal Adaptor uses only ExtraCmdArgsFile parameter to read args from file.
-        cmd_args_str = " ".join(self._get_ue_cmd_args())
+        extra_cmd_args_file_value = None
+        for p in parameter_values:
+            if p["name"] == OpenJobParameterNames.UNREAL_EXTRA_CMD_ARGS_FILE:
+                extra_cmd_args_file_value = p["value"]
+                break
+
+        # Read EXTRA_CMD_ARGS_FILE file value if file exists, and append its content to user_extra_cmd_args
+        args_from_file = None
+        if extra_cmd_args_file_value:
+            args_from_file = self.get_user_extra_cmd_args_from_file(str(extra_cmd_args_file_value))
+        user_extra_cmd_args = self.get_user_extra_cmd_args()
+
+        if args_from_file:
+            user_extra_cmd_args = merge_cmd_args_with_priority(user_extra_cmd_args, args_from_file)
+        executor_cmd_args = self.get_executor_cmd_args()
+
+        merged_cmd_args = merge_cmd_args_with_priority(user_extra_cmd_args, executor_cmd_args)
+        merged_cmd_args = self.clear_cmd_args(merged_cmd_args)
 
         unfilled_parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
             job_parameter_values=unfilled_parameter_values,
             job_parameter_name=OpenJobParameterNames.UNREAL_EXTRA_CMD_ARGS,
             job_parameter_value="",
         )
-
+        # Write the .txt file using the original temp file logic
         extra_cmd_args_file = common.create_deadline_cloud_temp_file(
             file_prefix=OpenJobParameterNames.UNREAL_EXTRA_CMD_ARGS_FILE,
-            file_data=cmd_args_str,
+            file_data=merged_cmd_args,
             file_ext=".txt",
         )
+
         unfilled_parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
             job_parameter_values=unfilled_parameter_values,
             job_parameter_name=OpenJobParameterNames.UNREAL_EXTRA_CMD_ARGS_FILE,
@@ -1036,44 +1057,80 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         all_parameter_values = filled_parameter_values + unfilled_parameter_values
         return all_parameter_values
 
-    def _get_ue_cmd_args(self) -> list[str]:
-        cmd_args = common.get_in_process_executor_cmd_args()
+    def get_executor_cmd_args(self) -> str:
+        """
+        Returns the cleaned list of command line arguments from the executor settings and MRQ job.
+        """
 
+        cmd_args = common.get_in_process_executor_cmd_args()
         if self._mrq_job:
-            cmd_args.extend(common.get_mrq_job_cmd_args(self.mrq_job))
+            cmd_args.extend(common.get_mrq_job_cmd_args(self._mrq_job))
+
+        return " ".join(a for a in cmd_args)
+
+    def get_user_extra_cmd_args(self) -> str:
+        """
+        Returns the cleaned list of user-specified extra command line arguments (UNREAL_EXTRA_CMD_ARGS),
+        with any -execcmds arguments removed.
+        """
 
         extra_cmd_args_param = self._find_extra_parameter(
             parameter_name=OpenJobParameterNames.UNREAL_EXTRA_CMD_ARGS,
             parameter_type="STRING",
         )
-
-        if extra_cmd_args_param:
+        if extra_cmd_args_param and extra_cmd_args_param.value:
             extra_cmd_args = str(extra_cmd_args_param.value)
-            cleared_extra_cmds_args = re.sub(
-                pattern='(-execcmds="[^"]*")', repl="", string=extra_cmd_args, flags=re.IGNORECASE
-            )
-            cleared_extra_cmds_args = re.sub(
-                pattern="(-execcmds='[^']*')",
-                repl="",
-                string=cleared_extra_cmds_args,
-                flags=re.IGNORECASE,
-            )
+            return extra_cmd_args
+
+        return ""
+
+    @staticmethod
+    def clear_cmd_args(cmd_args: str) -> str:
+        """
+        Cleans the command line arguments by removing any -execcmds arguments.
+        This is useful to ensure that no unintended execution commands are passed.
+
+        :param cmd_args: The command line arguments as a string.
+        :return: Cleaned command line arguments.
+        """
+        cleared_cmd_args = re.sub(
+            pattern='(-execcmds="[^"]*")', repl="", string=cmd_args, flags=re.IGNORECASE
+        )
+        cleared_cmd_args = re.sub(
+            pattern="(-execcmds='[^']*')",
+            repl="",
+            string=cleared_cmd_args,
+            flags=re.IGNORECASE,
+        )
+
+        if cleared_cmd_args != cmd_args:
             logger.warning(
                 "Appearance of custom '-execcmds' argument on the Render node can cause unpredictable "
                 "issues. Argument '-execcmds' of Unreal Open Job's "
                 "Extra Command Line arguments will be ignored."
             )
 
-            if cleared_extra_cmds_args:
-                cmd_args.extend(cleared_extra_cmds_args.split(" "))
+        return cleared_cmd_args
 
-        # remove duplicates
-        cmd_args = list(set(cmd_args))
+    def get_user_extra_cmd_args_from_file(self, file_path: str) -> str:
+        """
+        Reads the given EXTRA_CMD_ARGS_FILE and returns the string as-is (stripped).
+        Returns an empty string if the file is missing or empty. Logs if file is empty or error reading.
+        """
 
-        # remove empty args
-        cmd_args = [a for a in cmd_args if a != ""]
-
-        return cmd_args
+        if not file_path or not os.path.isfile(file_path):
+            logger.info(f"EXTRA_CMD_ARGS_FILE '{file_path}' does not exist or is not specified.")
+            return ""
+        try:
+            with open(file_path, "r", encoding="utf8") as f:
+                extra_data = f.read()
+            if not extra_data.strip():
+                logger.info(f"EXTRA_CMD_ARGS_FILE '{file_path}' is empty.")
+                return ""
+            return extra_data.strip()
+        except Exception as e:
+            logger.error(f"Error reading EXTRA_CMD_ARGS_FILE '{file_path}': {e}")
+            return ""
 
     def _collect_mrq_job_dependencies(self) -> list[str]:
         """

--- a/test/deadline_cmd_utils_for_unreal/__init__.py
+++ b/test/deadline_cmd_utils_for_unreal/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/deadline_cmd_utils_for_unreal/test_cmd_utils.py
+++ b/test/deadline_cmd_utils_for_unreal/test_cmd_utils.py
@@ -1,0 +1,148 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+
+from deadline.unreal_cmd_utils import (
+    merge_cmd_args_with_priority,
+    parse_command_line,
+)
+
+
+# ──────────────────────────────────────────────────────────────
+# Tokens and flags: deduplication + higher‑priority override
+# ──────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "lower, higher, exp_tokens, exp_switches",
+    [
+        (
+            "MapA MapB -fullscreen -flag1",
+            "MapB MapC -Flag1 -novsync",
+            {"mapa", "mapb", "mapc"},
+            {"fullscreen", "flag1", "novsync"},
+        ),
+        (
+            "Token -DEBUG",
+            "token -debug -someOther",
+            {"token"},
+            {"debug", "someother"},
+        ),
+    ],
+)
+def test_merge_tokens_and_switches(lower, higher, exp_tokens, exp_switches):
+    """Ensure tokens and switches are case‑insensitively deduplicated,
+    and switches from the higher‑priority string win."""
+    merged = merge_cmd_args_with_priority(higher, lower)
+    tokens, switches, _ = parse_command_line(merged)
+
+    assert {t.lower() for t in tokens} == exp_tokens
+    assert {s.lower() for s in switches} == exp_switches
+
+
+# ──────────────────────────────────────────────────────────────
+# Standard key=value pairs: higher priority wins
+# ──────────────────────────────────────────────────────────────
+def test_merge_key_value_priority():
+    lower = "-Foo=lower -Bar=willLose"
+    higher = "-bar=Override -Baz=New"
+
+    _, _, params = parse_command_line(merge_cmd_args_with_priority(higher, lower))
+
+    assert params == {
+        "Foo": "lower",  # from lower‑priority string
+        "bar": "Override",  # overridden by higher‑priority string
+        "Baz": "New",
+    }
+
+
+# ──────────────────────────────────────────────────────────────
+# DPCVars: merge lists, higher‑priority CVar values override
+# ──────────────────────────────────────────────────────────────
+def test_merge_dpcvars():
+    lower = '-DPCVars="r.ShadowQuality=2,r.ViewDistanceScale 4"'
+    higher = '-DPCVars="p.FogDensity 0.3,r.ShadowQuality 4"'
+
+    _, _, params = parse_command_line(merge_cmd_args_with_priority(higher, lower))
+
+    # The order is preserved by first appearance; r.ShadowQuality taken from higher.
+    assert params["DPCVars"] == ("r.ShadowQuality=4," "r.ViewDistanceScale=4," "p.FogDensity=0.3")
+
+
+# ──────────────────────────────────────────────────────────────
+# ExecCmds: merge lists, duplicates removed by first word
+# ──────────────────────────────────────────────────────────────
+def test_merge_execcmds():
+    lower = '-ExecCmds="stat fps, toggledebugcamera"'
+    higher = '-ExecCmds="stat fps, r.SetNearClipPlane 1"'
+
+    _, _, params = parse_command_line(merge_cmd_args_with_priority(higher, lower))
+
+    assert params["ExecCmds"] == "stat fps,toggledebugcamera,r.SetNearClipPlane 1"
+
+
+# ──────────────────────────────────────────────────────────────
+# Auto‑quoting for values containing spaces or commas
+# ──────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "arg_string, expected_fragment",
+    [
+        ('-Option="Has Spaces"', '-Option="Has Spaces"'),
+        ("-Option=comma,separated", '-Option="comma,separated"'),
+        ('-Option="both , things"', '-Option="both , things"'),
+    ],
+)
+def test_quote_if_needed(arg_string, expected_fragment):
+    merged = merge_cmd_args_with_priority(arg_string, "")
+    assert expected_fragment in merged
+
+
+# ──────────────────────────────────────────────────────────────
+# None and/or empty strings as inputs
+# ──────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "higher, lower, exp_tokens, exp_switches, exp_params",
+    [
+        (None, None, set(), set(), {}),
+        ("", "", set(), set(), {}),
+        (None, "MapA -Flag", {"mapa"}, {"flag"}, {}),
+        ("MapA -Flag", None, {"mapa"}, {"flag"}, {}),
+        ("", "-Opt=Val", set(), set(), {"Opt": "Val"}),
+    ],
+)
+def test_none_or_empty_inputs(higher, lower, exp_tokens, exp_switches, exp_params):
+    """Both None and empty strings should be treated as empty command lines."""
+    merged = merge_cmd_args_with_priority(higher, lower)
+    tokens, switches, params = parse_command_line(merged)
+
+    assert {t.lower() for t in tokens} == exp_tokens
+    assert {s.lower() for s in switches} == exp_switches
+    assert params == exp_params
+
+
+# ──────────────────────────────────────────────────────────────
+# Empty value in lower‑priority string overridden by non‑empty
+# ──────────────────────────────────────────────────────────────
+def test_empty_overridden_by_nonempty():
+    merged = merge_cmd_args_with_priority("-Setting=foo", "-Setting=")
+    _, switches, params = parse_command_line(merged)
+
+    assert "Setting" not in switches
+    assert params["Setting"] == "foo"  # value comes from higher string
+
+
+# ──────────────────────────────────────────────────────────────
+# Non‑empty value overridden by empty in higher string
+# ──────────────────────────────────────────────────────────────
+def test_nonempty_overridden_by_empty():
+    merged = merge_cmd_args_with_priority("-Setting=", "-Setting=bar")
+    _, switches, params = parse_command_line(merged)
+
+    assert "Setting" not in switches
+    assert params["Setting"] == ""
+
+
+# ──────────────────────────────────────────────────────────────
+# Both inputs empty or None → merged result is empty string
+# ──────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("higher, lower", [("", ""), (None, ""), ("", None), (None, None)])
+def test_both_inputs_empty_result_empty_string(higher, lower):
+    assert merge_cmd_args_with_priority(higher, lower) == ""


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Unreal OpenJob has two main parameters for the Unreal Engine launch arguments: ExtraCmdArgs and ExtraCmdArgsFile. On the submitter side value from ExtraCmdArgs merged to the ExtraCmdArgsFile during the submission and cleared. 

From the User perspective its not clear why final Job bundle has empty ExtraCmdArgs parameter. 
From the Developer perspective it would be useful to quickly change or add new args to ExtraCmdArgs to the already built OpenJob bundle and submit again for debugging goals.

### What was the solution? (How)

Change Extra Commandline Arguments logic to improve the total UX:
1. Does not clear the value of ExtraCmdArgs after submitting, leave it as is
2. If ExtraCmdArgsFile parameter not set, lead to default business logic: put here predefined arguments + user input from ExtraCmdArgs
3. If ExtraCmdArgsFile parameter is set and pointing to the valid file, update its content with the predefined arguments + value of user input
4. On the Adaptor side execute the same merge - case when ExtraCmdArgs was updated after the Job bundle was built

### What is the impact of this change?

Better UX, more usecases for developers unlocked

### How was this change tested?

Tested on different use cases:
1. Empty ExtraCmdArgs, empty ExtraCmdArgsFile -> predefind arguments
2. Empty ExtraCmdArgs, ExtraCmdArgsFile is set -> predefind arguments merged with file data
3. ExtraCmdArgs is set, empty ExtraCmdArgsFile  -> predefined arguments merged with user input
4. ExtraCmdArgs is set, ExtraCmdArgsFile is set -> predefined arguments + user input + file data merged

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

Yes

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*