### PR TITLE
fix: Autodetect Project Plugins

### DIFF
--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -416,42 +416,44 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         return asset_references
 
     @staticmethod
+    def get_plugins(path: str):
+        unreal_plugins: list[dict] = []
+        pattern = os.path.join(path, "**", "*.uplugin")
+
+        for uplugin in glob.iglob(pattern, recursive=True):
+            real_path = Path(uplugin).resolve(strict=True)
+            try:
+                with real_path.open(encoding="utf-8") as f:
+                    plugin_data = json.load(f)
+
+                unreal_plugins.append(
+                    {
+                        "name": real_path.stem,
+                        "enabled_by_default": plugin_data.get("EnabledByDefault", True),
+                        "folder": Path(uplugin).parent.name,
+                    }
+                )
+            except (OSError, json.JSONDecodeError):
+                continue
+
+        return unreal_plugins
+
+    @staticmethod
+    def parse_uproject(path: str) -> dict[str, bool]:
+        with open(path, encoding="utf‑8") as f:
+            data = json.load(f)
+
+        return {e["Name"]: e.get("Enabled", True) for e in data.get("Plugins", [])}
+
+    @staticmethod
     def get_plugins_references() -> AssetReferences:
-        def get_plugins(path):
-            unreal_plugins: list[dict] = []
-            pattern = os.path.join(path, "**", "*.uplugin")
-
-            for uplugin in glob.iglob(pattern, recursive=True):
-                real_path = Path(uplugin).resolve(strict=True)
-                try:
-                    with real_path.open(encoding="utf-8") as f:
-                        plugin_data = json.load(f)
-
-                    unreal_plugins.append(
-                        {
-                            "name": real_path.stem,
-                            "enabled_by_default": plugin_data.get("EnabledByDefault", True),
-                            "folder": Path(uplugin).parent.name,
-                        }
-                    )
-                except (OSError, json.JSONDecodeError):
-                    continue
-
-            return unreal_plugins
-
-        def parse_uproject(path: str) -> dict[str, bool]:
-            with open(path, encoding="utf‑8") as f:
-                data = json.load(f)
-
-            return {e["Name"]: e.get("Enabled", True) for e in data.get("Plugins", [])}
-
         project_path = unreal.Paths.get_project_file_path()
-        project_plugins_info = parse_uproject(project_path)
+        project_plugins_info = UnrealOpenJob.parse_uproject(project_path)
 
         result = AssetReferences()
         plugins_dir = unreal.Paths.project_plugins_dir()
         plugins_dir_full = unreal.Paths.convert_relative_path_to_full(plugins_dir)
-        plugins = get_plugins(plugins_dir_full)
+        plugins = UnrealOpenJob.get_plugins(plugins_dir_full)
 
         for plugin in plugins:
             if plugin["name"] == "UnrealDeadlineCloudService":
@@ -460,7 +462,7 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             is_enable = project_plugins_info.get(plugin["name"], plugin["enabled_by_default"])
 
             if is_enable:
-                result.input_directories.add(plugins_dir_full + plugin["folder"])
+                result.input_directories.add(os.path.join(plugins_dir_full, plugin["folder"]))
 
         return result
 

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -10,7 +10,8 @@ from enum import IntEnum
 from typing import Any, Optional
 from collections import OrderedDict
 from dataclasses import dataclass, asdict
-
+from pathlib import Path
+import glob
 from openjd.model import parse_model
 from openjd.model.v2023_09 import JobTemplate, ExtensionName
 
@@ -51,7 +52,6 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job_step_host_require
 
 from deadline.unreal_logger import get_logger
 from deadline.unreal_perforce_utils import perforce, unreal_source_control
-
 
 logger = get_logger()
 
@@ -414,6 +414,55 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             asset_references = asset_references.union(environment.get_asset_references())
 
         return asset_references
