### PR TITLE
fix: Switching to use openjd_redacted_env for potentially sensitive e…

### DIFF
--- a/docs/source/docs_usage/p4_credentials_management.rst
+++ b/docs/source/docs_usage/p4_credentials_management.rst
@@ -114,14 +114,6 @@ which is referencing to ``src/unreal_plugin/Content/Python/openjd_templates/p4/p
     :language: yaml
     :linenos:
 
-.. warning:: This environment apply P4 credentials from AWS Secretes Manager by printing them to the Job log
-   with prefix ``openjd_env:``. Please, see `OpenJD Environment`_ documentation about sharing new
-   environment variables across actions and other environments in runtime.
-
-   **Consider adding a CloudWatch data protection policy to your account if you'll be echoing***
-   **sensitive information. For example, this will apply a global policy to your CloudWatch logs**
-   **which suppresses "openjd_env": lines which appear to be setting environment variables:**
-
    .. literalinclude:: ../resources/logs_policy_example.sh
     :language: sh
     :linenos:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "deadline >= 0.51,< 0.52",
     "openjd-adaptor-runtime >= 0.8.1,< 0.10",
-    "openjd-model >= 0.8, < 0.9",
+    "openjd-model >= 0.8.1, < 0.9",
     "p4python == 2025.1.2767466",
     "psutil >= 5.9.0"
 ]

--- a/src/deadline/unreal_perforce_utils/app.py
+++ b/src/deadline/unreal_perforce_utils/app.py
@@ -399,20 +399,8 @@ def apply_perforce_secrets() -> None:
     - P4PASSWD
     - P4PORT
 
