### PR TITLE
feat: Persistent Data Asset

### DIFF
--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -621,8 +621,12 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             and self._mrq_job.job_template_overrides is not None
             and self._mrq_job.job_template_overrides.parameters
         ):
-            for p in self._mrq_job.job_template_overrides.parameters:
-                param = self._find_extra_parameter(p.name, p.type.name)
+            extra_params_override = [
+                UnrealOpenJobParameterDefinition.from_unreal_param_definition(p)
+                for p in self._mrq_job.job_template_overrides.parameters
+            ]
+            for p in extra_params_override:
+                param = self._find_extra_parameter(p.name, p.type)
                 if param:
                     param.value = p.value
 

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -621,10 +621,10 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             and self._mrq_job.job_template_overrides is not None
             and self._mrq_job.job_template_overrides.parameters
         ):
-            self._extra_parameters = [
-                UnrealOpenJobParameterDefinition.from_unreal_param_definition(p)
-                for p in self._mrq_job.job_template_overrides.parameters
-            ]
+            for p in self._mrq_job.job_template_overrides.parameters:
+                param = self._find_extra_parameter(p.name, p.type.name)
+                if param:
+                    param.value = p.value
 
         if (
             self._mrq_job is not None

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
@@ -480,7 +480,7 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
                 f"must be provided in extra parameters or template"
             )
 
-        chunk_size = chunk_size_parameter.value
+        chunk_size = int(chunk_size_parameter.value)
         if chunk_size <= 0:
             chunk_size = 1  # by default 1 chunk consist of 1 shot
 

--- a/src/unreal_plugin/Content/OpenJD_DataAssets/Default/OpenJD_Default_Environment.uasset
+++ b/src/unreal_plugin/Content/OpenJD_DataAssets/Default/OpenJD_Default_Environment.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bef08bff032fc7c7c1520c2e80408c6aeb6671dee0f82cc178038ebaa60e9ffa
-size 2338
+oid sha256:b89cbc364fa69614fa70eb74c53e0dc8148fe4ec8970f4a58e79e56063ef0020
+size 2298

--- a/src/unreal_plugin/Content/OpenJD_DataAssets/Default/OpenJD_Default_Environment.uasset
+++ b/src/unreal_plugin/Content/OpenJD_DataAssets/Default/OpenJD_Default_Environment.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bef08bff032fc7c7c1520c2e80408c6aeb6671dee0f82cc178038ebaa60e9ffa
+size 2338

--- a/src/unreal_plugin/Content/OpenJD_DataAssets/Default/OpenJD_Default_RenderJob.uasset
+++ b/src/unreal_plugin/Content/OpenJD_DataAssets/Default/OpenJD_Default_RenderJob.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ace44e4559cc4546e8fa2377bcc5934858dcd524de298649d74a6b248aa271f
+size 4852

--- a/src/unreal_plugin/Content/OpenJD_DataAssets/Default/OpenJD_Default_RenderJob.uasset
+++ b/src/unreal_plugin/Content/OpenJD_DataAssets/Default/OpenJD_Default_RenderJob.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4ace44e4559cc4546e8fa2377bcc5934858dcd524de298649d74a6b248aa271f
-size 4852
+oid sha256:3050a32399e3b6c515043eef1d048fb23953cb1e0f59bb44972227f5c7d02f52
+size 4812

--- a/src/unreal_plugin/Content/OpenJD_DataAssets/Default/OpenJD_Default_Step_Render.uasset
+++ b/src/unreal_plugin/Content/OpenJD_DataAssets/Default/OpenJD_Default_Step_Render.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24bbeb86f7e1ffa13818248e310613b5a45dd4047dc439d8ac00a3ed7774aff4
-size 3020
+oid sha256:17bae6454d83c1ee2e42c5bc6f818e7b30b9f5abbd58b715297d37a9ebfd45c7
+size 2980

--- a/src/unreal_plugin/Content/OpenJD_DataAssets/Default/OpenJD_Default_Step_Render.uasset
+++ b/src/unreal_plugin/Content/OpenJD_DataAssets/Default/OpenJD_Default_Step_Render.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24bbeb86f7e1ffa13818248e310613b5a45dd4047dc439d8ac00a3ed7774aff4
+size 3020

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.cpp
@@ -405,6 +405,23 @@ void SDeadlineCloudSavePresetWidget::UpdateValidity()
 	TMap<UDataAsset*, FString> ObjectsNames;
 	UMoviePipelineDeadlineCloudExecutorJob::GeneratePresetObjectsNames(MrqJob, FolderPath, NewName, ObjectsNames);
 
