### PR TITLE
feat: Using precache_clients in background thread for faster initialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.49,< 0.51",
+    "deadline >= 0.51,< 0.52",
     "openjd-adaptor-runtime >= 0.8.1,< 0.10",
     "openjd-model >= 0.8, < 0.9",
     "p4python == 2025.1.2767466",

--- a/src/deadline/unreal_submitter/submitter.py
+++ b/src/deadline/unreal_submitter/submitter.py
@@ -132,6 +132,23 @@ class UnrealSubmitter:
                 submit_task.enter_progress_frame(new_progress - last_progress, self.submit_message)
                 last_progress = new_progress
 
+    def show_confirmation_dialog(self, message: str, default_prompt_response: bool):
+        """
+        Show message dialog in the Unreal Editor UI
+
+        :param message: Message to display
+        :type message: str
+        :param default_prompt_response: Default response
+        :type default_prompt_response: bool
+        """
+
+        if self._silent_mode:
+            return default_prompt_response
+
+        # TODO handle confirmation
+
+        return True
+
     def _start_submit(self, job_bundle_path):
         """
         Start the OpenJob submission
@@ -139,6 +156,7 @@ class UnrealSubmitter:
         :param job_bundle_path: Path of the Job bundle to submit
         :type job_bundle_path: str
         """
+
         try:
             job_id = create_job_from_job_bundle(
                 job_bundle_dir=job_bundle_path,
@@ -147,6 +165,8 @@ class UnrealSubmitter:
                     upload_metadata
                 ),
                 create_job_result_callback=lambda: self._create_job_result(),
+                from_gui=True,
+                interactive_confirmation_callback=self.show_confirmation_dialog,
             )
             if job_id:
                 logger.info(f"Job creation result: {job_id}")

--- a/src/unreal_plugin/Content/Python/init_unreal.py
+++ b/src/unreal_plugin/Content/Python/init_unreal.py
@@ -108,6 +108,16 @@ if remote_execution != "True":
 
     logger.info(f'DEADLINE CLOUD PATH: {os.getenv("DEADLINE_CLOUD")}')
 
+    from deadline.client.api import precache_clients
+
+    def init_s3_client():
+        logger.info("INITIALIZING S3 CLIENT")
+        precache_clients()
+        logger.info("DONE INITIALIZING S3 CLIENT")
+
+    import threading
+
+    threading.Thread(target=init_s3_client, daemon=True, name="S3ClientInit").start()
     # These unused imports are REQUIRED!!!
     # Unreal Engine loads any init_unreal.py it finds in its search paths.
     # These imports finish the setup for the plugin.

--- a/test/deadline_submitter_for_unreal/unit/test_submitter.py
+++ b/test/deadline_submitter_for_unreal/unit/test_submitter.py
@@ -18,6 +18,8 @@ def create_job_from_bundle_mock(
     hashing_progress_callback=None,
     upload_progress_callback=None,
     create_job_result_callback=None,
+    from_gui=False,
+    interactive_confirmation_callback=None,
 ):
     time.sleep(0.1)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The new version of deadline_cloud exposes a new precache_clients api to initialize the s3 client which will be used for uploads during job submission.

Recent changes in deadline_cloud to require confirmation of uploads of assets outside the asset bundle which haven't been declared as known asset paths were failing job submission.

### What was the solution? (How)
- Pin to the new deadline_cloud minor version
- Use the new precache_clients option
- Temporarily auto accept asset path uploads until we have a dialog in place (Maintaining the previous behavior)

### What is the impact of this change?
Faster initial and subsequent job submissions

### How was this change tested?
hatch run test
hatch run e2e
Manual job submission

### Have you run a render job successfully with these changes?
Yes

### Was this change documented?
Yes

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*