-    .. warning::
-       Be aware that by default environment variables are persisted by printing to stdout
-       (See the openjd_env: line at the end of this method). Consider adding a CloudWatch data
-       protection policy to prevent potentially sensitive information from being echoed to your logs.
-       (See Custom data identifiers - https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL-custom-data-identifiers.html)
-
     """
 
-    logger.warning(
-        "Be aware that by default environment variables are persisted by printing to stdout."
-        "Consider adding a CloudWatch data protection policy to prevent potentially sensitive "
-        "information from being echoed to your logs. (See Custom data identifiers - "
-        "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL-custom-data-identifiers.html)"
-    )
     logger.info("Applying perforce secrets from Boto3 SecretsManager ...")
 
     p4_info = secret_manager.get_perforce_info()
@@ -422,4 +410,4 @@ def apply_perforce_secrets() -> None:
 
     for env_name, env_value in p4_info.items():
         # For some reason, adaptor doesn't show logger records, need to R&D
-        print(f"openjd_env: {env_name}={env_value}")
+        print(f"openjd_redacted_env: {env_name}={env_value}")

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from dataclasses import dataclass, asdict
 
 from openjd.model import parse_model
-from openjd.model.v2023_09 import JobTemplate
+from openjd.model.v2023_09 import JobTemplate, ExtensionName
 
 from deadline.client.job_bundle.submission import AssetReferences
 from deadline.client.job_bundle import deadline_yaml_dump, create_job_history_bundle_dir
@@ -241,6 +241,7 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         template_json = json.loads(template.json(exclude_none=True))
         ordered_keys = [
             "specificationVersion",
+            "extensions",
             "name",
             "parameterDefinitions",
             "jobEnvironments",
@@ -377,10 +378,20 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             "steps": [s.build_template() for s in self._steps],
         }
 
+        extension_list = self.get_template_object().get("extensions")
+
+        if extension_list:
+            template_dict["extensions"] = extension_list
+
         if self._environments:
             template_dict["jobEnvironments"] = [e.build_template() for e in self._environments]
 
-        job_template = parse_model(model=self.template_class, obj=template_dict)
+        # Use all available extension names from the ExtensionName enum
+        supported_extensions = [extension.value for extension in ExtensionName]
+
+        job_template = parse_model(
+            model=self.template_class, obj=template_dict, supported_extensions=supported_extensions
+        )
         return job_template
 
     def get_asset_references(self) -> AssetReferences:

--- a/src/unreal_plugin/Content/Python/openjd_templates/custom/custom_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/custom/custom_job.yml
@@ -1,4 +1,6 @@
 specificationVersion: jobtemplate-2023-09
+extensions:
+  - REDACTED_ENV_VARS
 name: CustomJob
 parameterDefinitions:
 - name: ProjectFilePath

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
@@ -1,4 +1,6 @@
 specificationVersion: jobtemplate-2023-09
+extensions:
+  - REDACTED_ENV_VARS
 name: RenderJob
 parameterDefinitions:
 - name: ProjectRelativePath

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
@@ -1,4 +1,6 @@
 specificationVersion: jobtemplate-2023-09
+extensions:
+  - REDACTED_ENV_VARS
 name: RenderJob
 parameterDefinitions:
 - name: ProjectFilePath

--- a/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_job.yml
@@ -1,4 +1,6 @@
 specificationVersion: jobtemplate-2023-09
+extensions:
+  - REDACTED_ENV_VARS
 name: RenderJob
 parameterDefinitions:
 - name: ProjectRelativePath

--- a/test/deadline_perforce_utils_for_unreal/test_app.py
+++ b/test/deadline_perforce_utils_for_unreal/test_app.py
@@ -67,7 +67,11 @@ class TestUnrealP4UtilsApp:
         [
             (
                 {"P4PORT": "port", "P4USER": "user", "P4PASSWD": "pass"},
-                ["openjd_env: P4PORT=port", "openjd_env: P4USER=user", "openjd_env: P4PASSWD=pass"],
+                [
+                    "openjd_redacted_env: P4PORT=port",
+                    "openjd_redacted_env: P4USER=user",
+                    "openjd_redacted_env: P4PASSWD=pass",
+                ],
             ),
             ({}, []),
         ],

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
@@ -15,6 +15,7 @@ from openjd.model.v2023_09 import (
     EnvironmentVariableValueString,
     CancelationMethodNotifyThenTerminate,
     CancelationMode,
+    ExtensionName,
 )
 
 from deadline.client.job_bundle.submission import AssetReferences
@@ -343,6 +344,44 @@ class TestUnrealOpenJob:
         # THEN
         assert isinstance(serialized, dict)
         assert list(serialized.keys()) == expected_keys
+
+    @pytest.mark.parametrize(
+        "steps, environments, expected_keys",
+        [
+            (
+                [fixtures.f_step_template_default()],
+                [fixtures.f_environment_template_default()],
+                [
+                    "specificationVersion",
+                    "extensions",
+                    "name",
+                    "parameterDefinitions",
+                    "jobEnvironments",
+                    "steps",
+                ],
+            ),
+        ],
+    )
+    def test_serialize_template_extension(self, steps, environments, expected_keys):
+        # GIVEN
+        extension_list = ["REDACTED_ENV_VARS"]
+        job_template_dict = fixtures.f_job_template_default()
+        job_template_dict["extensions"] = extension_list
+        job_template_dict["steps"] = steps
+        job_template_dict["jobEnvironments"] = environments
+
+        supported_extensions = [extension.value for extension in ExtensionName]
+        job_template = parse_model(
+            model=JobTemplate, obj=job_template_dict, supported_extensions=supported_extensions
+        )
+
+        # WHEN
+        serialized = UnrealOpenJob.serialize_template(job_template)
+
+        # THEN
+        assert isinstance(serialized, dict)
+        assert list(serialized.keys()) == expected_keys
+        assert serialized["extensions"] == extension_list
 
     @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The perforce helper credentials utility relied on OpenJD's openjd_env token to set P4 credentials in environment variables which also wrote the credentials to session logs.

### What was the solution? (How)
With support for the new openjd_redacted_env token fully deployed in Deadline Cloud we can switch to using openjd_redacted_env

### What is the impact of this change?
Customers are less likely to inadvertently write their perforce credentials to logs which may be shared with users not intended to have access to their perforce server.

### How was this change tested?
All existing tests pass
New tests pass
Ran a P4 render job and observed in the session logs that the environment variables were masked:

```
2025/08/01 19:30:29+00:00 Running command "C:\Program Files\Python312\Scripts\unreal-engine-p4-utils.EXE" apply_perforce_secrets
2025/08/01 19:30:29+00:00 Command started as pid: 1244
2025/08/01 19:30:29+00:00 Output:
2025/08/01 19:30:29+00:00 openjd_redacted_env: P4PASSWD=********
2025/08/01 19:30:29+00:00 openjd_redacted_env: P4USER=********
2025/08/01 19:30:29+00:00 openjd_redacted_env: P4PORT=********
2025/08/01 19:30:29+00:00 Process pid 1244 exited with code: 0 (unsigned) / 0x0 (hex)
```

### Have you run a render job successfully with these changes?
Yes, see above

### Was this change documented?
Docs have been updated to remove NLA warnings

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*