+	TMap<UDataAsset*, FString> CurrentPresetObjects;
+	UMoviePipelineDeadlineCloudExecutorJob::GetPresetObjectsNames(MrqJob, CurrentPresetObjects);
+
+	for (const auto& ObjectName : ObjectsNames)
+	{
+		for (const auto& CurrentObject : CurrentPresetObjects)
+		{
+			if (ObjectName.Value == CurrentObject.Value)
+			{
+				LastInputValidityErrorText = FText::Format(LOCTEXT("AssetDialog_OverrideCurrentPreset", "You cannot override current preset asset '{0}'."), FText::FromString(ObjectName.Value));
+				bLastInputValidityCheckSuccessful = false;
+				LastInputValidityErrorStyle = EMessageStyle::Error;
+				return;
+			}
+		}
+	}
+
 	for (const auto& ObjectName : ObjectsNames)
 	{
 		const FString PackageName = UPackageTools::SanitizePackageName(ObjectName.Value);

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.cpp
@@ -9,8 +9,419 @@
 #include "EditorDirectories.h"
 #include "Widgets/Notifications/SPopUpErrorText.h"
 #include "DesktopPlatformModule.h"
+#include "SWarningOrErrorBox.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "ContentBrowserModule.h"
+#include "IContentBrowserSingleton.h"
+#include "PackageTools.h"
 
 #define LOCTEXT_NAMESPACE "DeadlineWidgets"
+
+class SDeadlineCloudSavePresetWidget : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SDeadlineCloudSavePresetWidget)
+		: _MrqJob(nullptr)
+		{}
+		/** The MRQ job to save the preset for. */
+		SLATE_ARGUMENT(UMoviePipelineDeadlineCloudExecutorJob*, MrqJob)
+		SLATE_ARGUMENT(FString, Name)
+
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+protected:
+	EVisibility GetErrorLabelVisibility() const;
+	FText GetErrorLabelText() const;
+	FText OnGetNameText() const;
+	void OnNameTextChanged(const FText& NewText);
+	void OnNameTextCommitted(const FText& NewText, ETextCommit::Type CommitType);
+	FText OnGetPathText() const;
+	void OnPathTextChanged(const FString& NewText);
+	FReply HandleChooseFolderButtonClicked();
+	FReply HandleCreateButtonClicked();
+	//is create button enabled
+	bool IsCreateButtonEnabled() const
+	{
+		return bLastInputValidityCheckSuccessful || LastInputValidityErrorStyle == EMessageStyle::Warning;
+	}
+
+	void OnSetAsDefaultChanged(ECheckBoxState NewState)
+	{
+		bSetAsDefault = (NewState == ECheckBoxState::Checked);
+	}
+
+	void CloseWindow();
+	FReply HandleCancelButtonClicked();
+	FText GetJobResultPath() const;
+	void UpdateValidity();
+private:
+	UMoviePipelineDeadlineCloudExecutorJob* MrqJob;
+	FString NewName;
+	TSharedPtr<SEditableTextBox> NameEditBox;
+	FString NewPath;
+	bool bSetAsDefault = false;
+
+	EMessageStyle LastInputValidityErrorStyle = EMessageStyle::Error;
+	FText LastInputValidityErrorText;
+	bool bLastInputValidityCheckSuccessful = true;
+};
+
+void SDeadlineCloudSavePresetWidget::Construct(const FArguments& InArgs)
+{
+	MrqJob = InArgs._MrqJob;
+	NewName = InArgs._Name;
+
+	FContentBrowserModule& ContentBrowserModule = FModuleManager::LoadModuleChecked<FContentBrowserModule>("ContentBrowser");
+	FPathPickerConfig PathCfg;
+    PathCfg.DefaultPath = TEXT("/Game");
+	PathCfg.OnPathSelected = FOnPathSelected::CreateSP(this, &SDeadlineCloudSavePresetWidget::OnPathTextChanged);
+	NewPath = PathCfg.DefaultPath;
+
+	ChildSlot
+	[
+		SNew(SBorder)
+			.Padding(0)
+			.BorderImage(FAppStyle::GetBrush("Brushes.Panel"))
+			[
+				SNew(SVerticalBox)
+
+				+ SVerticalBox::Slot()
+					.AutoHeight()
+					[
+						SNew(SBorder)
+							.Visibility(this, &SDeadlineCloudSavePresetWidget::GetErrorLabelVisibility)
+							.Padding(FMargin(12.0f, 8.0f))
+							.BorderBackgroundColor(FLinearColor(0.24f, 0.05f, 0.05f)) 
+							.BorderImage(FAppStyle::GetBrush("DetailsView.CategoryTop"))
+							[
+								SNew(SHorizontalBox)
+								+ SHorizontalBox::Slot()
+									.FillWidth(1.0f)
+									.VAlign(VAlign_Center)
+									[
+										SNew(SWarningOrErrorBox)
+										.MessageStyle_Lambda([this]() { return LastInputValidityErrorStyle; })
+										.Message(this, &SDeadlineCloudSavePresetWidget::GetErrorLabelText)
+									]
+							]
+					]
+
+
+				+ SVerticalBox::Slot()
+				.FillHeight(1.0f)
+				.Padding(FMargin(10.0f)) 
+					[
+						SNew(SBorder)
+							.Padding(10.0f)
+							.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder")) 
+							[
+								SNew(SGridPanel)
+								.FillColumn(1, 1.0f)      
+
+								+ SGridPanel::Slot(0, 0)
+									.VAlign(VAlign_Center)
+									.HAlign(HAlign_Left)
+									.Padding(0.0f, 0.0f, 12.0f, 0.0f)
+									[
+										SNew(STextBlock)
+										.Text(LOCTEXT("PathLabel", "Folder"))
+									]
+
+								+ SGridPanel::Slot(1, 0)
+									.VAlign(VAlign_Center)
+									[
+										ContentBrowserModule.Get().CreatePathPicker(PathCfg)
+									]
+
+								+ SGridPanel::Slot(0, 1)
+									.VAlign(VAlign_Center)
+									.HAlign(HAlign_Left)
+									.Padding(0.0f, 6.0f, 12.0f, 6.0f)
+									[
+										SNew(STextBlock)
+										.Text(LOCTEXT("NameLabel", "Name"))
+									]
+
+								+ SGridPanel::Slot(1, 1)
+									.VAlign(VAlign_Center)
+									.Padding(0.0f, 6.0f, 0.0f, 6.0f)
+									[
+										SAssignNew(NameEditBox, SEditableTextBox)
+										.MinDesiredWidth(420.0f)
+										.Text(this, &SDeadlineCloudSavePresetWidget::OnGetNameText)
+										.OnTextChanged(this, &SDeadlineCloudSavePresetWidget::OnNameTextChanged)
+										.OnTextCommitted(this, &SDeadlineCloudSavePresetWidget::OnNameTextCommitted)
+									]
+
+
+								+ SGridPanel::Slot(0, 2)
+									.VAlign(VAlign_Center)
+									.HAlign(HAlign_Left)
+									.Padding(0.0f, 10.0f, 0.0f, 0.0f)
+									[
+										SNew(STextBlock)
+											.Text(LOCTEXT("JobLabel", "Job Path"))
+									]
+
+								+ SGridPanel::Slot(1, 2)
+									.VAlign(VAlign_Center)
+									.Padding(6.0f, 10.0f, 6.0f, 0.0f)
+									[
+										SNew(STextBlock)
+											.Text(this, &SDeadlineCloudSavePresetWidget::GetJobResultPath)
+									]
+							]
+					]
+
+			+ SVerticalBox::Slot()
+				.AutoHeight()
+				.HAlign(HAlign_Fill)
+				.VAlign(VAlign_Center)
+				.Padding(FMargin(10.0f, 6.0f))
+					[
+						SNew(SHorizontalBox)
+						+ SHorizontalBox::Slot()
+							.AutoWidth()
+							.Padding(0.0f, 0.0f, 8.0f, 0.0f)
+							.HAlign(HAlign_Left)
+							.VAlign(VAlign_Center)
+							[
+									SNew(SHorizontalBox)
+									+ SHorizontalBox::Slot()
+										.AutoWidth()
+										.Padding(0.0f, 0.0f, 8.0f, 0.0f)
+										.HAlign(HAlign_Left)
+										.VAlign(VAlign_Center)
+										[
+											SNew(SCheckBox)
+												.OnCheckStateChanged(this, &SDeadlineCloudSavePresetWidget::OnSetAsDefaultChanged)
+												.IsChecked_Lambda([this]() { return bSetAsDefault ? ECheckBoxState::Checked : ECheckBoxState::Unchecked; })
+													
+										]
+									+ SHorizontalBox::Slot()
+										.AutoWidth()
+										.HAlign(HAlign_Left)
+										.VAlign(VAlign_Center)
+										.Padding(0.0f, 0.0f, 8.0f, 0.0f)
+										[
+											SNew(STextBlock)
+												.Text(LOCTEXT("SetDefaultPreset", "Set as default preset"))
+												.Justification(ETextJustify::Center)
+										]
+							]
+						+ SHorizontalBox::Slot()
+							.FillWidth(1.0f)
+							.HAlign(HAlign_Fill)
+							.VAlign(VAlign_Center)
+							.Padding(0.0f, 0.0f, 0.0f, 0.0f)
+							[
+								SNew(SSpacer)
+							]
+
+						+ SHorizontalBox::Slot()
+							.AutoWidth()
+							.Padding(0.0f, 0.0f, 8.0f, 0.0f)
+							.HAlign(HAlign_Right)
+							.VAlign(VAlign_Center)
+							[
+								SNew(SButton)
+								.ButtonStyle(FAppStyle::Get(), "PrimaryButton")
+								.Text(LOCTEXT("CreateBtn", "Create"))
+								.IsEnabled(this, &SDeadlineCloudSavePresetWidget::IsCreateButtonEnabled)
+								.OnClicked(this, &SDeadlineCloudSavePresetWidget::HandleCreateButtonClicked)
+
+							]
+
+						+ SHorizontalBox::Slot()
+							.AutoWidth()
+							.HAlign(HAlign_Right)
+							[
+								SNew(SButton)
+								.Text(LOCTEXT("CancelBtn", "Cancel"))
+								.OnClicked(this, &SDeadlineCloudSavePresetWidget::HandleCancelButtonClicked)
+							]
+					]
+			]
+	];
+}
+
+EVisibility SDeadlineCloudSavePresetWidget::GetErrorLabelVisibility() const
+{
+	return GetErrorLabelText().IsEmpty() ? EVisibility::Collapsed : EVisibility::Visible;
+}
+
+FText SDeadlineCloudSavePresetWidget::GetErrorLabelText() const
+{
+	if (bLastInputValidityCheckSuccessful)
+	{
+		return FText::GetEmpty();
+	}
+	return LastInputValidityErrorText;
+}
+
+
+FText SDeadlineCloudSavePresetWidget::OnGetNameText() const
+{
+	return FText::FromString(NewName);
+}
+
+void SDeadlineCloudSavePresetWidget::OnNameTextChanged(const FText& NewText)
+{
+	NewName = NewText.ToString();
+	UpdateValidity();
+}
+
+void SDeadlineCloudSavePresetWidget::OnNameTextCommitted(const FText& NewText, ETextCommit::Type CommitType)
+{
+	UpdateValidity();
+}
+
+FText SDeadlineCloudSavePresetWidget::OnGetPathText() const
+{
+	return FText::FromString(NewPath);
+}
+
+void SDeadlineCloudSavePresetWidget::OnPathTextChanged(const FString& NewText)
+{
+	NewPath = NewText;
+
+	UpdateValidity();
+}
+
+FReply SDeadlineCloudSavePresetWidget::HandleChooseFolderButtonClicked()
+{
+	IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+	if ( DesktopPlatform )
+	{
+		TSharedPtr<SWindow> ParentWindow = FSlateApplication::Get().FindWidgetWindow(AsShared());
+		void* ParentWindowWindowHandle = (ParentWindow.IsValid()) ? ParentWindow->GetNativeWindow()->GetOSWindowHandle() : nullptr;
+
+		FString FolderName;
+		const FString Title = LOCTEXT("NewClassBrowseTitle", "Choose a source location").ToString();
+		const bool bFolderSelected = DesktopPlatform->OpenDirectoryDialog(
+			ParentWindowWindowHandle,
+			Title,
+			NewPath,
+			FolderName
+			);
+
+		if ( bFolderSelected )
+		{
+			if ( !FolderName.EndsWith(TEXT("/")) )
+			{
+				FolderName += TEXT("/");
+			}
+
+			NewPath = FolderName;
+
+			UpdateValidity();
+		}
+	}
+
+	return FReply::Handled();
+}
+
+void SDeadlineCloudSavePresetWidget::CloseWindow()
+{
+	TSharedPtr<SWindow> ParentWindow = FSlateApplication::Get().FindWidgetWindow(AsShared());
+	if (ParentWindow.IsValid())
+	{
+		ParentWindow->RequestDestroyWindow();
+	}
+}
+
+FReply SDeadlineCloudSavePresetWidget::HandleCreateButtonClicked()
+{
+	if (!bLastInputValidityCheckSuccessful && LastInputValidityErrorStyle == EMessageStyle::Warning)
+	{
+		// Show a warning dialog to the user
+		FText WarningTitle = LOCTEXT("CreatePresetWarningTitle", "Warning");
+		FText WarningMessage = LastInputValidityErrorText;
+
+		EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::OkCancel, WarningMessage, WarningTitle);
+
+		if (Result != EAppReturnType::Ok)
+		{
+			return FReply::Handled();
+		}
+	}
+
+	FString FolderPath = UPackageTools::SanitizePackageName(NewPath + TEXT("/") + NewName);
+	MrqJob->SaveAsJobPreset(FolderPath, NewName, bSetAsDefault);
+
+	CloseWindow();
+
+	return FReply::Handled();
+}
+
+FReply SDeadlineCloudSavePresetWidget::HandleCancelButtonClicked()
+{
+	CloseWindow();
+
+	return FReply::Handled();
+}
+
+FText SDeadlineCloudSavePresetWidget::GetJobResultPath() const
+{
+	return FText::FromString(FPaths::Combine(NewPath, NewName));
+}
+
+void SDeadlineCloudSavePresetWidget::UpdateValidity()
+{
+	bLastInputValidityCheckSuccessful = true;
+
+	if (NewName.IsEmpty())
+	{
+		LastInputValidityErrorText = LOCTEXT("AssetDialog_NoNameSelected", "You must select a name.");
+		LastInputValidityErrorStyle = EMessageStyle::Error;
+		bLastInputValidityCheckSuccessful = false;
+		return;
+	}
+
+	if ( NewPath.IsEmpty() )
+	{
+		LastInputValidityErrorText = LOCTEXT("AssetDialog_NoPathSelected", "You must select a path.");
+		LastInputValidityErrorStyle = EMessageStyle::Error;
+		bLastInputValidityCheckSuccessful = false;
+		return;
+	}
+	FString FolderPath = UPackageTools::SanitizePackageName(NewPath + TEXT("/") + NewName);
+
+	TMap<UDataAsset*, FString> ObjectsNames;
+	UMoviePipelineDeadlineCloudExecutorJob::GeneratePresetObjectsNames(MrqJob, FolderPath, NewName, ObjectsNames);
+
+	for (const auto& ObjectName : ObjectsNames)
+	{
+		const FString PackageName = UPackageTools::SanitizePackageName(ObjectName.Value);
+
+		FText Reason;
+		if (!FPackageName::IsValidLongPackageName(PackageName, true, &Reason))
+		{
+			LastInputValidityErrorText = Reason;
+			bLastInputValidityCheckSuccessful = false;
+			LastInputValidityErrorStyle = EMessageStyle::Error;
+			return;
+		}
+
+		const FString AssetName  = FPackageName::GetLongPackageAssetName(PackageName);
+		const FString ObjectPath = PackageName + TEXT(".") + AssetName;
+
+		FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+		FAssetData ExistingAsset = AssetRegistryModule.Get().GetAssetByObjectPath(FSoftObjectPath(ObjectPath));
+		if (ExistingAsset.IsValid())
+		{
+			const FString ObjectPathName = FPackageName::ObjectPathToObjectName(ObjectName.Value);
+			LastInputValidityErrorText = 
+				FText::Format(LOCTEXT("AssetDialog_AssetAlreadyExists", "An asset of type '{0}' already exists at this location with the name '{1}'."), 
+					FText::FromString(ExistingAsset.AssetClassPath.ToString()), 
+					FText::FromString(AssetName));
+			bLastInputValidityCheckSuccessful = false;
+			LastInputValidityErrorStyle = EMessageStyle::Warning;
+			return;
+		}		
+	}
+}
 
 /*
 SDeadlineCloudFilePathWidget is a custom Slate widget class that implements a file path picker interface.
@@ -521,6 +932,34 @@ void FDeadlineCloudDetailsWidgetsHelper::SEyeUpdateWidget::Construct(const FArgu
 };
 
 
+void FDeadlineCloudDetailsWidgetsHelper::CreateSavePresetDialogWidget(UMoviePipelineDeadlineCloudExecutorJob* MrqJob)
+{
+	//FVector2D Size(600, 400);
+	TSharedRef<SWindow> SaveDialogWindow = SNew(SWindow)
+		.Title(FText::FromString("Save Job Preset"))
+		//.ClientSize(Size)
+		.SizingRule(ESizingRule::Autosized)
+		.SupportsMinimize(false)
+		.SupportsMaximize(false);
+
+	FString PresetName = MrqJob->JobPreset->JobPresetStruct.JobSharedSettings.Name;
+
+	SaveDialogWindow->SetContent(
+		SNew(SBox)
+		//.WidthOverride(Size.X)
+		//.HeightOverride(Size.Y)
+		[
+			SNew(SDeadlineCloudSavePresetWidget)
+				.MrqJob(MrqJob)
+				.Name(PresetName)
+		]
+	);
+
+	TSharedPtr<SWindow> ParentWindow = FSlateApplication::Get().FindBestParentWindowForDialogs(nullptr);
+
+	FSlateApplication::Get().AddModalWindow(SaveDialogWindow, ParentWindow, false);
+}
+
 TSharedRef<SWidget> FDeadlineCloudDetailsWidgetsHelper::CreatePropertyWidgetByType(TSharedPtr<IPropertyHandle> ParameterHandle, EValueType Type, EValueValidationType ValidationType)
 {
 	switch (Type)
@@ -681,6 +1120,8 @@ UMoviePipelineDeadlineCloudExecutorJob* FDeadlineCloudDetailsWidgetsHelper::GetM
 	}
 	else return nullptr;
 }
+
+
 
 
 #undef LOCTEXT_NAMESPACE

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.cpp
@@ -14,6 +14,7 @@
 #include "ContentBrowserModule.h"
 #include "IContentBrowserSingleton.h"
 #include "PackageTools.h"
+#include "Framework/MetaData/DriverMetaData.h"
 
 #define LOCTEXT_NAMESPACE "DeadlineWidgets"
 
@@ -78,6 +79,30 @@ void SDeadlineCloudSavePresetWidget::Construct(const FArguments& InArgs)
 	PathCfg.OnPathSelected = FOnPathSelected::CreateSP(this, &SDeadlineCloudSavePresetWidget::OnPathTextChanged);
 	NewPath = PathCfg.DefaultPath;
 
+	TSharedRef<SWarningOrErrorBox> ErrorBox = SNew(SWarningOrErrorBox)
+		.MessageStyle_Lambda([this]() { return LastInputValidityErrorStyle; })
+		.Message(this, &SDeadlineCloudSavePresetWidget::GetErrorLabelText);
+	ErrorBox->AddMetadata(FDriverMetaData::Id(FName("DeadlineCloudSavePresetWidget.ErrorBox")));
+
+	 SAssignNew(NameEditBox, SEditableTextBox)
+		.MinDesiredWidth(420.0f)
+		.Text(this, &SDeadlineCloudSavePresetWidget::OnGetNameText)
+		.OnTextChanged(this, &SDeadlineCloudSavePresetWidget::OnNameTextChanged)
+		.OnTextCommitted(this, &SDeadlineCloudSavePresetWidget::OnNameTextCommitted);
+	NameEditBox->AddMetadata(FDriverMetaData::Id(FName("DeadlineCloudSavePresetWidget.NameEditBox")));
+
+	TSharedRef<SButton> CreateButton = SNew(SButton)
+		.ButtonStyle(FAppStyle::Get(), "PrimaryButton")
+		.Text(LOCTEXT("CreateBtn", "Create"))
+		.IsEnabled(this, &SDeadlineCloudSavePresetWidget::IsCreateButtonEnabled)
+		.OnClicked(this, &SDeadlineCloudSavePresetWidget::HandleCreateButtonClicked);
+	CreateButton->AddMetadata(FDriverMetaData::Id(FName("DeadlineCloudSavePresetWidget.CreateButton")));
+
+	TSharedRef<SButton> CancelButton = SNew(SButton)
+		.Text(LOCTEXT("CancelBtn", "Cancel"))
+		.OnClicked(this, &SDeadlineCloudSavePresetWidget::HandleCancelButtonClicked);
+	CancelButton->AddMetadata(FDriverMetaData::Id(FName("DeadlineCloudSavePresetWidget.CancelButton")));
+
 	ChildSlot
 	[
 		SNew(SBorder)
@@ -100,9 +125,7 @@ void SDeadlineCloudSavePresetWidget::Construct(const FArguments& InArgs)
 									.FillWidth(1.0f)
 									.VAlign(VAlign_Center)
 									[
-										SNew(SWarningOrErrorBox)
-										.MessageStyle_Lambda([this]() { return LastInputValidityErrorStyle; })
-										.Message(this, &SDeadlineCloudSavePresetWidget::GetErrorLabelText)
+										ErrorBox
 									]
 							]
 					]
@@ -147,11 +170,7 @@ void SDeadlineCloudSavePresetWidget::Construct(const FArguments& InArgs)
 									.VAlign(VAlign_Center)
 									.Padding(0.0f, 6.0f, 0.0f, 6.0f)
 									[
-										SAssignNew(NameEditBox, SEditableTextBox)
-										.MinDesiredWidth(420.0f)
-										.Text(this, &SDeadlineCloudSavePresetWidget::OnGetNameText)
-										.OnTextChanged(this, &SDeadlineCloudSavePresetWidget::OnNameTextChanged)
-										.OnTextCommitted(this, &SDeadlineCloudSavePresetWidget::OnNameTextCommitted)
+										NameEditBox.ToSharedRef()
 									]
 
 
@@ -225,25 +244,20 @@ void SDeadlineCloudSavePresetWidget::Construct(const FArguments& InArgs)
 							.HAlign(HAlign_Right)
 							.VAlign(VAlign_Center)
 							[
-								SNew(SButton)
-								.ButtonStyle(FAppStyle::Get(), "PrimaryButton")
-								.Text(LOCTEXT("CreateBtn", "Create"))
-								.IsEnabled(this, &SDeadlineCloudSavePresetWidget::IsCreateButtonEnabled)
-								.OnClicked(this, &SDeadlineCloudSavePresetWidget::HandleCreateButtonClicked)
-
+								CreateButton
 							]
 
 						+ SHorizontalBox::Slot()
 							.AutoWidth()
 							.HAlign(HAlign_Right)
 							[
-								SNew(SButton)
-								.Text(LOCTEXT("CancelBtn", "Cancel"))
-								.OnClicked(this, &SDeadlineCloudSavePresetWidget::HandleCancelButtonClicked)
+								CancelButton
 							]
 					]
 			]
 	];
+
+	AddMetadata(FDriverMetaData::Id(FName("DeadlineCloudSavePresetWidget")));
 }
 
 EVisibility SDeadlineCloudSavePresetWidget::GetErrorLabelVisibility() const
@@ -337,7 +351,7 @@ FReply SDeadlineCloudSavePresetWidget::HandleCreateButtonClicked()
 	{
 		// Show a warning dialog to the user
 		FText WarningTitle = LOCTEXT("CreatePresetWarningTitle", "Warning");
-		FText WarningMessage = LastInputValidityErrorText;
+		FText WarningMessage = LOCTEXT("OverrideDialog", "Override existing data assets");
 
 		EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::OkCancel, WarningMessage, WarningTitle);
 
@@ -932,12 +946,10 @@ void FDeadlineCloudDetailsWidgetsHelper::SEyeUpdateWidget::Construct(const FArgu
 };
 
 
-void FDeadlineCloudDetailsWidgetsHelper::CreateSavePresetDialogWidget(UMoviePipelineDeadlineCloudExecutorJob* MrqJob)
+void FDeadlineCloudDetailsWidgetsHelper::CreateSavePresetDialogWidget(UMoviePipelineDeadlineCloudExecutorJob* MrqJob, bool bModal)
 {
-	//FVector2D Size(600, 400);
 	TSharedRef<SWindow> SaveDialogWindow = SNew(SWindow)
 		.Title(FText::FromString("Save Job Preset"))
-		//.ClientSize(Size)
 		.SizingRule(ESizingRule::Autosized)
 		.SupportsMinimize(false)
 		.SupportsMaximize(false);
@@ -946,8 +958,6 @@ void FDeadlineCloudDetailsWidgetsHelper::CreateSavePresetDialogWidget(UMoviePipe
 
 	SaveDialogWindow->SetContent(
 		SNew(SBox)
-		//.WidthOverride(Size.X)
-		//.HeightOverride(Size.Y)
 		[
 			SNew(SDeadlineCloudSavePresetWidget)
 				.MrqJob(MrqJob)
@@ -955,9 +965,15 @@ void FDeadlineCloudDetailsWidgetsHelper::CreateSavePresetDialogWidget(UMoviePipe
 		]
 	);
 
-	TSharedPtr<SWindow> ParentWindow = FSlateApplication::Get().FindBestParentWindowForDialogs(nullptr);
-
-	FSlateApplication::Get().AddModalWindow(SaveDialogWindow, ParentWindow, false);
+	if (bModal)
+	{
+		TSharedPtr<SWindow> ParentWindow = FSlateApplication::Get().FindBestParentWindowForDialogs(nullptr);
+		FSlateApplication::Get().AddModalWindow(SaveDialogWindow, ParentWindow, false);
+	}
+	else
+	{
+		FSlateApplication::Get().AddWindow(SaveDialogWindow);
+	}
 }
 
 TSharedRef<SWidget> FDeadlineCloudDetailsWidgetsHelper::CreatePropertyWidgetByType(TSharedPtr<IPropertyHandle> ParameterHandle, EValueType Type, EValueValidationType ValidationType)

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.cpp
@@ -46,19 +46,56 @@ void UDeadlineCloudDeveloperSettings::LoadMRQJobPresetCache(UMoviePipelineDeadli
 {
 	if (auto Settings = UDeadlineCloudDeveloperSettings::GetMutable())
 	{
+		// If the user changed the default preset, we don't have anything to load
 		if (Settings->JobPresetCache.LastJobPreset != Settings->DefaultJobPreset)
 		{
 			Settings->JobPresetCache.LastJobPreset = Settings->DefaultJobPreset;
 			return;
 		}
 
+		// If the MRQ job is not using the default preset, we don't load anything
 		if (MRQJob->JobPreset != Settings->DefaultJobPreset)
 		{
 			return;
 		}
 
 		MRQJob->PresetOverrides = Settings->JobPresetCache.LastPresetOverrides;
-		MRQJob->JobTemplateOverrides = Settings->JobPresetCache.LastJobTemplateOverrides;
+		// copy overrides if parameter exists in current preset, maybe some parameters were removed from previous cache save
+		for (const auto& CachedParam : Settings->JobPresetCache.LastJobTemplateOverrides.Parameters)
+		{
+			for (auto& CurrentParam : MRQJob->JobTemplateOverrides.Parameters)
+			{
+				if (CachedParam.Name == CurrentParam.Name)
+				{
+					CurrentParam.Value = CachedParam.Value;
+					break;
+				}
+			}
+		}
+
+		for (const auto& CachedStepParam : Settings->JobPresetCache.LastJobTemplateOverrides.StepsOverrides)
+		{
+			for (auto& CurrentStepParam : MRQJob->JobTemplateOverrides.StepsOverrides)
+			{
+				if (CachedStepParam.Name == CurrentStepParam.Name)
+				{
+					CurrentStepParam.CopyParametersValuesFrom(CachedStepParam);
+					break;
+				}
+			}
+		}
+
+		for (const auto& CachedEnvParam : Settings->JobPresetCache.LastJobTemplateOverrides.EnvironmentsOverrides)
+		{
+			for (auto& CurrentEnvParam : MRQJob->JobTemplateOverrides.EnvironmentsOverrides)
+			{
+				if (CachedEnvParam.Name == CurrentEnvParam.Name)
+				{
+					CurrentEnvParam.CopyParametersValuesFrom(CachedEnvParam);
+					break;
+				}
+			}
+		}
 	}
 }
 
@@ -71,6 +108,7 @@ void UDeadlineCloudDeveloperSettings::SaveMRQJobPresetCache(const UMoviePipeline
 			Settings->JobPresetCache.LastJobPreset = Settings->DefaultJobPreset;
 		}
 
+		// If the MRQ job is not using the default preset, we don't save anything
 		if (MRQJob->JobPreset != Settings->DefaultJobPreset)
 		{
 			return;

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.cpp
@@ -2,6 +2,9 @@
 
 
 #include "DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h"
+#include "DeadlineCloudJobSettings/DeadlineCloudRenderJob.h"
+#include "DeadlineCloudJobSettings/DeadlineCloudJob.h"
+
 
 namespace DeadlineSettingsKeys
 {
@@ -18,6 +21,65 @@ namespace DeadlineSettingsKeys
 
 UDeadlineCloudDeveloperSettings::UDeadlineCloudDeveloperSettings()
 {
+}
+
+UDeadlineCloudRenderJob* UDeadlineCloudDeveloperSettings::GetDefaultJobPreset()
+{
+	if (auto Settings = UDeadlineCloudDeveloperSettings::Get())
+	{
+		return Settings->DefaultJobPreset.LoadSynchronous();
+	}
+
+	return nullptr;
+}
+
+void UDeadlineCloudDeveloperSettings::SetDefaultJobPreset(UDeadlineCloudRenderJob* NewJobPreset)
+{
+	if (auto Settings = UDeadlineCloudDeveloperSettings::GetMutable())
+	{
+		Settings->DefaultJobPreset = NewJobPreset;
+		Settings->SaveConfig();
+	}
+}
+
+void UDeadlineCloudDeveloperSettings::LoadMRQJobPresetCache(UMoviePipelineDeadlineCloudExecutorJob* MRQJob)
+{
+	if (auto Settings = UDeadlineCloudDeveloperSettings::GetMutable())
+	{
+		if (Settings->JobPresetCache.LastJobPreset != Settings->DefaultJobPreset)
+		{
+			Settings->JobPresetCache.LastJobPreset = Settings->DefaultJobPreset;
+			return;
+		}
+
+		if (MRQJob->JobPreset != Settings->DefaultJobPreset)
+		{
+			return;
+		}
+
+		MRQJob->PresetOverrides = Settings->JobPresetCache.LastPresetOverrides;
+		MRQJob->JobTemplateOverrides = Settings->JobPresetCache.LastJobTemplateOverrides;
+	}
+}
+
+void UDeadlineCloudDeveloperSettings::SaveMRQJobPresetCache(const UMoviePipelineDeadlineCloudExecutorJob* MRQJob)
+{
+	if (auto Settings = UDeadlineCloudDeveloperSettings::GetMutable())
+	{
+		if (Settings->JobPresetCache.LastJobPreset != Settings->DefaultJobPreset)
+		{
+			Settings->JobPresetCache.LastJobPreset = Settings->DefaultJobPreset;
+		}
+
+		if (MRQJob->JobPreset != Settings->DefaultJobPreset)
+		{
+			return;
+		}
+
+		Settings->JobPresetCache.LastPresetOverrides = MRQJob->PresetOverrides;
+		Settings->JobPresetCache.LastJobTemplateOverrides = MRQJob->JobTemplateOverrides;
+		Settings->SaveConfig();
+	}
 }
 
 TArray<FString> UDeadlineCloudDeveloperSettings::GetFarmsList()

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudEnvironment.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudEnvironment.cpp
@@ -142,3 +142,15 @@ void UDeadlineCloudEnvironment::PostEditChangeProperty(FPropertyChangedEvent& Pr
         UE_LOG(LogTemp, Error, TEXT("Changed property is nullptr"));
     }
 }
+
+void FDeadlineCloudEnvironmentOverride::CopyParametersValuesFrom(const FDeadlineCloudEnvironmentOverride& Other)
+{
+	for (auto& VarPair : Other.Variables.Variables)
+	{
+		auto FoundVar = Variables.Variables.Find(VarPair.Key);
+		if (FoundVar)
+		{
+			*FoundVar = VarPair.Value;
+		}
+	}
+}

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudEnvironmentDetails.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudEnvironmentDetails.cpp
@@ -437,11 +437,7 @@ bool FDeadlineCloudEnvironmentParametersMapBuilder::IsEyeWidgetEnabled(FName Par
 			{
 				if (EnvOverride)
 				{
-					
-					{
 						result = EnvOverride->ContainsHiddenParameters(Parameter);
-
-					}
 				}
 			}
 		}

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJob.cpp
@@ -117,6 +117,20 @@ TArray<FStepTaskParameterDefinition> UDeadlineCloudJob::GetAllStepParameters() c
     return result;
 }
 
+TArray<FParameterDefinition> UDeadlineCloudJob::GetParametersDataToOverride() const
+{
+    TArray<FParameterDefinition> Result;
+	for (const FParameterDefinition& Param : ParameterDefinition.Parameters)
+    {
+        if (!HiddenParametersList.Contains(FName(*Param.Name)))
+        {
+			Result.Add(Param);
+		}
+	}
+
+	return Result;
+}
+
 
 FParametersConsistencyCheckResult UDeadlineCloudJob::CheckJobParametersConsistency(const UDeadlineCloudJob* Job)
 {

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobDetails.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobDetails.cpp
@@ -328,18 +328,11 @@ void FDeadlineCloudJobParametersArrayBuilder::GenerateStepsExtraChildren(IDetail
             // Access the array property of StepOverride elements
             TArray<FDeadlineCloudStepOverride>& Steps = MrqJob->JobTemplateOverrides.StepsOverrides;
 
-            for (FDeadlineCloudStepOverride& Step : Steps)
-            {
-                // Check Steps all > Steps hidden 
-                if (Step.TaskParameterDefinitions.Parameters.Num() > Step.HiddenParametersList.Num())
-                {
-                    // Use custom array builder to hide the header
-                    TSharedRef<FDeadlineCloudStepOverrideArrayBuilder> StepsArrayBuilder = 
-                    FDeadlineCloudStepOverrideArrayBuilder::MakeInstance(StepsHandle.ToSharedRef());
+            // Use custom array builder to hide the header
+            TSharedRef<FDeadlineCloudStepOverrideArrayBuilder> StepsArrayBuilder = 
+            FDeadlineCloudStepOverrideArrayBuilder::MakeInstance(StepsHandle.ToSharedRef());
 
-                    ChildrenBuilder.AddCustomBuilder(StepsArrayBuilder);
-                }
-            }
+            ChildrenBuilder.AddCustomBuilder(StepsArrayBuilder);
         }
     }
 }
@@ -359,18 +352,12 @@ void FDeadlineCloudJobParametersArrayBuilder::GenerateEnvironmentsExtraChildren(
             // Access the array property of StepOverride elements
             TArray<FDeadlineCloudEnvironmentOverride>& Envs = MrqJob->JobTemplateOverrides.EnvironmentsOverrides;
 
-            for (FDeadlineCloudEnvironmentOverride& Environment : Envs)
-            {
-                // Check Steps all > Steps hidden 
-                if (Environment.Variables.Variables.Num() > Environment.HiddenVarsList.Num())
-                {
-                    // Use custom array builder to hide the header
-                    TSharedRef<FDeadlineCloudEnvOverrideArrayBuilder> EnvsArrayBuilder =
-                        FDeadlineCloudEnvOverrideArrayBuilder::MakeInstance(EnvHandle.ToSharedRef());
 
-                    ChildrenBuilder.AddCustomBuilder(EnvsArrayBuilder);
-                }
-            }
+            // Use custom array builder to hide the header
+            TSharedRef<FDeadlineCloudEnvOverrideArrayBuilder> EnvsArrayBuilder =
+                FDeadlineCloudEnvOverrideArrayBuilder::MakeInstance(EnvHandle.ToSharedRef());
+
+            ChildrenBuilder.AddCustomBuilder(EnvsArrayBuilder);
         }
     }
 }

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobDetails.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobDetails.cpp
@@ -652,10 +652,7 @@ void FDeadlineCloudJobParametersArrayBuilder::OnGenerateEntry(TSharedRef<IProper
                 return true;
             })
     );
-
-    PropertyRow.Visibility(IsPropertyHidden(FName(ParameterName)) ? EVisibility::Collapsed : EVisibility::Visible);
 }
-
 
 
 void FJobTemplateOverridesCustomization::CustomizeHeader(TSharedRef<IPropertyHandle> InPropertyHandle, FDetailWidgetRow& InHeaderRow, IPropertyTypeCustomizationUtils& InCustomizationUtils)

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.cpp
@@ -24,6 +24,18 @@ TSharedRef<IPropertyTypeCustomization> FDeadlineCloudJobPresetDetailsCustomizati
 void FDeadlineCloudJobPresetDetailsCustomization::CustomizeHeader(TSharedRef<IPropertyHandle> PropertyHandle, FDetailWidgetRow& HeaderRow,
     IPropertyTypeCustomizationUtils& CustomizationUtils)
 {
+	const auto NameWidget = PropertyHandle->CreatePropertyNameWidget();
+	const auto ValueWidget = PropertyHandle->CreatePropertyValueWidget();
+
+	HeaderRow
+		.NameContent()
+		[
+			NameWidget
+		]
+		.ValueContent()
+		[
+			ValueWidget
+		];
 }
 
 void FDeadlineCloudJobPresetDetailsCustomization::CustomizeChildren(TSharedRef<IPropertyHandle> StructHandle,
@@ -34,12 +46,6 @@ void FDeadlineCloudJobPresetDetailsCustomization::CustomizeChildren(TSharedRef<I
 
     TMap<FName, IDetailGroup*> CreatedCategories;
     const FName StructName(StructHandle->GetProperty()->GetFName());
-
-    if (OuterJob)
-    {
-        IDetailGroup& BaseCategoryGroup = ChildBuilder.AddGroup(StructName, StructHandle->GetPropertyDisplayName());
-        CreatedCategories.Add(StructName, &BaseCategoryGroup);
-    }
 
     // For each map member and each struct member in the map member value
     uint32 NumChildren;
@@ -56,31 +62,8 @@ void FDeadlineCloudJobPresetDetailsCustomization::CustomizeChildren(TSharedRef<I
             continue;
         }
 
-        IDetailGroup* GroupToUse = nullptr;
-        if (const FString* PropertyCategoryString = ChildHandle->GetProperty()->FindMetaData(TEXT("Category")))
-        {
-            FName PropertyCategoryName(*PropertyCategoryString);
 
-            if (IDetailGroup** FoundCategory = CreatedCategories.Find(PropertyCategoryName))
-            {
-                GroupToUse = *FoundCategory;
-            }
-            else
-            {
-                if (OuterJob)
-                {
-                    GroupToUse = CreatedCategories.FindChecked(StructName);
-                }
-                else
-                {
-                    IDetailGroup& NewGroup = ChildBuilder.AddGroup(StructName, StructHandle->GetPropertyDisplayName());
-                    NewGroup.ToggleExpansion(true);
-                    GroupToUse = CreatedCategories.Add(PropertyCategoryName, &NewGroup);
-                }
-            }
-        }
-
-        IDetailPropertyRow& PropertyRow = GroupToUse->AddPropertyRow(ChildHandle);
+        IDetailPropertyRow& PropertyRow = ChildBuilder.AddProperty(ChildHandle);
 
         TSharedPtr<SWidget> CustomValueWidget = FDeadlineCloudDetailsWidgetsHelper::TryCreatePropertyWidgetFromMetadata(ChildHandle);
         if (CustomValueWidget.IsValid())
@@ -97,15 +80,6 @@ void FDeadlineCloudJobPresetDetailsCustomization::CustomizeChildren(TSharedRef<I
         else
         {
             CustomizeStructChildrenInAssetDetails(PropertyRow, CustomValueWidget);
-        }
-    }
-
-    // Force expansion of all categories
-    for (const TTuple<FName, IDetailGroup*>& Pair : CreatedCategories)
-    {
-        if (Pair.Value)
-        {
-            Pair.Value->ToggleExpansion(true);
         }
     }
 }

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudStep.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudStep.cpp
@@ -257,3 +257,36 @@ void UDeadlineCloudStep::ResetParameterArray(FString ParameterName)
         }
     }
 }
+
+void FDeadlineCloudStepOverride::CopyParametersValuesFrom(const FDeadlineCloudStepOverride& Other)
+{
+	// Copy EnvironmentsOverrides
+	for (const FDeadlineCloudEnvironmentOverride& OtherEnv : Other.EnvironmentsOverrides)
+	{
+		bool bFound = false;
+		for (FDeadlineCloudEnvironmentOverride& ThisEnv : EnvironmentsOverrides)
+		{
+			if (ThisEnv.Name == OtherEnv.Name)
+			{
+				bFound = true;
+				ThisEnv.CopyParametersValuesFrom(OtherEnv);
+				break;
+			}
+		}
+	}
+
+	// Copy TaskParameterDefinitions values
+	for (const FStepTaskParameterDefinition& OtherParam : Other.TaskParameterDefinitions.Parameters)
+	{
+		bool bFound = false;
+		for (FStepTaskParameterDefinition& ThisParam : TaskParameterDefinitions.Parameters)
+		{
+			if (ThisParam.Name == OtherParam.Name)
+			{
+				bFound = true;
+				ThisParam.Range = OtherParam.Range;
+				break;
+			}
+		}
+	}
+}

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -12,7 +12,17 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.h"
 #include "DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.h"
+#include "DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h"
+#include "DesktopPlatformModule.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Factories/DataAssetFactory.h"
+#include "AssetToolsModule.h"
+#include "PackageTools.h"
 #include "PythonAPILibraries/PythonYamlLibrary.h"
+#include "DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h"
+#include "ObjectTools.h"
+#include "UObject/SavePackage.h"
+#include "Serialization/ArchiveReplaceObjectRef.h"
 
 UMoviePipelineDeadlineCloudExecutorJob::UMoviePipelineDeadlineCloudExecutorJob()
 {
@@ -63,10 +73,98 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostInitProperties()
 	Super::PostInitProperties();
 
 #if WITH_EDITOR
-	if (!HasAnyFlags(RF_ClassDefaultObject)){
+	if (!HasAnyFlags(RF_ClassDefaultObject))
+	{
 		JobPresetChanged();
 	}
 #endif // WITH_EDITOR
+}
+
+void UMoviePipelineDeadlineCloudExecutorJob::SaveAsJobPreset(FString& FolderPath, FString& BaseName, bool bSetAsDefault)
+{
+	IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+
+	if (DesktopPlatform == nullptr)
+	{
+		return;
+	}
+
+	TMap<UDataAsset*, FString> ObjectsNames;
+
+	UMoviePipelineDeadlineCloudExecutorJob::GeneratePresetObjectsNames(this, FolderPath, BaseName, ObjectsNames);
+
+	TArray<UDataAsset*> ResultAssets;
+	UDeadlineCloudRenderJob* ResultJob = nullptr;
+	for (const auto& Name : ObjectsNames)
+	{
+		FString PackageName = Name.Value;
+
+		auto Asset = Name.Key;
+
+		const FString AssetName  = FPackageName::GetLongPackageAssetName(PackageName);
+		const FString ObjectPath = PackageName + TEXT(".") + AssetName;
+
+		FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+		FAssetData ExistingAsset = AssetRegistryModule.Get().GetAssetByObjectPath(FSoftObjectPath(ObjectPath));
+
+		if (ExistingAsset.IsValid())
+		{
+			ObjectTools::DeleteAssets({ ExistingAsset }, false);
+		}
+		
+		UPackage* Pkg = CreatePackage(*PackageName);
+
+		UDataAsset* NewObj = DuplicateObject<UDataAsset>(Asset, Pkg, *FPaths::GetBaseFilename(PackageName));
+		if (!NewObj)
+		{
+			return;
+		}
+
+		NewObj->SetFlags(RF_Public | RF_Standalone);
+		FAssetRegistryModule::AssetCreated(NewObj);
+
+		if (auto Job = Cast<UDeadlineCloudRenderJob>(NewObj))
+		{
+			CopyJobOverrides(Job);
+			ResultJob = Job;
+		}
+		else if (auto Step = Cast<UDeadlineCloudStep>(NewObj))
+		{
+			CopyStepOverrides(Step);
+		}
+		else if (auto Env = Cast<UDeadlineCloudEnvironment>(NewObj))
+		{
+			CopyEnvironmentOverrides(Env);
+		}
+
+		Pkg->MarkPackageDirty();
+		FString FilePath = FPackageName::LongPackageNameToFilename(
+					PackageName, FPackageName::GetAssetPackageExtension());
+
+		FSavePackageArgs SaveArgs = FSavePackageArgs();
+		SaveArgs.TopLevelFlags = EObjectFlags::RF_Public | EObjectFlags::RF_Standalone;
+		SaveArgs.Error = GError;
+		SaveArgs.bWarnOfLongFilename = true;
+
+		UPackage::SavePackage(
+			Pkg, NewObj, *FilePath, SaveArgs);
+
+		ResultAssets.Add(NewObj);
+	}
+
+	FixReferencesAfterDuplication(ObjectsNames, ResultAssets);
+
+	if (bSetAsDefault)
+	{
+		UDeadlineCloudDeveloperSettings::GetMutable()->DefaultJobPreset = ResultJob;
+	}
+
+	Modify();
+	JobPreset = ResultJob;
+	if (OnRequestDetailsRefresh.IsBound())
+	{
+		OnRequestDetailsRefresh.Execute();
+	}
 }
 
 void UMoviePipelineDeadlineCloudExecutorJob::GetPresetStructWithOverrides(UStruct* InStruct, const void* InContainer, void* OutContainer) const
@@ -144,9 +242,7 @@ FDeadlineCloudJobParametersArray UMoviePipelineDeadlineCloudExecutorJob::GetPara
 	);
 
 	return ReturnValue;
-
 }
-
 
 void UMoviePipelineDeadlineCloudExecutorJob::UpdateAttachmentFields()
 {
@@ -157,54 +253,50 @@ void UMoviePipelineDeadlineCloudExecutorJob::UpdateAttachmentFields()
 void UMoviePipelineDeadlineCloudExecutorJob::JobPresetChanged()
 {
 	UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: JobPresetChanged called"));
-	const UDeadlineCloudJob* SelectedJobPreset = this->JobPreset;
-
-	if (!SelectedJobPreset)
+	if (!IsValid(JobPreset))
 	{
 		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: JobPreset is null, creating default in JobPresetChanged"));
-		this->JobPreset = CreateDefaultJobPresetFromTemplates(JobPreset);
-		SelectedJobPreset = this->JobPreset;
+		JobPreset = CreateDefaultJobPresetFromTemplates(JobPreset);
 	} else {
 		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: JobPreset exists in JobPresetChanged"));
 	}
 
-	this->PresetOverrides.HostRequirements = SelectedJobPreset->JobPresetStruct.HostRequirements;
-	this->PresetOverrides.JobSharedSettings = SelectedJobPreset->JobPresetStruct.JobSharedSettings;
+	ReloadDataFromJobPreset();
 
-	this->PresetOverrides.JobAttachments.InputFiles.Files =
-		SelectedJobPreset->JobPresetStruct.JobAttachments.InputFiles.Files;
-
-	this->PresetOverrides.JobAttachments.InputDirectories.Directories =
-		SelectedJobPreset->JobPresetStruct.JobAttachments.InputDirectories.Directories;
-
-	this->PresetOverrides.JobAttachments.OutputDirectories.Directories =
-		SelectedJobPreset->JobPresetStruct.JobAttachments.OutputDirectories.Directories;
-
-	this->JobTemplateOverrides.Parameters = SelectedJobPreset->ParameterDefinition.Parameters;
-
-	this->JobTemplateOverrides.StepsOverrides = GetStepsToOverride(SelectedJobPreset);
-	this->JobTemplateOverrides.EnvironmentsOverrides = GetEnvironmentsToOverride(SelectedJobPreset);
+	if (IsUsingDefaultPreset())
+	{
+		ApplyLastUsedTo(this);
+	}
 }
 
 void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
 {
-	
-	if (PropertyChangedEvent.Property)
-	{
-	// Check if we changed the job Preset an update the override details
-	if (const FName PropertyName = PropertyChangedEvent.GetPropertyName(); PropertyName == "JobPreset")
-	{
-		JobPresetChanged();
+	Super::PostEditChangeProperty(PropertyChangedEvent);
 
-		// Update MRQ widget request
-		if (OnRequestDetailsRefresh.IsBound())
+	if (!HasAnyFlags(RF_ClassDefaultObject))
+	{
+		if (PropertyChangedEvent.Property)
 		{
-			OnRequestDetailsRefresh.Execute();
-		}
-	}
+			// Check if we changed the job Preset an update the override details
+			if (const FName PropertyName = PropertyChangedEvent.GetPropertyName(); PropertyName == "JobPreset")
+			{
+				JobPresetChanged();
 
-	UE_LOG(LogTemp, Display, TEXT("Deadline Cloud job changed: %s"),
-		*PropertyChangedEvent.Property->GetPathName());
+				// Update MRQ widget request
+				if (OnRequestDetailsRefresh.IsBound())
+				{
+					OnRequestDetailsRefresh.Execute();
+				}
+			}
+
+			if (IsUsingDefaultPreset())
+			{
+				SaveLastUsedFrom(this);
+			}
+
+			UE_LOG(LogTemp, Display, TEXT("Deadline Cloud job changed: %s"),
+				*PropertyChangedEvent.Property->GetPathName());
+		}
 	}
 }
 
@@ -225,9 +317,12 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 		return false;
 	}
 
+	const FString AssetName  = FPackageName::GetLongPackageAssetName(LongPackagePath);
+	const FString ObjectPath = LongPackagePath + TEXT(".") + AssetName;
+
 	// Check AssetRegistry
 	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
-	FAssetData AssetData = AssetRegistryModule.Get().GetAssetByObjectPath(*LongPackagePath);
+	FAssetData AssetData = AssetRegistryModule.Get().GetAssetByObjectPath(FSoftObjectPath(ObjectPath));
 
 	if (!AssetData.IsValid())
 	{
@@ -251,7 +346,6 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 
 void UMoviePipelineDeadlineCloudExecutorJob::CollectDependencies()
 {
-
 	if (GEngine)
 	{
 		UE_LOG(LogTemp, Display, TEXT("Running Garbage Collection before dependency update..."));
@@ -284,7 +378,6 @@ void UMoviePipelineDeadlineCloudExecutorJob::CollectDependencies()
 			{
 				UE_LOG(LogTemp, Error, TEXT("Error get DeadlineCloudJobBundleLibrary"));
 			}
-
 		});
 }
 
@@ -328,6 +421,119 @@ void UMoviePipelineDeadlineCloudExecutorJob::UpdateInputFilesProperty()
 	{
 		PresetOverrides.JobAttachments.InputFiles.AutoDetected.Paths.Empty();
 	}
+}
+
+void UMoviePipelineDeadlineCloudExecutorJob::ReloadDataFromJobPreset()
+{
+	PresetOverrides.HostRequirements = JobPreset->JobPresetStruct.HostRequirements;
+	PresetOverrides.JobSharedSettings = JobPreset->JobPresetStruct.JobSharedSettings;
+
+	PresetOverrides.JobAttachments.InputFiles.Files =
+		JobPreset->JobPresetStruct.JobAttachments.InputFiles.Files;
+
+	PresetOverrides.JobAttachments.InputDirectories.Directories =
+		JobPreset->JobPresetStruct.JobAttachments.InputDirectories.Directories;
+
+	PresetOverrides.JobAttachments.OutputDirectories.Directories =
+		JobPreset->JobPresetStruct.JobAttachments.OutputDirectories.Directories;
+
+	JobTemplateOverrides.Parameters = JobPreset->ParameterDefinition.Parameters;
+
+	JobTemplateOverrides.StepsOverrides = GetStepsToOverride(JobPreset);
+	JobTemplateOverrides.EnvironmentsOverrides = GetEnvironmentsToOverride(JobPreset);
+}
+
+void UMoviePipelineDeadlineCloudExecutorJob::GeneratePresetObjectsNames(
+	const UMoviePipelineDeadlineCloudExecutorJob* MrqJob,
+	const FString& FolderPath, const FString& BaseName,
+	TMap<UDataAsset*, FString>& OutPresetPackageNames
+)
+{
+	if (!MrqJob || !MrqJob->JobPreset)
+	{
+		return;
+	}
+
+	FString NewName = UPackageTools::SanitizePackageName(FolderPath + TEXT("/") + BaseName);
+
+	OutPresetPackageNames.Add(MrqJob->JobPreset, NewName);
+
+	for (int i = 0; i < MrqJob->JobPreset->Steps.Num(); i++)
+	{
+		auto Step = MrqJob->JobPreset->Steps[i];
+
+		if (IsValid(Step))
+		{
+			FString StepName = NewName + "_" + "Step" + FString::FromInt(i + 1);
+			OutPresetPackageNames.Add(Step, StepName);
+
+			for (int j = 0; j < Step->Environments.Num(); j++)
+			{
+				auto Env = Step->Environments[j];
+				if (IsValid(Env))
+				{
+					FString EnvName = StepName + "_" + "Environment" + FString::FromInt(j + 1);
+					OutPresetPackageNames.Add(Env, EnvName);
+				}
+			}
+		}
+	}
+
+	for (int i = 0; i < MrqJob->JobPreset->Environments.Num(); i++)
+	{
+		auto Env = MrqJob->JobPreset->Environments[i];
+		if (IsValid(Env))
+		{
+			FString EnvName = NewName + "_" + "Environment" + FString::FromInt(i + 1);
+			OutPresetPackageNames.Add(Env, EnvName);
+		}
+	}
+}
+
+void UMoviePipelineDeadlineCloudExecutorJob::CopyEnvironmentOverrides(UDeadlineCloudEnvironment* Environment)
+{
+	for (auto& EnvOverride : JobTemplateOverrides.EnvironmentsOverrides)
+	{
+		if (EnvOverride.Name == Environment->Name)
+		{
+			Environment->Variables = EnvOverride.Variables;
+			return;
+		}
+	}
+
+	for (auto& StepOverride : JobTemplateOverrides.StepsOverrides)
+	{
+		for (auto& EnvOverride : StepOverride.EnvironmentsOverrides)
+		{
+			if (EnvOverride.Name == Environment->Name)
+			{
+				Environment->Variables = EnvOverride.Variables;
+				return;
+			}
+		}
+	}
+}
+
+void UMoviePipelineDeadlineCloudExecutorJob::CopyStepOverrides(UDeadlineCloudStep* Step)
+{
+	for (auto& StepOverride : JobTemplateOverrides.StepsOverrides)
+	{
+		if (StepOverride.Name == Step->Name)
+		{
+			Step->TaskParameterDefinitions.Parameters = StepOverride.TaskParameterDefinitions.Parameters;
+			break;
+		}
+	}
+}
+
+void UMoviePipelineDeadlineCloudExecutorJob::CopyJobOverrides(UDeadlineCloudRenderJob* Job)
+{
+	Job->JobPresetStruct.HostRequirements = PresetOverrides.HostRequirements;
+	Job->JobPresetStruct.JobSharedSettings = PresetOverrides.JobSharedSettings;
+	Job->JobPresetStruct.JobAttachments.InputFiles = PresetOverrides.JobAttachments.InputFiles;
+	Job->JobPresetStruct.JobAttachments.InputDirectories = PresetOverrides.JobAttachments.InputDirectories;
+	Job->JobPresetStruct.JobAttachments.OutputDirectories = PresetOverrides.JobAttachments.OutputDirectories;
+	Job->ParameterDefinition.Parameters = JobTemplateOverrides.Parameters;
 }
 
 void UMoviePipelineDeadlineCloudExecutorJob::UpdateInputDirectoriesProperty()
@@ -386,6 +592,23 @@ TArray<FString> UMoviePipelineDeadlineCloudExecutorJob::GetCpuArchitectures()
 	return {};
 }
 
+bool UMoviePipelineDeadlineCloudExecutorJob::IsUsingDefaultPreset() const
+{
+	auto DefaultJobPreset = UDeadlineCloudDeveloperSettings::GetDefaultJobPreset();
+
+    return JobPreset == DefaultJobPreset;
+}
+
+void UMoviePipelineDeadlineCloudExecutorJob::SaveLastUsedFrom(const UMoviePipelineDeadlineCloudExecutorJob* Source)
+{
+	UDeadlineCloudDeveloperSettings::SaveMRQJobPresetCache(Source);
+}
+
+void UMoviePipelineDeadlineCloudExecutorJob::ApplyLastUsedTo(UMoviePipelineDeadlineCloudExecutorJob* Target)
+{
+	UDeadlineCloudDeveloperSettings::LoadMRQJobPresetCache(Target);
+}
+
 TArray<FString> UMoviePipelineDeadlineCloudExecutorJob::GetOperatingSystems()
 {
 	if (auto Library = UDeadlineCloudJobBundleLibrary::Get())
@@ -419,44 +642,52 @@ UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJo
 
 	if (Preset == nullptr)
 	{
-		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Creating new UDeadlineCloudRenderJob"));
+		auto DefaultPreset = UDeadlineCloudDeveloperSettings::GetDefaultJobPreset();
+		if (IsValid(DefaultPreset))
+		{
+			Preset = DefaultPreset;
+		}
+		else
+		{
+			UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Creating new UDeadlineCloudRenderJob"));
+			Preset = NewObject<UDeadlineCloudRenderJob>();
 
-		Preset = NewObject<UDeadlineCloudRenderJob>();
+			FString DefaultTemplate = "/Content/Python/openjd_templates/render_job.yml";
+			FString StepTemplate = "/Content/Python/openjd_templates/render_step.yml";
+			FString EnvTemplate = "/Content/Python/openjd_templates/launch_ue_environment.yml";
 
-		FString DefaultTemplate = "/Content/Python/openjd_templates/render_job.yml";
-		FString StepTemplate = "/Content/Python/openjd_templates/render_step.yml";
-		FString EnvTemplate = "/Content/Python/openjd_templates/launch_ue_environment.yml";
+			FString  PluginContentDir = IPluginManager::Get().FindPlugin(TEXT("UnrealDeadlineCloudService"))->GetBaseDir();
 
-		FString PluginContentDir = IPluginManager::Get().FindPlugin(TEXT("UnrealDeadlineCloudService"))->GetBaseDir();
+			FString PathToJobTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), DefaultTemplate);
+			FPaths::NormalizeDirectoryName(PathToJobTemplate);
+			UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Looking for job template at: %s"), *PathToJobTemplate);
+			
+			UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Job template found, opening file"));
+			Preset->PathToTemplate.FilePath = PathToJobTemplate;
+			Preset->OpenJobFile(PathToJobTemplate);
 
-		FString PathToJobTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), DefaultTemplate);
-		FPaths::NormalizeDirectoryName(PathToJobTemplate);
-		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Looking for job template at: %s"), *PathToJobTemplate);
+			TObjectPtr <UDeadlineCloudRenderStep> PresetStep;
+			PresetStep = NewObject<UDeadlineCloudRenderStep>();
+			FString PathToStepTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), StepTemplate);
+			FPaths::NormalizeDirectoryName(PathToStepTemplate);
+			UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Looking for step template at: %s"), *PathToStepTemplate);
+			
+			PresetStep->PathToTemplate.FilePath = PathToStepTemplate;
+			PresetStep->OpenStepFile(PathToStepTemplate);
+			Preset->Steps.Add(PresetStep);
 
-		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Job template found, opening file"));
-		Preset->PathToTemplate.FilePath = PathToJobTemplate;
-		Preset->OpenJobFile(PathToJobTemplate);
+			UDeadlineCloudEnvironment* PresetEnv;
+			PresetEnv = NewObject<UDeadlineCloudEnvironment>();
+			FString PathToEnvTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), EnvTemplate);
+			FPaths::NormalizeDirectoryName(PathToEnvTemplate);
+			UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Looking for env template at: %s"), *PathToEnvTemplate);
+			
+			PresetEnv->PathToTemplate.FilePath = PathToEnvTemplate;
+			PresetEnv->OpenEnvFile(PathToEnvTemplate);
+			Preset->Environments.Add(PresetEnv);
+			UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates completed successfully"));
+		}
 
-		TObjectPtr <UDeadlineCloudRenderStep> PresetStep;
-		PresetStep = NewObject<UDeadlineCloudRenderStep>();
-		FString PathToStepTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), StepTemplate);
-		FPaths::NormalizeDirectoryName(PathToStepTemplate);
-		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Looking for step template at: %s"), *PathToStepTemplate);
-
-		PresetStep->PathToTemplate.FilePath = PathToStepTemplate;
-		PresetStep->OpenStepFile(PathToStepTemplate);
-		Preset->Steps.Add(PresetStep);
-
-		UDeadlineCloudEnvironment* PresetEnv;
-		PresetEnv = NewObject<UDeadlineCloudEnvironment>();
-		FString PathToEnvTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), EnvTemplate);
-		FPaths::NormalizeDirectoryName(PathToEnvTemplate);
-		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Looking for env template at: %s"), *PathToEnvTemplate);
-
-		PresetEnv->PathToTemplate.FilePath = PathToEnvTemplate;
-		PresetEnv->OpenEnvFile(PathToEnvTemplate);
-		Preset->Environments.Add(PresetEnv);
-		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates completed successfully"));
 	}
 	return Preset;
 }
@@ -483,6 +714,54 @@ TArray<FDeadlineCloudStepOverride> UMoviePipelineDeadlineCloudExecutorJob::GetSt
 		}
 	}
 	return DeadlineStepsOverrides;
+}
+
+void UMoviePipelineDeadlineCloudExecutorJob::FixReferencesAfterDuplication(TMap<UDataAsset*, FString>& SourceObjects, TArray<UDataAsset*> NewObjects)
+{
+    TArray<UDataAsset*> OldObjects;
+    OldObjects.Reserve(SourceObjects.Num());
+    for (const TPair<UDataAsset*, FString>& Pair : SourceObjects)
+    {
+        OldObjects.Add(Pair.Key);
+    }
+
+    if (OldObjects.Num() != NewObjects.Num())
+    {
+        UE_LOG(LogTemp, Warning, TEXT("FixReferencesAfterDuplication: size mismatch Old=%d New=%d"),
+            OldObjects.Num(), NewObjects.Num());
+    }
+
+    const int32 Count = FMath::Min(OldObjects.Num(), NewObjects.Num());
+
+    TMap<UObject*, UObject*> ReplacementMap;
+    ReplacementMap.Reserve(Count);
+    for (int32 i = 0; i < Count; ++i)
+    {
+        if (OldObjects[i] && NewObjects[i])
+        {
+            ReplacementMap.Add(OldObjects[i], NewObjects[i]);
+        }
+    }
+
+    for (UDataAsset* NewAsset : NewObjects)
+    {
+        if (!NewAsset) { continue; }
+
+        NewAsset->Modify(); 
+
+        {
+            FArchiveReplaceObjectRef<UObject> ReplaceAr(
+                NewAsset,
+                ReplacementMap,
+                EArchiveReplaceObjectFlags::None
+            );
+        }
+
+#if WITH_EDITOR
+        NewAsset->PostEditChange();
+        NewAsset->MarkPackageDirty();
+#endif
+	}
 }
 
 TArray<FDeadlineCloudEnvironmentOverride> UMoviePipelineDeadlineCloudExecutorJob::GetEnvironmentsToOverride(const UDeadlineCloudJob* Preset)
@@ -555,11 +834,70 @@ void FMoviePipelineDeadlineCloudExecutorJobCustomization::CustomizeDetails(IDeta
 					)
 				];
 		}
-		
+		else if (PropertyName == GET_MEMBER_NAME_CHECKED(UMoviePipelineDeadlineCloudExecutorJob, JobPreset))
+		{
+			const FResetToDefaultOverride ResetDefaultOverride = FResetToDefaultOverride::Create(
+				FIsResetToDefaultVisible::CreateLambda([](TSharedPtr<IPropertyHandle> PropertyHandle) {return true; }),
+            FResetToDefaultHandler::CreateSP(this, &FMoviePipelineDeadlineCloudExecutorJobCustomization::ResetPresetToDefaultHandler)
+			);
 
+			DeadlineCategory.AddProperty(PropertyName)
+				.OverrideResetToDefault(ResetDefaultOverride)
+				.CustomWidget()
+				.NameContent()
+				[
+					Property->CreatePropertyNameWidget()
+				]
+				.ValueContent()
+				[
+					SNew(SHorizontalBox)
+						+ SHorizontalBox::Slot()
+						.FillWidth(1.0f)
+						[
+							Property->CreatePropertyValueWidget()
+						]
+						+ SHorizontalBox::Slot()
+						.AutoWidth()
+						.VAlign(VAlign_Top)
+						.HAlign(HAlign_Center)
+						.Padding(2.0f, 4.0f)
+						[
+							SNew(SButton)
+								.ToolTipText(FText::FromString("Save the current job preset."))
+								.ButtonStyle(FAppStyle::Get(), "SimpleButton")
+								.ContentPadding(FMargin(2.f))
+								.IsEnabled_Lambda([this]() 
+									{ 
+										return MrqJob.IsValid() && MrqJob->JobPreset != nullptr; 
+									})
+								.OnClicked_Lambda([this]() 
+									{ 
+										FDeadlineCloudDetailsWidgetsHelper::CreateSavePresetDialogWidget(MrqJob.Get());
+										return FReply::Handled();
+									})
+								[
+									SNew(SImage)
+										.Image(FAppStyle::Get().GetBrush("Icons.Save"))
+								]
+						]
+
+				];
+		}
 		else
 		{
 			DeadlineCategory.AddProperty(Property);
 		}
+	}
+
+	IDetailCategoryBuilder& DeadlineCloudCategoryBuilder = DetailBuilder.EditCategory(
+		"DeadlineCloud"
+	);
+}
+
+void FMoviePipelineDeadlineCloudExecutorJobCustomization::ResetPresetToDefaultHandler(TSharedPtr<IPropertyHandle> PropertyHandle) const
+{
+	if (MrqJob.IsValid() && MrqJob->JobPreset)
+	{
+		MrqJob->ReloadDataFromJobPreset();
 	}
 }

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -903,5 +903,9 @@ void FMoviePipelineDeadlineCloudExecutorJobCustomization::ResetPresetToDefaultHa
 	if (MrqJob.IsValid() && MrqJob->JobPreset)
 	{
 		MrqJob->ReloadDataFromJobPreset();
+		if (MrqJob->OnRequestDetailsRefresh.IsBound())
+		{
+			MrqJob->OnRequestDetailsRefresh.Execute();
+		}
 	}
 }

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -23,6 +23,7 @@
 #include "ObjectTools.h"
 #include "UObject/SavePackage.h"
 #include "Serialization/ArchiveReplaceObjectRef.h"
+#include "Framework/MetaData/DriverMetaData.h"
 
 UMoviePipelineDeadlineCloudExecutorJob::UMoviePipelineDeadlineCloudExecutorJob()
 {
@@ -110,6 +111,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::SaveAsJobPreset(FString& FolderPath
 		if (ExistingAsset.IsValid())
 		{
 			ObjectTools::DeleteAssets({ ExistingAsset }, false);
+
 		}
 		
 		UPackage* Pkg = CreatePackage(*PackageName);
@@ -758,7 +760,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::FixReferencesAfterDuplication(TMap<
         }
 
 #if WITH_EDITOR
-        NewAsset->PostEditChange();
+        FCoreUObjectDelegates::OnObjectModified.Broadcast(NewAsset);
         NewAsset->MarkPackageDirty();
 #endif
 	}
@@ -841,6 +843,25 @@ void FMoviePipelineDeadlineCloudExecutorJobCustomization::CustomizeDetails(IDeta
             FResetToDefaultHandler::CreateSP(this, &FMoviePipelineDeadlineCloudExecutorJobCustomization::ResetPresetToDefaultHandler)
 			);
 
+			TSharedRef<SWidget> SaveButtonWidget = SNew(SButton)
+				.ToolTipText(FText::FromString("Save the current job preset."))
+				.ButtonStyle(FAppStyle::Get(), "SimpleButton")
+				.ContentPadding(FMargin(2.f))
+				.IsEnabled_Lambda([this]() 
+					{ 
+						return MrqJob.IsValid() && MrqJob->JobPreset != nullptr; 
+					})
+				.OnClicked_Lambda([this]() 
+					{ 
+						FDeadlineCloudDetailsWidgetsHelper::CreateSavePresetDialogWidget(MrqJob.Get());
+						return FReply::Handled();
+					})
+					[
+						SNew(SImage)
+							.Image(FAppStyle::Get().GetBrush("Icons.Save"))
+					];
+			SaveButtonWidget->AddMetadata(FDriverMetaData::Id(FName("MRQJobSavePresetButton")));
+
 			DeadlineCategory.AddProperty(PropertyName)
 				.OverrideResetToDefault(ResetDefaultOverride)
 				.CustomWidget()
@@ -862,25 +883,8 @@ void FMoviePipelineDeadlineCloudExecutorJobCustomization::CustomizeDetails(IDeta
 						.HAlign(HAlign_Center)
 						.Padding(2.0f, 4.0f)
 						[
-							SNew(SButton)
-								.ToolTipText(FText::FromString("Save the current job preset."))
-								.ButtonStyle(FAppStyle::Get(), "SimpleButton")
-								.ContentPadding(FMargin(2.f))
-								.IsEnabled_Lambda([this]() 
-									{ 
-										return MrqJob.IsValid() && MrqJob->JobPreset != nullptr; 
-									})
-								.OnClicked_Lambda([this]() 
-									{ 
-										FDeadlineCloudDetailsWidgetsHelper::CreateSavePresetDialogWidget(MrqJob.Get());
-										return FReply::Handled();
-									})
-								[
-									SNew(SImage)
-										.Image(FAppStyle::Get().GetBrush("Icons.Save"))
-								]
+							SaveButtonWidget
 						]
-
 				];
 		}
 		else

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -83,13 +83,6 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostInitProperties()
 
 void UMoviePipelineDeadlineCloudExecutorJob::SaveAsJobPreset(FString& FolderPath, FString& BaseName, bool bSetAsDefault)
 {
-	IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
-
-	if (DesktopPlatform == nullptr)
-	{
-		return;
-	}
-
 	TMap<UDataAsset*, FString> ObjectsNames;
 
 	UMoviePipelineDeadlineCloudExecutorJob::GeneratePresetObjectsNames(this, FolderPath, BaseName, ObjectsNames);
@@ -439,8 +432,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::ReloadDataFromJobPreset()
 	PresetOverrides.JobAttachments.OutputDirectories.Directories =
 		JobPreset->JobPresetStruct.JobAttachments.OutputDirectories.Directories;
 
-	JobTemplateOverrides.Parameters = JobPreset->ParameterDefinition.Parameters;
-
+	JobTemplateOverrides.Parameters = JobPreset->GetParametersDataToOverride();
 	JobTemplateOverrides.StepsOverrides = GetStepsToOverride(JobPreset);
 	JobTemplateOverrides.EnvironmentsOverrides = GetEnvironmentsToOverride(JobPreset);
 }
@@ -466,7 +458,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::GeneratePresetObjectsNames(
 
 		if (IsValid(Step))
 		{
-			FString StepName = NewName + "_" + "Step" + FString::FromInt(i + 1);
+			FString StepName = NewName + "_Step" + FString::FromInt(i + 1);
 			OutPresetPackageNames.Add(Step, StepName);
 
 			for (int j = 0; j < Step->Environments.Num(); j++)
@@ -474,7 +466,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::GeneratePresetObjectsNames(
 				auto Env = Step->Environments[j];
 				if (IsValid(Env))
 				{
-					FString EnvName = StepName + "_" + "Environment" + FString::FromInt(j + 1);
+					FString EnvName = StepName + "_Environment" + FString::FromInt(j + 1);
 					OutPresetPackageNames.Add(Env, EnvName);
 				}
 			}
@@ -486,7 +478,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::GeneratePresetObjectsNames(
 		auto Env = MrqJob->JobPreset->Environments[i];
 		if (IsValid(Env))
 		{
-			FString EnvName = NewName + "_" + "Environment" + FString::FromInt(i + 1);
+			FString EnvName = NewName + "_Environment" + FString::FromInt(i + 1);
 			OutPresetPackageNames.Add(Env, EnvName);
 		}
 	}
@@ -558,7 +550,6 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeChainProperty(FProper
 	{
 		static const FName InputFilesName = GET_MEMBER_NAME_CHECKED(FDeadlineCloudAttachmentsStruct, InputFiles);
 		static const FName InputDirectoriesName = GET_MEMBER_NAME_CHECKED(FDeadlineCloudAttachmentsStruct, InputDirectories);
-		// static const FName OutputDirectoriesName = GET_MEMBER_NAME_CHECKED(FDeadlineCloudAttachmentsStruct, OutputDirectories);
 
 		const FProperty* Property = PropertyChangedEvent.PropertyChain.GetActiveNode()->GetPrevNode()->GetValue();
 		if (Property->GetFName() == InputFilesName)
@@ -689,8 +680,8 @@ UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJo
 			Preset->Environments.Add(PresetEnv);
 			UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates completed successfully"));
 		}
-
 	}
+
 	return Preset;
 }
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -103,8 +103,8 @@ void UMoviePipelineDeadlineCloudExecutorJob::SaveAsJobPreset(FString& FolderPath
 
 		if (ExistingAsset.IsValid())
 		{
+			// Delete existing asset with the same path
 			ObjectTools::DeleteAssets({ ExistingAsset }, false);
-
 		}
 		
 		UPackage* Pkg = CreatePackage(*PackageName);
@@ -112,6 +112,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::SaveAsJobPreset(FString& FolderPath
 		UDataAsset* NewObj = DuplicateObject<UDataAsset>(Asset, Pkg, *FPaths::GetBaseFilename(PackageName));
 		if (!NewObj)
 		{
+			UE_LOG(LogTemp, Error, TEXT("Could not duplicate asset: %s"), *PackageName);
 			return;
 		}
 
@@ -147,13 +148,16 @@ void UMoviePipelineDeadlineCloudExecutorJob::SaveAsJobPreset(FString& FolderPath
 		ResultAssets.Add(NewObj);
 	}
 
+	// replace old references with new ones
 	FixReferencesAfterDuplication(ObjectsNames, ResultAssets);
 
 	if (bSetAsDefault)
 	{
+		// Set as default in settings
 		UDeadlineCloudDeveloperSettings::GetMutable()->DefaultJobPreset = ResultJob;
 	}
 
+	// Update current job to use the new preset
 	Modify();
 	JobPreset = ResultJob;
 	if (OnRequestDetailsRefresh.IsBound())
@@ -437,6 +441,43 @@ void UMoviePipelineDeadlineCloudExecutorJob::ReloadDataFromJobPreset()
 	JobTemplateOverrides.EnvironmentsOverrides = GetEnvironmentsToOverride(JobPreset);
 }
 
+void UMoviePipelineDeadlineCloudExecutorJob::GetPresetObjectsNames(const UMoviePipelineDeadlineCloudExecutorJob* MrqJob, TMap<UDataAsset*, FString>& OutPresetPackageNames)
+{
+	if (!MrqJob || !MrqJob->JobPreset)
+	{
+		return;
+	}
+
+	FString PackageName = FSoftObjectPath(MrqJob->JobPreset).GetLongPackageName();
+	OutPresetPackageNames.Add(MrqJob->JobPreset, PackageName);
+	for (auto Step : MrqJob->JobPreset->Steps)
+	{
+		if (IsValid(Step))
+		{
+			PackageName = FSoftObjectPath(Step).GetLongPackageName();
+			OutPresetPackageNames.Add(Step, PackageName);
+
+			for (auto Env : Step->Environments)
+			{
+				if (IsValid(Env))
+				{
+					PackageName = FSoftObjectPath(Env).GetLongPackageName();
+					OutPresetPackageNames.Add(Env, PackageName);
+				}
+			}
+		}
+	}
+
+	for (auto Env : MrqJob->JobPreset->Environments)
+	{
+		if (IsValid(Env))
+		{
+			PackageName = FSoftObjectPath(Env).GetLongPackageName();
+			OutPresetPackageNames.Add(Env, PackageName);
+		}
+	}
+}
+
 void UMoviePipelineDeadlineCloudExecutorJob::GeneratePresetObjectsNames(
 	const UMoviePipelineDeadlineCloudExecutorJob* MrqJob,
 	const FString& FolderPath, const FString& BaseName,
@@ -452,37 +493,59 @@ void UMoviePipelineDeadlineCloudExecutorJob::GeneratePresetObjectsNames(
 
 	OutPresetPackageNames.Add(MrqJob->JobPreset, NewName);
 
-	for (int i = 0; i < MrqJob->JobPreset->Steps.Num(); i++)
+	uint32 StepIndex = 1;
+	for (const auto& Step : MrqJob->JobPreset->Steps)
 	{
-		auto Step = MrqJob->JobPreset->Steps[i];
-
 		if (IsValid(Step))
 		{
-			FString StepName = NewName + "_Step" + FString::FromInt(i + 1);
-			OutPresetPackageNames.Add(Step, StepName);
-
-			for (int j = 0; j < Step->Environments.Num(); j++)
+			if (OutPresetPackageNames.Contains(Step))
 			{
-				auto Env = Step->Environments[j];
-				if (IsValid(Env))
+				// Already added
+				continue;
+			}
+
+			FString StepName = NewName + "_Step" + FString::FromInt(StepIndex);
+			OutPresetPackageNames.Add(Step, StepName);
+			StepIndex++;
+
+			// Add step environments
+			uint32 StepEnvIndex = 1;
+			for (const auto& StepEnv : Step->Environments)
+			{
+				if (IsValid(StepEnv))
 				{
-					FString EnvName = StepName + "_Environment" + FString::FromInt(j + 1);
-					OutPresetPackageNames.Add(Env, EnvName);
+					if (OutPresetPackageNames.Contains(StepEnv))
+					{
+						// Already added
+						continue;
+					}
+					FString EnvName = StepName + "_Environment" + FString::FromInt(StepEnvIndex);
+					OutPresetPackageNames.Add(StepEnv, EnvName);
+					StepEnvIndex++;
 				}
 			}
 		}
 	}
 
-	for (int i = 0; i < MrqJob->JobPreset->Environments.Num(); i++)
+	// Add job environments
+	uint32 EnvIndex = 1;
+	for (const auto& Env : MrqJob->JobPreset->Environments)
 	{
-		auto Env = MrqJob->JobPreset->Environments[i];
 		if (IsValid(Env))
 		{
-			FString EnvName = NewName + "_Environment" + FString::FromInt(i + 1);
+			if (OutPresetPackageNames.Contains(Env))
+			{
+				// Already added
+				continue;
+			}
+
+			FString EnvName = NewName + "_Environment" + FString::FromInt(EnvIndex);
 			OutPresetPackageNames.Add(Env, EnvName);
 		}
 	}
 }
+
+
 
 void UMoviePipelineDeadlineCloudExecutorJob::CopyEnvironmentOverrides(UDeadlineCloudEnvironment* Environment)
 {
@@ -742,13 +805,11 @@ void UMoviePipelineDeadlineCloudExecutorJob::FixReferencesAfterDuplication(TMap<
 
         NewAsset->Modify(); 
 
-        {
-            FArchiveReplaceObjectRef<UObject> ReplaceAr(
-                NewAsset,
-                ReplacementMap,
-                EArchiveReplaceObjectFlags::None
-            );
-        }
+        FArchiveReplaceObjectRef<UObject> ReplaceAr(
+            NewAsset,
+            ReplacementMap,
+            EArchiveReplaceObjectFlags::None
+        );
 
 #if WITH_EDITOR
         FCoreUObjectDelegates::OnObjectModified.Broadcast(NewAsset);

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UI.spec.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UI.spec.cpp
@@ -21,6 +21,8 @@
 #include "PythonAPILibraries/DeadlineCloudJobBundleLibrary.h"
 #include "PythonAPILibraries/PythonParametersConsistencyChecker.h"
 #include "DeadlineCloudJobSettings/DeadlineCloudInputValidationHelper.h"
+#include "DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.h"
+#include "DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h"
 
 #include "Tests/AutomationCommon.h"
 #include "Subsystems/AssetEditorSubsystem.h"
@@ -33,6 +35,8 @@
 
 #include "PropertyEditorModule.h"
 #include "IDetailsView.h"
+#include "PackageTools.h"
+#include "AssetViewUtils.h"
 
 #include "MoviePipelineQueueSubsystem.h"
 
@@ -48,6 +52,118 @@
 #define EPIC_TEST_BOOLEAN_(text, expression, expected) \
 	TestEqual(text, expression, expected);
 
+static void BuildMinimalPreset(UMoviePipelineDeadlineCloudExecutorJob* ExecJob)
+{
+    const FString Path = TEXT("/UnrealDeadlineCloudService/OpenJD_DataAssets/Default/OpenJD_Default_RenderJob.OpenJD_Default_RenderJob");
+    
+    UDeadlineCloudRenderJob* DefaultJob = LoadObject<UDeadlineCloudRenderJob>(nullptr, *Path);
+    check(DefaultJob);
+
+    ExecJob->JobPreset = DefaultJob;
+	ExecJob->ReloadDataFromJobPreset();
+}
+
+static void CleanupCreatedAssets(const FString& FolderPath, FAutomationTestBase* Test)
+{
+    FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+
+    TArray<FAssetData> Assets;
+    AssetRegistryModule.Get().GetAssetsByPath(*FolderPath, Assets, true);
+
+    if (Assets.Num() == 0)
+    {
+        return;
+    }
+
+	TArray<UObject*> ObjectsToDelete;
+    for (const FAssetData& Asset : Assets)
+    {
+        UObject* AssetObj = Asset.GetAsset();
+        if (AssetObj)
+        {
+            ObjectsToDelete.Add(AssetObj);
+        }
+    }
+
+    ObjectTools::DeleteObjects(ObjectsToDelete, false);
+	AssetViewUtils::DeleteFolders({ FolderPath });
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSaveAsJobPreset_BasicCreation,
+	"DeadlineCloud.SaveAsJobPreset.BasicCreation",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSaveAsJobPreset_BasicCreation::RunTest(const FString& Parameters)
+{
+	UMoviePipelineDeadlineCloudExecutorJob* ExecJob = NewObject<UMoviePipelineDeadlineCloudExecutorJob>();
+	TestNotNull(TEXT("ExecutorJob must be created"), ExecJob);
+
+	BuildMinimalPreset(ExecJob);
+
+	const FString FolderPath = TEXT("/Game/Automated/DeadlineCloud/") + FGuid::NewGuid().ToString(EGuidFormats::Digits);
+	FString BaseName         = TEXT("Preset_") + FGuid::NewGuid().ToString(EGuidFormats::Digits);
+
+	FString FolderCopy = FolderPath;
+	FString BaseCopy   = BaseName;
+	ExecJob->SaveAsJobPreset(FolderCopy, BaseCopy, false);
+
+	FAssetRegistryModule& ARM = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	FARFilter Filter;
+	Filter.PackagePaths.Add(*FolderPath);
+	Filter.bRecursivePaths = true;
+
+	TArray<FAssetData> FoundAssets;
+	ARM.Get().GetAssets(Filter, FoundAssets);
+	TestTrue(*FString::Printf(TEXT("Assets should be created in %s"), *FolderPath), FoundAssets.Num() > 0);
+
+	bool bAnyHasFlags = false;
+	for (const FAssetData& AD : FoundAssets)
+	{
+		if (const UObject* Obj = AD.GetAsset())
+		{
+			const EObjectFlags Flags = Obj->GetFlags();
+			if ((Flags & RF_Public) && (Flags & RF_Standalone))
+			{
+				bAnyHasFlags = true;
+				break;
+			}
+		}
+	}
+	TestTrue(TEXT("At least one created asset should have RF_Public | RF_Standalone"), bAnyHasFlags);
+
+	CleanupCreatedAssets(FolderPath, this);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSaveAsJobPreset_OverwritesExisting,
+	"DeadlineCloud.SaveAsJobPreset.OverwritesExisting",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSaveAsJobPreset_OverwritesExisting::RunTest(const FString& Parameters)
+{
+	UMoviePipelineDeadlineCloudExecutorJob* ExecJob = NewObject<UMoviePipelineDeadlineCloudExecutorJob>();
+	ExecJob->AddToRoot();
+	TestNotNull(TEXT("ExecutorJob created"), ExecJob);
+
+	BuildMinimalPreset(ExecJob);
+	TestNotNull(TEXT("Precondition: JobPreset prepared"), ExecJob->JobPreset.Get());
+
+	const FString FolderPath = TEXT("/Game/Automated/DeadlineCloud/") + FGuid::NewGuid().ToString(EGuidFormats::Digits);
+	FString BaseName         = TEXT("PresetOverwrite_") + FGuid::NewGuid().ToString(EGuidFormats::Digits);
+
+	FString FolderCopy = FolderPath;
+	FString BaseCopy   = BaseName;
+	ExecJob->SaveAsJobPreset(FolderCopy, BaseCopy, false);
+
+	TestNotNull(TEXT("JobPreset after first save"), ExecJob->JobPreset.Get());
+	BuildMinimalPreset(ExecJob);
+	ExecJob->SaveAsJobPreset(FolderCopy, BaseCopy, false);
+
+	TestNotNull(TEXT("JobPreset after second save"), ExecJob->JobPreset.Get());
+	ExecJob->RemoveFromRoot();
+	CleanupCreatedAssets(FolderPath, this);
+	return true;
+}
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FIsValidLength_RangeOK, "DeadlineCloud.Validation.IsValidLength.RangeOK", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 bool FIsValidLength_RangeOK::RunTest(const FString& Parameters)
@@ -579,6 +695,8 @@ void FDeadlinePluginUISpec::Define()
 			FDriverElementRef DefaultEnvCategory = Driver->FindElement(By::Path("#MRQEnvHeader.LaunchUnrealEditor"));
 			FDriverElementRef EmptyStepEnvCategory = Driver->FindElement(By::Path("#MRQStepEnvHeader.Empty"));
 
+			FDriverElementRef SavePresetButton = Driver->FindElement(By::Path("#MRQJobSavePresetButton"));
+
 			auto VisibilityTest = [this](const FString& ParameterName, FDriverElementRef Widget, bool bShouldBeVisible)
 				{
 					ScrollToElement(Driver, List.ToSharedRef(), ScrollBar.ToSharedRef(), Widget, 50);
@@ -592,6 +710,8 @@ void FDeadlinePluginUISpec::Define()
 						TestFalse(ParameterName + " widget should be hidden", bIsVisible);
 					}
 				};
+
+			VisibilityTest("SavePresetButton", SavePresetButton, true);
 
 			VisibilityTest("StringParameters", StringParametersWidget, true);
 			VisibilityTest("PathParameters", PathParametersWidget, true);
@@ -1031,6 +1151,75 @@ void FDeadlinePluginUISpec::Define()
 
 				CreatedEnvironmentDataAsset->RemoveFromRoot();
 				CreatedEnvironmentDataAsset = nullptr;
+		});
+    });
+
+	Describe("DeadlineCloudSavePresetWidget", [this]()
+    {
+		BeforeEach([this]() {
+			MRQJob = NewObject<UMoviePipelineDeadlineCloudExecutorJob>();
+			MRQJob->AddToRoot();
+
+			FDeadlineCloudDetailsWidgetsHelper::CreateSavePresetDialogWidget(MRQJob, false);
+		});
+
+		It("DeadlineCloudSavePresetWidget", EAsyncExecution::ThreadPool, FTimespan::FromSeconds(120), [this]() {
+			FDriverElementRef DialogWidget = Driver->FindElement(By::Path("#DeadlineCloudSavePresetWidget"));
+			FDriverElementRef ErrorWidget = Driver->FindElement(By::Path("#DeadlineCloudSavePresetWidget.ErrorBox"));
+			FDriverElementRef NameWidget = Driver->FindElement(By::Path("#DeadlineCloudSavePresetWidget.NameEditBox"));
+			FDriverElementRef CreateButton = Driver->FindElement(By::Path("#DeadlineCloudSavePresetWidget.CreateButton"));
+			FDriverElementRef CancelButton = Driver->FindElement(By::Path("#DeadlineCloudSavePresetWidget.CancelButton"));
+
+			Driver->Wait(Until::ElementExists(DialogWidget, FWaitTimeout::InSeconds(2.f)));
+			if (!DialogWidget->Exists())
+			{
+				TestTrue(TEXT("Dialog widget should exist"), false);
+				return;
+			}
+
+			DialogWidget->Focus();
+
+			if (!NameWidget->Exists())
+			{
+				TestTrue(TEXT("Name widget should exist"), false);
+				return;
+			}
+
+			if (!CreateButton->Exists())
+			{
+				TestTrue(TEXT("CreateButton widget should exist"), false);
+				return;
+			}
+
+			InputText(NameWidget, "", true);
+			Driver->Wait(FTimespan::FromSeconds(0.5f));
+			TestTrue("Error widget should be visible when name is empty", ErrorWidget->IsVisible());
+			TestFalse("Create button widget should be disabled when name is empty", CreateButton->IsInteractable());
+
+			InputText(NameWidget, "Invalid/", true);
+			Driver->Wait(FTimespan::FromSeconds(0.5f));
+			TestTrue("Error widget should be visible when name contains invalid characters", ErrorWidget->IsVisible());
+			TestFalse("Create button widget should be disabled when name contains invalid characters", CreateButton->IsInteractable());
+
+			InputText(NameWidget, "ValidName", true);
+			Driver->Wait(FTimespan::FromSeconds(0.5f));
+			TestFalse("Error widget should be hidden when name is valid", ErrorWidget->IsVisible());
+			TestTrue("Create button widget should be enabled when name is valid", CreateButton->IsInteractable());
+
+			if (!CancelButton->Exists())
+			{
+				TestTrue(TEXT("CancelButton widget should exist"), false);
+				return;
+			}
+
+			CancelButton->Click(EMouseButtons::Type::Left);
+			Driver->Wait(FTimespan::FromSeconds(1));
+			TestFalse("Dialog widget should be closed after CancelButton click", DialogWidget->Exists());
+		});
+
+        AfterEach([this]() {
+			MRQJob->RemoveFromRoot();
+			MRQJob = nullptr;
 		});
     });
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
@@ -68,9 +68,10 @@ void FUnrealDeadlineCloudServiceModule::StartupModule()
 		FDeadlineCloudJobParametersArray::StaticStruct()->GetFName(),
 		FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FDeadlineCloudJobParametersArrayCustomization::MakeInstance));
 	
-		PropertyModule.RegisterCustomPropertyTypeLayout(
-			FJobTemplateOverrides::StaticStruct()->GetFName(),
-			FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FJobTemplateOverridesCustomization::MakeInstance));
+	PropertyModule.RegisterCustomPropertyTypeLayout(
+		FJobTemplateOverrides::StaticStruct()->GetFName(),
+		FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FJobTemplateOverridesCustomization::MakeInstance));
+
 	//Step details arrays 
 	PropertyModule.RegisterCustomPropertyTypeLayout(
 		FDeadlineCloudStepParametersArray::StaticStruct()->GetFName(),

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.h
@@ -12,6 +12,7 @@ class DeadlineCloudJobPresetDetailsCustomization;
 class FDeadlineCloudDetailsWidgetsHelper
 {
 public:
+	static void CreateSavePresetDialogWidget(class UMoviePipelineDeadlineCloudExecutorJob* MrqJob);
 
 	static TSharedRef<SWidget> CreatePropertyWidgetByType(TSharedPtr<IPropertyHandle> ParameterHandle, EValueType Type, EValueValidationType ValidationType = EValueValidationType::Default);
 	static TSharedPtr<SWidget> TryCreatePropertyWidgetFromMetadata(TSharedPtr<IPropertyHandle> ParameterHandle);
@@ -173,7 +174,6 @@ public:
 	static UMoviePipelineDeadlineCloudExecutorJob* GetMrqJob(TSharedRef<IPropertyHandle> Handle);
 	
 private:
-
 	static TSharedRef<SWidget> CreatePathWidget(TSharedPtr<IPropertyHandle> ParameterHandle, FOnVerifyTextChanged Validation);
 	static TSharedRef<SWidget> CreateIntWidget(TSharedPtr<IPropertyHandle> ParameterHandle);
 	static TSharedRef<SWidget> CreateFloatWidget(TSharedPtr<IPropertyHandle> ParameterHandle);

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.h
@@ -12,7 +12,7 @@ class DeadlineCloudJobPresetDetailsCustomization;
 class FDeadlineCloudDetailsWidgetsHelper
 {
 public:
-	static void CreateSavePresetDialogWidget(class UMoviePipelineDeadlineCloudExecutorJob* MrqJob);
+	static void CreateSavePresetDialogWidget(class UMoviePipelineDeadlineCloudExecutorJob* MrqJob, bool bModal = true);
 
 	static TSharedRef<SWidget> CreatePropertyWidgetByType(TSharedPtr<IPropertyHandle> ParameterHandle, EValueType Type, EValueValidationType ValidationType = EValueValidationType::Default);
 	static TSharedPtr<SWidget> TryCreatePropertyWidgetFromMetadata(TSharedPtr<IPropertyHandle> ParameterHandle);

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h
@@ -4,12 +4,13 @@
 #include "CoreMinimal.h"
 #include "Engine/DeveloperSettings.h"
 #include "PythonAPILibraries/DeadlineCloudSettingsLibrary.h"
+#include "MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h"
 #include "DeadlineCloudDeveloperSettings.generated.h"
 
 /**
  * Deadline Cloud Workstation Configuration settings located in Project -> Settings.
  */