+
+    @staticmethod
+    def get_plugins_references() -> AssetReferences:
+        def get_plugins(path):
+            unreal_plugins: list[dict] = []
+            pattern = os.path.join(path, "**", "*.uplugin")
+
+            for uplugin in glob.iglob(pattern, recursive=True):
+                real_path = Path(uplugin).resolve(strict=True)
+                try:
+                    with real_path.open(encoding="utf-8") as f:
+                        plugin_data = json.load(f)
+
+                    unreal_plugins.append(
+                        {
+                            "name": real_path.stem,
+                            "enabled_by_default": plugin_data.get("EnabledByDefault", True),
+                            "folder": Path(uplugin).parent.name,
+                        }
+                    )
+                except (OSError, json.JSONDecodeError):
+                    continue
+
+            return unreal_plugins
+
+        def parse_uproject(path: str) -> dict[str, bool]:
+            with open(path, encoding="utf‑8") as f:
+                data = json.load(f)
+
+            return {e["Name"]: e.get("Enabled", True) for e in data.get("Plugins", [])}
+
+        project_path = unreal.Paths.get_project_file_path()
+        project_plugins_info = parse_uproject(project_path)
+
+        result = AssetReferences()
+        plugins_dir = unreal.Paths.project_plugins_dir()
+        plugins_dir_full = unreal.Paths.convert_relative_path_to_full(plugins_dir)
+        plugins = get_plugins(plugins_dir_full)
+
+        for plugin in plugins:
+            if plugin["name"] == "UnrealDeadlineCloudService":
+                continue
+
+            is_enable = project_plugins_info.get(plugin["name"], plugin["enabled_by_default"])
+
+            if is_enable:
+                result.input_directories.add(plugins_dir_full + plugin["folder"])
+
+        return result
 
     def create_job_bundle(self):
         """
@@ -1325,6 +1374,9 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             asset_references.input_directories.update(
                 RenderUnrealOpenJob.get_required_project_directories()
             )
+            plugins = UnrealOpenJob.get_plugins_references()
+            if plugins:
+                asset_references.input_directories.update(plugins.input_directories)
 
         # add attachments from preset overrides
         if self.mrq_job:

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
@@ -581,6 +581,9 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
         new_job.preset_overrides.job_attachments.input_files.auto_detected = (
             unreal.DeadlineCloudFileAttachmentsArray()
         )
+        new_job.preset_overrides.job_attachments.input_directories.auto_detected_directories = (
+            unreal.DeadlineCloudDirectoryAttachmentsArray()
+        )
 
         _, manifest_path = unreal.MoviePipelineEditorLibrary.save_queue_to_manifest_file(new_queue)
         serialized_manifest = unreal.MoviePipelineEditorLibrary.convert_manifest_file_to_string(

--- a/src/unreal_plugin/Content/Python/job_library.py
+++ b/src/unreal_plugin/Content/Python/job_library.py
@@ -10,6 +10,7 @@ from deadline.unreal_submitter.unreal_dependency_collector import (
     DependencyFilters,
 )
 
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job import UnrealOpenJob
 
 logger = get_logger()
 
@@ -47,6 +48,10 @@ class DeadlineCloudJobBundleLibraryImplementation(unreal.DeadlineCloudJobBundleL
         unreal_dependencies = list(set(unreal_dependencies))
 
         return [common.os_path_from_unreal_path(d, with_ext=True) for d in unreal_dependencies]
+
+    @unreal.ufunction(override=True)
+    def get_plugins_dependencies(self):
+        return [d for d in UnrealOpenJob.get_plugins_references().input_directories]
 
     @unreal.ufunction(override=True)
     def get_cpu_architectures(self):

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -142,14 +142,8 @@ FDeadlineCloudJobParametersArray UMoviePipelineDeadlineCloudExecutorJob::GetPara
 
 void UMoviePipelineDeadlineCloudExecutorJob::UpdateAttachmentFields()
 {
-	if (PresetOverrides.JobAttachments.InputFiles.bShowAutoDetected)
-	{
-		this->CollectDependencies();
-	}
-	else
-	{
-		PresetOverrides.JobAttachments.InputFiles.AutoDetected.Paths.Empty();
-	}
+	UpdateInputFilesProperty();
+	UpdateInputDirectoriesProperty();
 }
 
 void UMoviePipelineDeadlineCloudExecutorJob::JobPresetChanged()
@@ -233,6 +227,17 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 	return true;
 }
 
+ bool UMoviePipelineDeadlineCloudExecutorJob::IsAssetDirectoryValid(const FString& DirectoryPath)
+ {
+	 // Check directory on disk
+	 if (!FPaths::DirectoryExists(DirectoryPath))
+	 {
+		 UE_LOG(LogTemp, Warning, TEXT("Dependency directory missing: %s"), *DirectoryPath);
+		 return false;
+	 }
+	 return true;
+ }
+
 void UMoviePipelineDeadlineCloudExecutorJob::CollectDependencies()
 {
 
@@ -270,7 +275,36 @@ void UMoviePipelineDeadlineCloudExecutorJob::CollectDependencies()
 			}
 
 		});
+}
 
+void UMoviePipelineDeadlineCloudExecutorJob::CollectPluginsDependencies()
+{
+	PresetOverrides.JobAttachments.InputDirectories.AutoDetectedDirectories.Paths.Empty();
+	AsyncTask(ENamedThreads::GameThread, [this]()
+		{
+			auto& Plugins = PresetOverrides.JobAttachments.InputFiles.AutoDetected.Paths;
+			TArray<FString> Paths;
+			if (auto Library = UDeadlineCloudJobBundleLibrary::Get())
+			{
+				Paths = Library->GetPluginsDependencies();
+				for (const auto& Path : Paths)
+				{
+					if (!IsAssetDirectoryValid(Path))
+					{
+						continue;
+					}
+					FDirectoryPath Item;
+					Item.Path = Path;
+					PresetOverrides.JobAttachments.InputDirectories.AutoDetectedDirectories.Paths.Add(Item);
+				}
+
+				UE_LOG(LogTemp, Log, TEXT("Added %d dependency directories:"), Plugins.Num());
+			}
+			else
+			{
+				UE_LOG(LogTemp, Error, TEXT("Error get DeadlineCloudJobBundleLibrary"));
+			}
+		});
 }
 
 void UMoviePipelineDeadlineCloudExecutorJob::UpdateInputFilesProperty()
@@ -285,6 +319,18 @@ void UMoviePipelineDeadlineCloudExecutorJob::UpdateInputFilesProperty()
 	}
 }
 
+void UMoviePipelineDeadlineCloudExecutorJob::UpdateInputDirectoriesProperty()
+{
+	if (PresetOverrides.JobAttachments.InputDirectories.bShowAutoDetected)
+	{
+		CollectPluginsDependencies();
+	}
+	else
+	{
+		PresetOverrides.JobAttachments.InputDirectories.AutoDetectedDirectories.Paths.Empty();
+	}
+}
+
 void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeChainProperty(FPropertyChangedChainEvent& PropertyChangedEvent)
 {
 	Super::PostEditChangeChainProperty(PropertyChangedEvent);
@@ -292,13 +338,17 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeChainProperty(FProper
 	if (PropertyChangedEvent.GetPropertyName() == "bShowAutoDetected")
 	{
 		static const FName InputFilesName = GET_MEMBER_NAME_CHECKED(FDeadlineCloudAttachmentsStruct, InputFiles);
-		// static const FName InputDirectoriesName = GET_MEMBER_NAME_CHECKED(FDeadlineCloudAttachmentsStruct, InputDirectories);
+		static const FName InputDirectoriesName = GET_MEMBER_NAME_CHECKED(FDeadlineCloudAttachmentsStruct, InputDirectories);
 		// static const FName OutputDirectoriesName = GET_MEMBER_NAME_CHECKED(FDeadlineCloudAttachmentsStruct, OutputDirectories);
 
 		const FProperty* Property = PropertyChangedEvent.PropertyChain.GetActiveNode()->GetPrevNode()->GetValue();
 		if (Property->GetFName() == InputFilesName)
 		{
 			UpdateInputFilesProperty();
+		}
+		if (Property->GetFName() == InputDirectoriesName)
+		{
+			UpdateInputDirectoriesProperty();
 		}
 		return;
 	}

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
@@ -106,12 +106,15 @@ public:
 
     void JobPresetChanged();
     static bool IsAssetFileValid(const FString& FilePath);
+	static bool IsAssetDirectoryValid(const FString& DirectoryPath);
 
 protected:
 
 #if WITH_EDITOR
     void CollectDependencies();
+	void CollectPluginsDependencies();
     void UpdateInputFilesProperty();
+    void UpdateInputDirectoriesProperty();
 #endif
 
     /**

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudJobBundleLibrary.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudJobBundleLibrary.h
@@ -26,6 +26,13 @@ public:
     UFUNCTION(BlueprintImplementableEvent)
     TArray<FString> GetJobDependencies(const UMoviePipelineDeadlineCloudExecutorJob *MrqJob);
 
+	 /**
+	 * Collect list of required plugins for the job
+	 * @return List of the plugins dependencies
+     */
+	UFUNCTION(BlueprintImplementableEvent)
+    TArray<FString> GetPluginsDependencies();
+
 	/** @return list of CPU architectures */
 	UFUNCTION(BlueprintImplementableEvent)
 	TArray<FString> GetCpuArchitectures();

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
@@ -2,7 +2,10 @@
 
 import sys
 import pytest
-from unittest.mock import patch, Mock, MagicMock
+import os
+import json
+from unittest.mock import patch, mock_open, Mock, MagicMock
+from pathlib import Path
 from openjd.model import parse_model
 from openjd.model.v2023_09 import (
     JobTemplate,
@@ -504,3 +507,146 @@ class TestRenderUnrealOpenJob:
         ):
             with pytest.raises(exceptions.ProjectIsNotUnderWorkspaceError):
                 RenderUnrealOpenJob._get_project_path_relative_to_workspace_root(workspace_root)
+
+    def test_get_plugins(self, monkeypatch):
+        fake_files = [
+            os.path.join("/Game/Plugins/PluginA", "PluginA.uplugin"),
+            os.path.join("/Game/Plugins/PluginB", "PluginB.uplugin"),
+            os.path.join("/Game/Plugins/Broken", "Broken.uplugin"),
+        ]
+        monkeypatch.setattr("glob.iglob", lambda pattern, recursive=True: fake_files)
+
+        monkeypatch.setattr(Path, "resolve", lambda self, strict=True: self, raising=False)
+
+        class _DummyFile:
+            def __init__(self, path):
+                self.name = path
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        monkeypatch.setattr(
+            Path, "open", lambda self, *a, **kw: _DummyFile(str(self)), raising=False
+        )
+
+        def _fake_json_load(fh):
+            if "Broken" in fh.name:
+                raise ValueError("corrupted json")
+            return {"EnabledByDefault": False} if "PluginA" in fh.name else {}
+
+        target_json_path = "deadline.unreal_submitter.unreal_open_job.unreal_open_job.json"
+        monkeypatch.setattr(f"{target_json_path}.load", _fake_json_load, raising=False)
+        monkeypatch.setattr(f"{target_json_path}.JSONDecodeError", ValueError, raising=False)
+
+        plugins = UnrealOpenJob.get_plugins("/Game")
+
+        assert sorted(p["name"] for p in plugins) == ["PluginA", "PluginB"]
+
+        expected = {
+            "PluginA": dict(enabled_by_default=False, folder="PluginA"),
+            "PluginB": dict(enabled_by_default=True, folder="PluginB"),
+        }
+        for p in plugins:
+            e = expected[p["name"]]
+            assert p["enabled_by_default"] == e["enabled_by_default"]
+            assert p["folder"] == e["folder"]
+
+    def test_parse_uproject(self, monkeypatch):
+        data = {
+            "Plugins": [
+                {"Name": "PluginA", "Enabled": False},
+                {"Name": "PluginB", "Enabled": True},
+                {"Name": "PluginC"},
+            ]
+        }
+        json_text = json.dumps(data)
+
+        monkeypatch.setattr(
+            "builtins.open",
+            mock_open(read_data=json_text),
+        )
+
+        result = UnrealOpenJob.parse_uproject("any/path/Project.uproject")
+
+        assert result == {"PluginA": False, "PluginB": True, "PluginC": True}
+
+    PROJECT_ROOT = "C:/Project"
+    PLUGINS_REL = "Plugins/"
+
+    @pytest.mark.parametrize(
+        "uproject_plugins, plugins_list, expected_dirs",
+        [
+            (
+                {"PluginA": True, "PluginB": False},  # parse_uproject
+                [  # get_plugins
+                    {"name": "PluginA", "enabled_by_default": True, "folder": "PluginA"},
+                    {"name": "PluginB", "enabled_by_default": True, "folder": "PluginB"},
+                    {"name": "PluginC", "enabled_by_default": True, "folder": "PluginC"},
+                    {
+                        "name": "UnrealDeadlineCloudService",
+                        "enabled_by_default": True,
+                        "folder": "UDCS",
+                    },
+                ],
+                {  # expected_dirs
+                    f"{PROJECT_ROOT}/Plugins/PluginA",
+                    f"{PROJECT_ROOT}/Plugins/PluginC",
+                },
+            ),
+            (
+                {"PluginA": False, "PluginB": False},  # parse_uproject
+                [  # get_plugins
+                    {"name": "PluginA", "enabled_by_default": True, "folder": "PluginA"},
+                    {"name": "PluginB", "enabled_by_default": True, "folder": "PluginB"},
+                ],
+                set(),  # expected_dirs
+            ),
+            (
+                {"PluginD": True},  # parse_uproject
+                [  # get_plugins
+                    {"name": "PluginD", "enabled_by_default": False, "folder": "PluginD"},
+                ],
+                {f"{PROJECT_ROOT}/Plugins/PluginD"},  # expected_dirs
+            ),
+            (
+                {},  # parse_uproject
+                [  # get_plugins
+                    {
+                        "name": "UnrealDeadlineCloudService",
+                        "enabled_by_default": True,
+                        "folder": "UDCS",
+                    },
+                ],
+                set(),  # expected_dirs
+            ),
+        ],
+    )
+    def test_get_plugins_references(
+        self, monkeypatch, uproject_plugins, plugins_list, expected_dirs
+    ):
+        project_root = "C:/Project"
+        plugins_rel = "Plugins/"
+
+        fake_paths = MagicMock()
+        fake_paths.get_project_file_path.return_value = f"{project_root}/MyGame.uproject"
+        fake_paths.project_plugins_dir.return_value = plugins_rel
+        fake_paths.convert_relative_path_to_full.return_value = f"{project_root}/{plugins_rel}"
+
+        monkeypatch.setattr(
+            "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.Paths", fake_paths
+        )
+
+        monkeypatch.setattr(
+            UnrealOpenJob,
+            "parse_uproject",
+            lambda _path: uproject_plugins,
+        )
+
+        monkeypatch.setattr(UnrealOpenJob, "get_plugins", lambda _dir: plugins_list)
+
+        refs: AssetReferences = UnrealOpenJob.get_plugins_references()
+
+        assert refs.input_directories == expected_dirs


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Need to implement Project plugins autodetection system similar to the Project Assets autodetection system.

### What was the solution? (How)

Parse .uproject and .uplugins files to build the Plugins list that used in this Project

### What is the impact of this change?

List of the Project plugins automatically attached to asset references of the OpenJob.

### How was this change tested?

Submit the simple Render OpenJob on the project with some plugins enabled. Autodetected directories must contain these plugins

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

Yes, docstrings

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*