-UCLASS(BlueprintType, HideCategories="cache")
+UCLASS(config = EditorPerProjectUserSettings, BlueprintType, HideCategories="cache")
 class UNREALDEADLINECLOUDSERVICE_API UDeadlineCloudDeveloperSettings : public UDeveloperSettings
 {
 	GENERATED_BODY()
@@ -32,6 +33,20 @@ public:
 	* @return A mutable settings instance.
 	*/
 	static UDeadlineCloudDeveloperSettings* GetMutable() { return GetMutableDefault<UDeadlineCloudDeveloperSettings>(); }
+
+	static class UDeadlineCloudRenderJob* GetDefaultJobPreset();
+	static void SetDefaultJobPreset(class UDeadlineCloudRenderJob* NewJobPreset);
+
+	static void LoadMRQJobPresetCache(class UMoviePipelineDeadlineCloudExecutorJob* MRQJob);
+	static void SaveMRQJobPresetCache(const class UMoviePipelineDeadlineCloudExecutorJob* MRQJob);
+	/** 
+	* Deadline Cloud Default MRQ job preset
+	*/
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, meta = (Category = "Deadline Cloud Job Presets", DisplayPriority = 3))
+	TSoftObjectPtr<class UDeadlineCloudRenderJob> DefaultJobPreset;
+
+	UPROPERTY(Config)
+	FDeadlineCloudJobPresetCache JobPresetCache;
 
 	/** 
 	* Deadline Cloud Workstation Configuration settings container.

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudEnvironment.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudEnvironment.h
@@ -18,6 +18,8 @@ struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudEnvironmentOverride
 {
     GENERATED_BODY()
 
+public:
+
     UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Parameters")
 	FString Name;
 
@@ -26,6 +28,8 @@ struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudEnvironmentOverride
 
 	TArray<FName> HiddenVarsList;
 
+	//copy only values for existing parameters
+	void CopyParametersValuesFrom(const FDeadlineCloudEnvironmentOverride& Other);
 };
 
 UCLASS(BlueprintType, Blueprintable)

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudJob.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudJob.h
@@ -304,7 +304,7 @@ public:
 
 	TArray<FStepTaskParameterDefinition> GetAllStepParameters() const;
 
-
+	TArray<FParameterDefinition> GetParametersDataToOverride() const;
 public:
 
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudStep.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudStep.h
@@ -16,9 +16,11 @@ struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudStepParametersArray
 };
 
 USTRUCT(BlueprintType)
-struct  FDeadlineCloudStepOverride
+struct FDeadlineCloudStepOverride
 {
     GENERATED_BODY()
+
+public:
 
     UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Parameters", meta = (DisplayPriority = 1))
     FString Name;
@@ -33,6 +35,9 @@ struct  FDeadlineCloudStepOverride
 	FDeadlineCloudStepParametersArray TaskParameterDefinitions;
 
 	TArray<FName> HiddenParametersList;
+
+
+	void CopyParametersValuesFrom(const FDeadlineCloudStepOverride& Other);
 };
 
 UCLASS(BlueprintType, Blueprintable)

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
@@ -38,10 +38,26 @@ struct UNREALDEADLINECLOUDSERVICE_API FJobTemplateOverrides
     TArray<FDeadlineCloudEnvironmentOverride> EnvironmentsOverrides;
 };
 
+USTRUCT()
+struct FDeadlineCloudJobPresetCache
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY()
+	TSoftObjectPtr<class UDeadlineCloudRenderJob> LastJobPreset;
+
+    UPROPERTY(Config)
+    FDeadlineCloudJobPresetStruct LastPresetOverrides;
+
+    UPROPERTY(Config)
+    FJobTemplateOverrides LastJobTemplateOverrides;
+};
+
 /**
  * Movie pipeline executor job
  */
-UCLASS(BlueprintType, config = EditorPerProjectUserSettings)
+UCLASS(BlueprintType)
 class UNREALDEADLINECLOUDSERVICE_API UMoviePipelineDeadlineCloudExecutorJob : public UMoviePipelineExecutorJob
 {
     GENERATED_BODY()
@@ -54,6 +70,24 @@ public:
 
     void PostInitProperties() override;
 
+    void SaveAsJobPreset(FString& FolderPath, FString& BaseName, bool bSetAsDefault);
+
+    void CopyJobOverrides(UDeadlineCloudRenderJob* Job);
+	void CopyStepOverrides(UDeadlineCloudStep* Step);
+    void CopyEnvironmentOverrides(UDeadlineCloudEnvironment* Environment);
+
+	void FixReferencesAfterDuplication(TMap<UDataAsset*, FString>& SourceObjects, TArray<UDataAsset*> NewObjects);
+
+	static void GeneratePresetObjectsNames(
+        const UMoviePipelineDeadlineCloudExecutorJob* MrqJob, 
+        const FString& FolderPath, const FString& BaseName,
+        TMap<UDataAsset*, FString>& OutPresetPackageNames);
+
+	void ReloadDataFromJobPreset();
+   
+    bool IsUsingDefaultPreset() const;
+    static void SaveLastUsedFrom(const UMoviePipelineDeadlineCloudExecutorJob* Source);
+    static void ApplyLastUsedTo(UMoviePipelineDeadlineCloudExecutorJob* Target);
     /**
      * Returns the Deadline job info with overrides applied, if enabled.
      * Skips any property not
@@ -66,7 +100,7 @@ public:
 
 #if WITH_EDITOR
     void UpdateAttachmentFields();
-   virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+    virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
     virtual void PostEditChangeChainProperty(FPropertyChangedChainEvent& PropertyChangedEvent) override;
 #endif
 
@@ -87,6 +121,7 @@ public:
 
     UFUNCTION()
     TArray<FString> GetJobInitialStateOptions();
+
     // End Job list options methods
     UFUNCTION()
     UDeadlineCloudRenderJob* CreateDefaultJobPresetFromTemplates(UDeadlineCloudRenderJob* Preset);
@@ -108,13 +143,13 @@ public:
     /**
      * Reference to Deadline Cloud job preset DataAsset. Contains overriden job settings
      */
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, config, Category = "DeadlineCloud")
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DeadlineCloud")
     FDeadlineCloudJobPresetStruct PresetOverrides = FDeadlineCloudJobPresetStruct();
 
     /**
  * Reference to Deadline Cloud job parameters. Contains overriden job settings
  */
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, config, Category = "DeadlineCloud")
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DeadlineCloud")
     FJobTemplateOverrides JobTemplateOverrides = FJobTemplateOverrides();
 
     void JobPresetChanged();
@@ -142,7 +177,7 @@ protected:
     /**
      * List of property "enabled" states in UI
      */
-    UPROPERTY(config)
+    UPROPERTY()
     TArray<FPropertyRowEnabledInfo> EnabledPropertyOverrides;
 public:
 
@@ -164,4 +199,6 @@ public:
     /** Begin IDetailCustomization interface */
     virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
     /** End IDetailCustomization interface */
+
+    void ResetPresetToDefaultHandler(TSharedPtr<IPropertyHandle> PropertyHandle) const;
 };

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
@@ -147,8 +147,8 @@ public:
     FDeadlineCloudJobPresetStruct PresetOverrides = FDeadlineCloudJobPresetStruct();
 
     /**
- * Reference to Deadline Cloud job parameters. Contains overriden job settings
- */
+     * Reference to Deadline Cloud job parameters. Contains overriden job settings
+     */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DeadlineCloud")
     FJobTemplateOverrides JobTemplateOverrides = FJobTemplateOverrides();
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
@@ -83,6 +83,10 @@ public:
         const FString& FolderPath, const FString& BaseName,
         TMap<UDataAsset*, FString>& OutPresetPackageNames);
 
+	static void GetPresetObjectsNames(
+		const UMoviePipelineDeadlineCloudExecutorJob* MrqJob,
+		TMap<UDataAsset*, FString>& OutPresetPackageNames);
+
 	void ReloadDataFromJobPreset();
    
     bool IsUsingDefaultPreset() const;

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/UnrealDeadlineCloudService.Build.cs
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/UnrealDeadlineCloudService.Build.cs
@@ -29,6 +29,7 @@ public class UnrealDeadlineCloudService : ModuleRules
                  "EditorSubsystem",
                  "Slate",
                  "SlateCore",
+                 "ToolWidgets",
                  "EditorWidgets",
                  "Core",
                  "CoreUObject",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Need to provide the ability to configure default Job data asset that would be used for all MRQ Jobs initially

### What was the solution? (How)

- Default Job Preset data asset can be selected in In Project Settings of the Plugin
- Added the ability to save current MRQ Job as the bunch of Data Assets (for Job, its Steps and Environments) with all of the MRQ overrides
- Last modified MRQ Job that used default data asset cached overrides to its settings and save to config to apply them in the newly created MRQ Jobs
- Three default Data Assets added to the Plugin's Content folder

### What is the impact of this change?

- Users now can configure their own default data asset that will be used across all of the MRQ Jobs initially

### How was this change tested?

Smoke tests, unit tests

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

Yes, in TDD and appropriate docstrings

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*