### PR TITLE
feat: Set right UE version to CondaPackages parameter

### DIFF
--- a/src/deadline/unreal_submitter/exceptions.py
+++ b/src/deadline/unreal_submitter/exceptions.py
@@ -31,6 +31,12 @@ class OpenJobIsMissingError(DeadlineCloudSubmitterException):
     pass
 
 
+class InvalidUEVersionInCondaPackageParameter(DeadlineCloudSubmitterException):
+    """Raised when Conda Package parameter is contains invalid ue version"""
+
+    pass
+
+
 class RenderArgumentsTypeNotSetError(DeadlineCloudSubmitterException):
     """Raised when the render arguments type is not set"""
 

--- a/src/deadline/unreal_submitter/exceptions.py
+++ b/src/deadline/unreal_submitter/exceptions.py
@@ -7,8 +7,8 @@ class DeadlineCloudSubmitterException(Exception):
     pass
 
 
-class NoUINotification:
-    """Marker mixin: Exceptions that shouldn't trigger UI notifications"""
+class UserException:
+    """Marker mixin: Exceptions that do not trigger UI notifications and are raised by user choice."""
 
     pass
 
@@ -37,15 +37,13 @@ class OpenJobIsMissingError(DeadlineCloudSubmitterException):
     pass
 
 
-class InvalidUEVersionInCondaPackageParameter(DeadlineCloudSubmitterException):
-    """Raised when Conda Package parameter contains an invalid UE version"""
+class UEVersionParseError(DeadlineCloudSubmitterException):
+    """Raised when the current Unreal Engine version string cannot be parsed (expected 'x.y')."""
 
     pass
 
 
-class InvalidUEVersionInCondaPackageParameterNoUI(
-    InvalidUEVersionInCondaPackageParameter, NoUINotification
-):
+class UserCancelledSubmissionMissMatchedUEVersion(DeadlineCloudSubmitterException, UserException):
     """Raised when Conda Package parameter contains an invalid UE version"""
 
     pass

--- a/src/deadline/unreal_submitter/exceptions.py
+++ b/src/deadline/unreal_submitter/exceptions.py
@@ -32,7 +32,7 @@ class OpenJobIsMissingError(DeadlineCloudSubmitterException):
 
 
 class InvalidUEVersionInCondaPackageParameter(DeadlineCloudSubmitterException):
-    """Raised when Conda Package parameter is contains invalid ue version"""
+    """Raised when Conda Package parameter contains an invalid UE version"""
 
     pass
 

--- a/src/deadline/unreal_submitter/exceptions.py
+++ b/src/deadline/unreal_submitter/exceptions.py
@@ -7,6 +7,12 @@ class DeadlineCloudSubmitterException(Exception):
     pass
 
 
+class NoUINotification:
+    """Marker mixin: Exceptions that shouldn't trigger UI notifications"""
+
+    pass
+
+
 class ParametersAreNotConsistentError(DeadlineCloudSubmitterException):
     """Raised when OpenJD parameters/variables are not consistent"""
 
@@ -32,6 +38,14 @@ class OpenJobIsMissingError(DeadlineCloudSubmitterException):
 
 
 class InvalidUEVersionInCondaPackageParameter(DeadlineCloudSubmitterException):
+    """Raised when Conda Package parameter contains an invalid UE version"""
+
+    pass
+
+
+class InvalidUEVersionInCondaPackageParameterNoUI(
+    InvalidUEVersionInCondaPackageParameter, NoUINotification
+):
     """Raised when Conda Package parameter contains an invalid UE version"""
 
     pass

--- a/src/deadline/unreal_submitter/exceptions.py
+++ b/src/deadline/unreal_submitter/exceptions.py
@@ -43,7 +43,7 @@ class UEVersionParseError(DeadlineCloudSubmitterException):
     pass
 
 
-class UserCancelledSubmissionMissMatchedUEVersion(DeadlineCloudSubmitterException, UserException):
+class UserCancelledSubmissionMismatchedUEVersion(DeadlineCloudSubmitterException, UserException):
     """Raised when Conda Package parameter contains an invalid UE version"""
 
     pass

--- a/src/deadline/unreal_submitter/submitter.py
+++ b/src/deadline/unreal_submitter/submitter.py
@@ -375,12 +375,6 @@ class UnrealMrqJobSubmitter(UnrealSubmitter):
     @error_notify("Data asset converting failed")
     def add_job(self, mrq_job: unreal.MoviePipelineExecutorJob):
         render_open_job = self.open_job_class.from_mrq_job(mrq_job)
-        
-        # Check conda package version when adding job
-        if hasattr(render_open_job, 'check_conda_package_version'):
-            if not render_open_job.check_conda_package_version():
-                raise ValueError(f"Job {render_open_job.name} failed conda package version check")
-        
         self._jobs.append(render_open_job)
 
 

--- a/src/deadline/unreal_submitter/submitter.py
+++ b/src/deadline/unreal_submitter/submitter.py
@@ -375,6 +375,12 @@ class UnrealMrqJobSubmitter(UnrealSubmitter):
     @error_notify("Data asset converting failed")
     def add_job(self, mrq_job: unreal.MoviePipelineExecutorJob):
         render_open_job = self.open_job_class.from_mrq_job(mrq_job)
+        
+        # Check conda package version when adding job
+        if hasattr(render_open_job, 'check_conda_package_version'):
+            if not render_open_job.check_conda_package_version():
+                raise ValueError(f"Job {render_open_job.name} failed conda package version check")
+        
         self._jobs.append(render_open_job)
 
 

--- a/src/deadline/unreal_submitter/submitter.py
+++ b/src/deadline/unreal_submitter/submitter.py
@@ -20,6 +20,7 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job import (
     UnrealOpenJob,
     RenderUnrealOpenJob,
 )
+from deadline.unreal_submitter.exceptions import NoUINotification
 
 from ._version import version
 
@@ -56,6 +57,9 @@ def error_notify(
                     exception_type=str(type(e)),
                     from_gui=not self._silent_mode,
                 )
+
+                if isinstance(e, NoUINotification):
+                    return
 
                 message = notify_prefix + str(e)
                 if with_traceback:

--- a/src/deadline/unreal_submitter/submitter.py
+++ b/src/deadline/unreal_submitter/submitter.py
@@ -20,7 +20,7 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job import (
     UnrealOpenJob,
     RenderUnrealOpenJob,
 )
-from deadline.unreal_submitter.exceptions import NoUINotification
+from deadline.unreal_submitter.exceptions import UserException
 
 from ._version import version
 
@@ -58,7 +58,7 @@ def error_notify(
                     from_gui=not self._silent_mode,
                 )
 
-                if isinstance(e, NoUINotification):
+                if isinstance(e, UserException):
                     return
 
                 message = notify_prefix + str(e)

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -558,9 +558,16 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         # Compare versions
         if not template_ue_version == current_version:
             # Versions don't match
-            raise exceptions.InvalidUEVersionInCondaPackageParameter(
-                "CondaPackages Unreal Engine version mismatch"
+            result = unreal.EditorDialog.show_message(
+                "Version Mismatch Warning",
+                f"You are attempting to render a UE {current_version} project using UE {template_ue_version}.Do you wish to continue?",
+                unreal.AppMsgType.YES_NO
             )
+
+            if result != unreal.AppReturnType.YES:
+                raise exceptions.InvalidUEVersionInCondaPackageParameter(
+                    "CondaPackages Unreal Engine version mismatch"
+                )
 
         logger.info("Unreal Engine versions match, continuing with submission")
 
@@ -719,42 +726,6 @@ class RenderUnrealOpenJob(UnrealOpenJob):
 
         if self._name is None:
             self._name = self._mrq_job.job_name
-
-    def get_mrq_template_object(self) -> dict:
-        """
-        Get the template object from the MRQ job template overrides instead of the default YAML file.
-        This method provides template information from the MRQ job configuration.
-
-        :return: Template descriptor from MRQ job
-        :rtype: dict
-        """
-        if not self._mrq_job or not self._mrq_job.job_template_overrides:
-            # Fall back to base implementation if no MRQ job or template overrides
-            return super().get_template_object()
-
-        # Build template from MRQ job template overrides
-        template = {
-            "specificationVersion": settings.JOB_TEMPLATE_VERSION,
-            "name": self.name or "MRQ Job Template",
-            "parameterDefinitions": [],
-        }
-
-        # Add parameter definitions from MRQ job template overrides
-        if self._mrq_job.job_template_overrides.parameters:
-            for param in self._mrq_job.job_template_overrides.parameters:
-                param_def = {
-                    "name": param.name,
-                    "type": param.type.name,
-                }
-                if hasattr(param, "value") and param.value:
-                    param_def["default"] = param.value
-                template["parameterDefinitions"].append(param_def)
-
-        # Add extensions if available
-        if hasattr(self._mrq_job.job_template_overrides, "extensions"):
-            template["extensions"] = self._mrq_job.job_template_overrides.extensions
-
-        return template
 
     @classmethod
     def from_data_asset(cls, data_asset: unreal.DeadlineCloudRenderJob) -> "RenderUnrealOpenJob":

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -339,7 +339,10 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         if self._job_shared_settings:
             parameter_values += self._job_shared_settings.serialize()
 
-        UnrealOpenJob.check_conda_package_version(parameter_values)
+        if not UnrealOpenJob.check_conda_package_version(parameter_values):
+            raise exceptions.InvalidUEVersionInCondaPackageParameterNoUI(
+                "CondaPackages Unreal Engine version mismatch"
+            )
 
         return parameter_values
 
@@ -523,7 +526,7 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         return current_version_match.group(0)
 
     @staticmethod
-    def check_conda_package_version(parameter_values: list[dict[str, Any]]):
+    def check_conda_package_version(parameter_values: list[dict[str, Any]]) -> bool:
         """
         Check if the CondaPackages parameter contains Unreal Engine version and compare with current UE version.
 
@@ -536,14 +539,14 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         )
 
         if not conda_packages_param:
-            return
+            return True
 
         current_version = UnrealOpenJob.get_current_ue_version()
 
         conda_packages_value = conda_packages_param.get("value", "")
         if not conda_packages_value:
             conda_packages_param["value"] = f"unrealengine={current_version}"
-            return
+            return True
 
         # Check for unrealengine=x.x pattern
         ue_version_match = re.search(r"unrealengine=(\d+\.\d+)", conda_packages_value)
@@ -551,7 +554,7 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             conda_packages_param["value"] = (
                 f"unrealengine={current_version} " + conda_packages_value
             )
-            return
+            return True
 
         template_ue_version = ue_version_match.group(1)
         logger.info(f"Template specifies Unreal Engine version: {template_ue_version}")
@@ -567,11 +570,10 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             )
 
             if result != unreal.AppReturnType.YES:
-                raise exceptions.InvalidUEVersionInCondaPackageParameterNoUI(
-                    "CondaPackages Unreal Engine version mismatch"
-                )
+                return False
 
         logger.info("Unreal Engine versions match, continuing with submission")
+        return True
 
 
 # Render Open Job

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -567,7 +567,7 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             )
 
             if result != unreal.AppReturnType.YES:
-                raise exceptions.InvalidUEVersionInCondaPackageParameter(
+                raise exceptions.InvalidUEVersionInCondaPackageParameterNoUI(
                     "CondaPackages Unreal Engine version mismatch"
                 )
 

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -340,7 +340,7 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             parameter_values += self._job_shared_settings.serialize()
 
         if not UnrealOpenJob.check_conda_package_version(parameter_values):
-            raise exceptions.UserCancelledSubmissionMissMatchedUEVersion(
+            raise exceptions.UserCancelledSubmissionMismatchedUEVersion(
                 "CondaPackages Unreal Engine version mismatch"
             )
 

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -511,6 +511,13 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         :rtype: bool
         """
 
+        conda_packages_param = next(
+            (p for p in parameter_values if p["name"] == OpenJobParameterNames.CONDA_PACKAGES), None
+        )
+
+        if not conda_packages_param:
+            return
+
         current_ue_version = unreal.SystemLibrary.get_engine_version()
         logger.info(f"Current Unreal Engine version: {current_ue_version}")
         current_version_match = re.search(r"\b\d+\.\d+\b", current_ue_version)
@@ -522,35 +529,18 @@ class UnrealOpenJob(UnrealOpenJobEntity):
 
         current_version = current_version_match.group(0)
 
-        # Check for CondaPackages parameter
-        conda_packages_param = next(
-            (p for p in parameter_values if p["name"] == OpenJobParameterNames.CONDA_PACKAGES), None
-        )
-
-        if not conda_packages_param:
-            logger.info(
-                "No CondaPackages parameter found in template, building with current version"
-            )
-            parameter_values.append(
-                dict(
-                    name=OpenJobParameterNames.CONDA_PACKAGES,
-                    value=f"unrealengine={current_version}",
-                )
-            )
-            return
-
         conda_packages_value = conda_packages_param.get("value", "")
         if not conda_packages_value:
-            raise exceptions.InvalidUEVersionInCondaPackageParameter(
-                "CondaPackages parameter is empty, cannot determine Unreal Engine version"
-            )
+            conda_packages_param["value"] = f"unrealengine={current_version}"
+            return
 
         # Check for unrealengine=x.x pattern
         ue_version_match = re.search(r"unrealengine=(\d+\.\d+)", conda_packages_value)
         if not ue_version_match:
-            raise exceptions.InvalidUEVersionInCondaPackageParameter(
-                f"CondaPackages parameter does not specify Unreal Engine version: {conda_packages_value}"
+            conda_packages_param["value"] = (
+                f"unrealengine={current_version} " + conda_packages_value
             )
+            return
 
         template_ue_version = ue_version_match.group(1)
         logger.info(f"Template specifies Unreal Engine version: {template_ue_version}")
@@ -560,7 +550,7 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             # Versions don't match
             result = unreal.EditorDialog.show_message(
                 "Version Mismatch Warning",
-                f"You are attempting to render a UE {current_version} project using UE {template_ue_version}.Do you wish to continue?",
+                f"You are attempting to render a UE {current_version} project using UE {template_ue_version}. Do you wish to continue?",
                 unreal.AppMsgType.YES_NO,
             )
 

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -340,7 +340,7 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             parameter_values += self._job_shared_settings.serialize()
 
         if not UnrealOpenJob.check_conda_package_version(parameter_values):
-            raise exceptions.InvalidUEVersionInCondaPackageParameterNoUI(
+            raise exceptions.UserCancelledSubmissionMissMatchedUEVersion(
                 "CondaPackages Unreal Engine version mismatch"
             )
 
@@ -519,7 +519,7 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         current_version_match = re.search(r"\b\d+\.\d+\b", current_ue_version)
         if not current_version_match:
             logger.warning(f"Could not parse current UE version: {current_ue_version}")
-            raise exceptions.InvalidUEVersionInCondaPackageParameter(
+            raise exceptions.UEVersionParseError(
                 f"Could not parse current UE version: {current_ue_version}"
             )
 

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -503,6 +503,26 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         return job_bundle_path
 
     @staticmethod
+    def get_current_ue_version():
+        """
+        Get current Unreal Engine version in x.y format
+
+        :return: Current Unreal Engine version
+        :rtype: str
+        """
+
+        current_ue_version = unreal.SystemLibrary.get_engine_version()
+        logger.info(f"Current Unreal Engine version: {current_ue_version}")
+        current_version_match = re.search(r"\b\d+\.\d+\b", current_ue_version)
+        if not current_version_match:
+            logger.warning(f"Could not parse current UE version: {current_ue_version}")
+            raise exceptions.InvalidUEVersionInCondaPackageParameter(
+                f"Could not parse current UE version: {current_ue_version}"
+            )
+
+        return current_version_match.group(0)
+
+    @staticmethod
     def check_conda_package_version(parameter_values: list[dict[str, Any]]):
         """
         Check if the CondaPackages parameter contains Unreal Engine version and compare with current UE version.
@@ -518,16 +538,7 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         if not conda_packages_param:
             return
 
-        current_ue_version = unreal.SystemLibrary.get_engine_version()
-        logger.info(f"Current Unreal Engine version: {current_ue_version}")
-        current_version_match = re.search(r"\b\d+\.\d+\b", current_ue_version)
-        if not current_version_match:
-            logger.warning(f"Could not parse current UE version: {current_ue_version}")
-            raise exceptions.InvalidUEVersionInCondaPackageParameter(
-                f"Could not parse current UE version: {current_ue_version}"
-            )
-
-        current_version = current_version_match.group(0)
+        current_version = UnrealOpenJob.get_current_ue_version()
 
         conda_packages_value = conda_packages_param.get("value", "")
         if not conda_packages_value:

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -526,6 +526,24 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         return current_version_match.group(0)
 
     @staticmethod
+    def normalize_openjd_version_param(param_value: str) -> str:
+        """
+        Check if the given CondaPackages parameter value contains openjd version.
+        If not, append "unrealengine-openjd=*.*.*" to the value.
+        :param param_value: CondaPackages parameter value
+        :return: Updated CondaPackages parameter value
+        :rtype: str
+        """
+        match = re.search(r"unrealengine-openjd=(?:\d+|\*)\.(?:\d+|\*)\.(?:\d+|\*)", param_value)
+        if match:
+            return param_value
+
+        if re.search(r"unrealengine-openjd=[^\s]+", param_value):
+            return re.sub(r"unrealengine-openjd=[^\s]+", "unrealengine-openjd=*.*.*", param_value)
+
+        return param_value + " unrealengine-openjd=*.*.*"
+
+    @staticmethod
     def check_conda_package_version(parameter_values: list[dict[str, Any]]) -> bool:
         """
         Check if the CondaPackages parameter contains Unreal Engine version and compare with current UE version.
@@ -545,13 +563,15 @@ class UnrealOpenJob(UnrealOpenJobEntity):
 
         conda_packages_value = conda_packages_param.get("value", "")
         if not conda_packages_value:
-            conda_packages_param["value"] = f"unrealengine={current_version}"
+            conda_packages_param["value"] = UnrealOpenJob.normalize_openjd_version_param(
+                f"unrealengine={current_version}"
+            )
             return True
 
         # Check for unrealengine=x.x pattern
         ue_version_match = re.search(r"unrealengine=(\d+\.\d+)", conda_packages_value)
         if not ue_version_match:
-            conda_packages_param["value"] = (
+            conda_packages_param["value"] = UnrealOpenJob.normalize_openjd_version_param(
                 f"unrealengine={current_version} " + conda_packages_value
             )
             return True
@@ -572,6 +592,9 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             if result != unreal.AppReturnType.YES:
                 return False
 
+        conda_packages_param["value"] = UnrealOpenJob.normalize_openjd_version_param(
+            conda_packages_value
+        )
         logger.info("Unreal Engine versions match, continuing with submission")
         return True
 

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -656,6 +656,42 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         if self._name is None:
             self._name = self._mrq_job.job_name
 
+    def get_mrq_template_object(self) -> dict:
+        """
+        Get the template object from the MRQ job template overrides instead of the default YAML file.
+        This method provides template information from the MRQ job configuration.
+
+        :return: Template descriptor from MRQ job
+        :rtype: dict
+        """
+        if not self._mrq_job or not self._mrq_job.job_template_overrides:
+            # Fall back to base implementation if no MRQ job or template overrides
+            return super().get_template_object()
+        
+        # Build template from MRQ job template overrides
+        template = {
+            "specificationVersion": settings.JOB_TEMPLATE_VERSION,
+            "name": self.name or "MRQ Job Template",
+            "parameterDefinitions": []
+        }
+        
+        # Add parameter definitions from MRQ job template overrides
+        if self._mrq_job.job_template_overrides.parameters:
+            for param in self._mrq_job.job_template_overrides.parameters:
+                param_def = {
+                    "name": param.name,
+                    "type": param.type.name,
+                }
+                if hasattr(param, 'value') and param.value:
+                    param_def["default"] = param.value
+                template["parameterDefinitions"].append(param_def)
+        
+        # Add extensions if available
+        if hasattr(self._mrq_job.job_template_overrides, 'extensions'):
+            template["extensions"] = self._mrq_job.job_template_overrides.extensions
+        
+        return template
+
     @classmethod
     def from_data_asset(cls, data_asset: unreal.DeadlineCloudRenderJob) -> "RenderUnrealOpenJob":
         """

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -339,6 +339,8 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         if self._job_shared_settings:
             parameter_values += self._job_shared_settings.serialize()
 
+        UnrealOpenJob.check_conda_package_version(parameter_values)
+
         return parameter_values
 
     def _check_parameters_consistency(self):
@@ -499,6 +501,68 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             deadline_yaml_dump(asset_references.to_dict(), f, indent=1)
 
         return job_bundle_path
+
+    @staticmethod
+    def check_conda_package_version(parameter_values: list[dict[str, Any]]):
+        """
+        Check if the CondaPackages parameter contains Unreal Engine version and compare with current UE version.
+
+        :return: True if version check passes or user confirms, False if user cancels
+        :rtype: bool
+        """
+
+        current_ue_version = unreal.SystemLibrary.get_engine_version()
+        logger.info(f"Current Unreal Engine version: {current_ue_version}")
+        current_version_match = re.search(r"(\d+\.\d+)", current_ue_version)
+        if not current_version_match:
+            logger.warning(f"Could not parse current UE version: {current_ue_version}")
+            raise exceptions.InvalidUEVersionInCondaPackageParameter(
+                f"Could not parse current UE version: {current_ue_version}"
+            )
+            return
+        current_version = current_version_match.group(1)
+
+        # Check for CondaPackages parameter
+        conda_packages_param = next(
+            (p for p in parameter_values if p["name"] == OpenJobParameterNames.CONDA_PACKAGES), None
+        )
+
+        if not conda_packages_param:
+            logger.info(
+                "No CondaPackages parameter found in template, building with current version"
+            )
+            parameter_values.append(
+                dict(
+                    name=OpenJobParameterNames.CONDA_PACKAGES,
+                    value=f"unrealengine={current_version}",
+                )
+            )
+            return
+
+        conda_packages_value = conda_packages_param.get("value", "")
+        if not conda_packages_value:
+            raise exceptions.InvalidUEVersionInCondaPackageParameter(
+                "CondaPackages parameter is empty, cannot determine Unreal Engine version"
+            )
+
+        # Check for unrealengine=x.x pattern
+        ue_version_match = re.search(r"unrealengine=(\d+\.\d+)", conda_packages_value)
+        if not ue_version_match:
+            raise exceptions.InvalidUEVersionInCondaPackageParameter(
+                f"CondaPackages parameter does not specify Unreal Engine version: {conda_packages_value}"
+            )
+
+        template_ue_version = ue_version_match.group(1)
+        logger.info(f"Template specifies Unreal Engine version: {template_ue_version}")
+
+        # Compare versions
+        if not template_ue_version == current_version:
+            # Versions don't match
+            raise exceptions.InvalidUEVersionInCondaPackageParameter(
+                "CondaPackages Unreal Engine version mismatch"
+            )
+
+        logger.info("Unreal Engine versions match, continuing with submission")
 
 
 # Render Open Job
@@ -667,14 +731,14 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         if not self._mrq_job or not self._mrq_job.job_template_overrides:
             # Fall back to base implementation if no MRQ job or template overrides
             return super().get_template_object()
-        
+
         # Build template from MRQ job template overrides
         template = {
             "specificationVersion": settings.JOB_TEMPLATE_VERSION,
             "name": self.name or "MRQ Job Template",
-            "parameterDefinitions": []
+            "parameterDefinitions": [],
         }
-        
+
         # Add parameter definitions from MRQ job template overrides
         if self._mrq_job.job_template_overrides.parameters:
             for param in self._mrq_job.job_template_overrides.parameters:
@@ -682,14 +746,14 @@ class RenderUnrealOpenJob(UnrealOpenJob):
                     "name": param.name,
                     "type": param.type.name,
                 }
-                if hasattr(param, 'value') and param.value:
+                if hasattr(param, "value") and param.value:
                     param_def["default"] = param.value
                 template["parameterDefinitions"].append(param_def)
-        
+
         # Add extensions if available
-        if hasattr(self._mrq_job.job_template_overrides, 'extensions'):
+        if hasattr(self._mrq_job.job_template_overrides, "extensions"):
             template["extensions"] = self._mrq_job.job_template_overrides.extensions
-        
+
         return template
 
     @classmethod

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -552,6 +552,7 @@ class UnrealOpenJob(UnrealOpenJobEntity):
                 "Version Mismatch Warning",
                 f"You are attempting to render a UE {current_version} project using UE {template_ue_version}. Do you wish to continue?",
                 unreal.AppMsgType.YES_NO,
+                unreal.AppReturnType.YES,
             )
 
             if result != unreal.AppReturnType.YES:

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -513,14 +513,14 @@ class UnrealOpenJob(UnrealOpenJobEntity):
 
         current_ue_version = unreal.SystemLibrary.get_engine_version()
         logger.info(f"Current Unreal Engine version: {current_ue_version}")
-        current_version_match = re.search(r"(\d+\.\d+)", current_ue_version)
+        current_version_match = re.search(r"\b\d+\.\d+\b", current_ue_version)
         if not current_version_match:
             logger.warning(f"Could not parse current UE version: {current_ue_version}")
             raise exceptions.InvalidUEVersionInCondaPackageParameter(
                 f"Could not parse current UE version: {current_ue_version}"
             )
-            return
-        current_version = current_version_match.group(1)
+
+        current_version = current_version_match.group(0)
 
         # Check for CondaPackages parameter
         conda_packages_param = next(

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -561,7 +561,7 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             result = unreal.EditorDialog.show_message(
                 "Version Mismatch Warning",
                 f"You are attempting to render a UE {current_version} project using UE {template_ue_version}.Do you wish to continue?",
-                unreal.AppMsgType.YES_NO
+                unreal.AppMsgType.YES_NO,
             )
 
             if result != unreal.AppReturnType.YES:

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
@@ -1,11 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import os
+import re
 import yaml
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
 from typing import Type, Union, Literal, Optional
-
+import unreal
 from openjd.model import parse_model
 
 from openjd.model.v2023_09 import (
@@ -172,6 +173,70 @@ class UnrealOpenJobEntity(UnrealOpenJobEntityBase):
         """
         return ParametersConsistencyCheckResult(True, "Parameters are consistent")
 
+    def check_conda_package_version(self) -> bool:
+        """
+        Check if the CondaPackages parameter contains Unreal Engine version and compare with current UE version.
+        
+        :return: True if version check passes or user confirms, False if user cancels
+        :rtype: bool
+        """    
+        current_ue_version = unreal.SystemLibrary.get_engine_version()
+        logger.info(f"Current Unreal Engine version: {current_ue_version}")   
+        current_version_match = re.search(r'(\d+\.\d+)', current_ue_version)
+        if not current_version_match:
+            logger.warning(f"Could not parse current UE version: {current_ue_version}")
+            return True       
+        current_version = current_version_match.group(1)
+            
+            # Get template object to check for CondaPackages parameter
+        template_obj = self.get_mrq_template_object()
+        parameter_definitions = template_obj.get('parameterDefinitions', [])
+        conda_packages_param = None
+        for param in parameter_definitions:
+            if param.get('name') == OpenJobParameterNames.CONDA_PACKAGES:
+                conda_packages_param = param
+                break
+            
+        if not conda_packages_param:
+            logger.info("No CondaPackages parameter found in template, building with current version")
+            return True
+        
+        conda_packages_value = conda_packages_param.get('default', '')
+        if not conda_packages_value:
+            logger.info("CondaPackages parameter has no value, building with current version")
+            return True
+            
+            # Check for unrealengine=x.x pattern
+        ue_version_match = re.search(r'unrealengine=(\d+\.\d+)', conda_packages_value)
+        if not ue_version_match:
+            logger.info("No unrealengine version specified in CondaPackages, building with current version")
+            return True           
+        template_ue_version = ue_version_match.group(1)
+        logger.info(f"Template specifies Unreal Engine version: {template_ue_version}")
+            
+            # Compare versions
+        if template_ue_version == current_version:
+            logger.info("Unreal Engine versions match, continuing with submission")
+            return True
+
+                # Versions don't match, show warning dialog
+        message = (
+                    f"Unreal Engine version mismatch detected!\n\n"
+                    f"Template specifies: unrealengine={template_ue_version}\n"
+                    f"Current UE version: {current_version}\n\n"
+                    f"This may cause compatibility issues. Do you want to continue with submission?"
+            )
+                
+                # Show confirmation dialog
+        result = unreal.EditorDialog.show_message(
+                    "Unreal Engine Version Mismatch",
+                    message,
+                    unreal.AppMsgType.YES_NO
+            )
+
+        return result == unreal.AppReturnType.YES
+
+
     def build_template(self) -> Template:
         """
         Base implementation of building entity template.
@@ -279,6 +344,7 @@ class OpenJobParameterNames:
     UNREAL_EXTRA_CMD_ARGS_FILE = "ExtraCmdArgsFile"
     UNREAL_EXECUTABLE_RELATIVE_PATH = "ExecutableRelativePath"
     UNREAL_MRQ_JOB_DEPENDENCIES_DESCRIPTOR = "MrqJobDependenciesDescriptor"
+    CONDA_PACKAGES = "CondaPackages"
 
     PERFORCE_STREAM_PATH = "PerforceStreamPath"
     PERFORCE_CHANGELIST_NUMBER = "PerforceChangelistNumber"

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
@@ -1,12 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import os
-import re
 import yaml
 from dataclasses import dataclass
 from abc import ABC, abstractmethod
 from typing import Type, Union, Literal, Optional
-import unreal
 from openjd.model import parse_model
 
 from openjd.model.v2023_09 import (
@@ -172,70 +170,6 @@ class UnrealOpenJobEntity(UnrealOpenJobEntityBase):
         :rtype: ParametersConsistencyCheckResult
         """
         return ParametersConsistencyCheckResult(True, "Parameters are consistent")
-
-    def check_conda_package_version(self) -> bool:
-        """
-        Check if the CondaPackages parameter contains Unreal Engine version and compare with current UE version.
-        
-        :return: True if version check passes or user confirms, False if user cancels
-        :rtype: bool
-        """    
-        current_ue_version = unreal.SystemLibrary.get_engine_version()
-        logger.info(f"Current Unreal Engine version: {current_ue_version}")   
-        current_version_match = re.search(r'(\d+\.\d+)', current_ue_version)
-        if not current_version_match:
-            logger.warning(f"Could not parse current UE version: {current_ue_version}")
-            return True       
-        current_version = current_version_match.group(1)
-            
-            # Get template object to check for CondaPackages parameter
-        template_obj = self.get_mrq_template_object()
-        parameter_definitions = template_obj.get('parameterDefinitions', [])
-        conda_packages_param = None
-        for param in parameter_definitions:
-            if param.get('name') == OpenJobParameterNames.CONDA_PACKAGES:
-                conda_packages_param = param
-                break
-            
-        if not conda_packages_param:
-            logger.info("No CondaPackages parameter found in template, building with current version")
-            return True
-        
-        conda_packages_value = conda_packages_param.get('default', '')
-        if not conda_packages_value:
-            logger.info("CondaPackages parameter has no value, building with current version")
-            return True
-            
-            # Check for unrealengine=x.x pattern
-        ue_version_match = re.search(r'unrealengine=(\d+\.\d+)', conda_packages_value)
-        if not ue_version_match:
-            logger.info("No unrealengine version specified in CondaPackages, building with current version")
-            return True           
-        template_ue_version = ue_version_match.group(1)
-        logger.info(f"Template specifies Unreal Engine version: {template_ue_version}")
-            
-            # Compare versions
-        if template_ue_version == current_version:
-            logger.info("Unreal Engine versions match, continuing with submission")
-            return True
-
-                # Versions don't match, show warning dialog
-        message = (
-                    f"Unreal Engine version mismatch detected!\n\n"
-                    f"Template specifies: unrealengine={template_ue_version}\n"
-                    f"Current UE version: {current_version}\n\n"
-                    f"This may cause compatibility issues. Do you want to continue with submission?"
-            )
-                
-                # Show confirmation dialog
-        result = unreal.EditorDialog.show_message(
-                    "Unreal Engine Version Mismatch",
-                    message,
-                    unreal.AppMsgType.YES_NO
-            )
-
-        return result == unreal.AppReturnType.YES
-
 
     def build_template(self) -> Template:
         """

--- a/src/unreal_plugin/Content/Python/job_library.py
+++ b/src/unreal_plugin/Content/Python/job_library.py
@@ -71,16 +71,19 @@ class DeadlineCloudJobBundleLibraryImplementation(unreal.DeadlineCloudJobBundleL
 
         conda_packages_value = conda_packages_param.value
         if not conda_packages_value:
-            conda_packages_param.value = f"unrealengine={current_version}"
+            conda_packages_param.value = UnrealOpenJob.normalize_openjd_version_param(
+                f"unrealengine={current_version}"
+            )
             parameters[conda_packages_param_index] = conda_packages_param
             return parameters
 
         # Check for unrealengine=x.x pattern
         ue_version_match = re.search(r"unrealengine=(\d+\.\d+)", conda_packages_value)
         if not ue_version_match:
-            conda_packages_param.get_editor_property(
-                "Value", f"unrealengine={current_version} " + conda_packages_value
+            conda_packages_param.value = UnrealOpenJob.normalize_openjd_version_param(
+                f"unrealengine={current_version} " + conda_packages_value
             )
+
             parameters[conda_packages_param_index] = conda_packages_param
             return parameters
 
@@ -90,10 +93,12 @@ class DeadlineCloudJobBundleLibraryImplementation(unreal.DeadlineCloudJobBundleL
         # Compare versions
         if not template_ue_version == current_version:
             # replace with current version
-            conda_packages_param.value = re.sub(
-                r"unrealengine=\d+\.\d+",
-                f"unrealengine={current_version}",
-                conda_packages_value,
+            conda_packages_param.value = UnrealOpenJob.normalize_openjd_version_param(
+                re.sub(
+                    r"unrealengine=\d+\.\d+",
+                    f"unrealengine={current_version}",
+                    conda_packages_value,
+                )
             )
             logger.info(f"Updated Unreal Engine version in conda packages to: {current_version}")
             parameters[conda_packages_param_index] = conda_packages_param

--- a/src/unreal_plugin/Content/Python/job_library.py
+++ b/src/unreal_plugin/Content/Python/job_library.py
@@ -1,6 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import os
+import re
+
 import unreal
 
 from deadline.unreal_submitter import common
@@ -11,6 +13,7 @@ from deadline.unreal_submitter.unreal_dependency_collector import (
 )
 
 from deadline.unreal_submitter.unreal_open_job.unreal_open_job import UnrealOpenJob
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity import OpenJobParameterNames
 
 logger = get_logger()
 
@@ -48,6 +51,54 @@ class DeadlineCloudJobBundleLibraryImplementation(unreal.DeadlineCloudJobBundleL
         unreal_dependencies = list(set(unreal_dependencies))
 
         return [common.os_path_from_unreal_path(d, with_ext=True) for d in unreal_dependencies]
+
+    @unreal.ufunction(override=True)
+    def validate_mrq_job_parameters(
+        self, parameters: list[unreal.ParameterDefinition]
+    ) -> list[unreal.ParameterDefinition]:
+        conda_packages_param = None
+        conda_packages_param_index = 0
+        for i, p in enumerate(parameters):
+            if p.get_editor_property("Name") == OpenJobParameterNames.CONDA_PACKAGES:
+                conda_packages_param = p
+                conda_packages_param_index = i
+                break
+
+        if not conda_packages_param:
+            return parameters
+
+        current_version = UnrealOpenJob.get_current_ue_version()
+
+        conda_packages_value = conda_packages_param.value
+        if not conda_packages_value:
+            conda_packages_param.value = f"unrealengine={current_version}"
+            parameters[conda_packages_param_index] = conda_packages_param
+            return parameters
+
+        # Check for unrealengine=x.x pattern
+        ue_version_match = re.search(r"unrealengine=(\d+\.\d+)", conda_packages_value)
+        if not ue_version_match:
+            conda_packages_param.get_editor_property(
+                "Value", f"unrealengine={current_version} " + conda_packages_value
+            )
+            parameters[conda_packages_param_index] = conda_packages_param
+            return parameters
+
+        template_ue_version = ue_version_match.group(1)
+        logger.info(f"Template specifies Unreal Engine version: {template_ue_version}")
+
+        # Compare versions
+        if not template_ue_version == current_version:
+            # replace with current version
+            conda_packages_param.value = re.sub(
+                r"unrealengine=\d+\.\d+",
+                f"unrealengine={current_version}",
+                conda_packages_value,
+            )
+            logger.info(f"Updated Unreal Engine version in conda packages to: {current_version}")
+            parameters[conda_packages_param_index] = conda_packages_param
+
+        return parameters
 
     @unreal.ufunction(override=True)
     def get_plugins_dependencies(self):

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -439,6 +439,16 @@ void UMoviePipelineDeadlineCloudExecutorJob::ReloadDataFromJobPreset()
 	JobTemplateOverrides.Parameters = JobPreset->GetParametersDataToOverride();
 	JobTemplateOverrides.StepsOverrides = GetStepsToOverride(JobPreset);
 	JobTemplateOverrides.EnvironmentsOverrides = GetEnvironmentsToOverride(JobPreset);
+	
+	UDeadlineCloudJobBundleLibrary* Library = UDeadlineCloudJobBundleLibrary::Get();
+	if (Library)
+	{
+		JobTemplateOverrides.Parameters = Library->ValidateMrqJobParameters(JobTemplateOverrides.Parameters);
+	}
+	else
+	{
+		UE_LOG(LogTemp, Error, TEXT("Error get DeadlineCloudJobBundleLibrary"));
+	}
 }
 
 void UMoviePipelineDeadlineCloudExecutorJob::GetPresetObjectsNames(const UMoviePipelineDeadlineCloudExecutorJob* MrqJob, TMap<UDataAsset*, FString>& OutPresetPackageNames)

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudJobBundleLibrary.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudJobBundleLibrary.h
@@ -26,6 +26,13 @@ public:
     UFUNCTION(BlueprintImplementableEvent)
     TArray<FString> GetJobDependencies(const UMoviePipelineDeadlineCloudExecutorJob *MrqJob);
 
+	/**
+	* Validate MRQ job parameters
+	* @param MrqJob Unreal MRQ job
+	*/
+	UFUNCTION(BlueprintImplementableEvent)
+	TArray<FParameterDefinition> ValidateMrqJobParameters(const TArray<FParameterDefinition>& Parameters);
+
 	 /**
 	 * Collect list of required plugins for the job
 	 * @return List of the plugins dependencies

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_check_conda_package_ver.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_check_conda_package_ver.py
@@ -1,121 +1,93 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import sys
+from typing import Any
+
 import pytest
-from unittest.mock import  MagicMock, patch
-import unreal
-from openjd.model.v2023_09 import JobTemplate
+from unittest.mock import MagicMock, patch
+from deadline.unreal_submitter import exceptions
 
 unreal_mock = MagicMock()
 sys.modules["unreal"] = unreal_mock
 
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job import (  # noqa: E402
+    UnrealOpenJob,
+)
+
 from deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity import (  # noqa: E402
-    UnrealOpenJobEntity,
     OpenJobParameterNames,
 )
-from deadline.unreal_submitter.submitter import UnrealMrqJobSubmitter
 
 
 class TestCheckCondaPackageVersion:
 
-
-    def test_check_conda_package_version_no_conda_packages_param(self):
-        # Change UE version
-        unreal.SystemLibrary.get_engine_version = lambda: "5.3.0"
-        unreal.EditorDialog.show_message = MagicMock()
-
-        open_job_entity = UnrealOpenJobEntity(template_class=JobTemplate, file_path="")
-
-        open_job_entity.get_mrq_template_object = lambda: {"parameterDefinitions": []}
-
-        result = open_job_entity.check_conda_package_version()
-
-        assert result is True
-        unreal.EditorDialog.show_message.assert_not_called()
-
-    @patch("unreal.SystemLibrary.get_engine_version")
-    @patch("unreal.EditorDialog.show_message")
-    @patch.object(UnrealOpenJobEntity, "get_mrq_template_object", create=True)
-    def test_check_conda_package_version_conda_packages_no_value(self, get_mrq_template_mock, show_message_mock, get_engine_version_mock):
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"
+    )
+    def test_check_conda_package_version_no_conda_packages_param(self, get_engine_version_mock):
         # GIVEN
-        get_engine_version_mock.return_value = "5.3.0"
-        get_mrq_template_mock.return_value = {
-            "parameterDefinitions": [
-                {"name": OpenJobParameterNames.CONDA_PACKAGES, "default": ""}
-            ]
-        }
-        
-        unreal_open_job_entity = UnrealOpenJobEntity(template_class=JobTemplate, file_path="")
+        get_engine_version_mock.return_value = "5.4.0"
+
+        job_parameter_values: list[dict[str, Any]] = []
 
         # WHEN
-        result = unreal_open_job_entity.check_conda_package_version()
+        UnrealOpenJob.check_conda_package_version(job_parameter_values)
 
         # THEN
-        assert result is True
-        get_mrq_template_mock.assert_called_once()
-        show_message_mock.assert_not_called()
+        assert job_parameter_values[0].get("value") == "unrealengine=5.4"
 
-    @patch("unreal.SystemLibrary.get_engine_version")
-    @patch("unreal.EditorDialog.show_message")
-    @patch.object(UnrealOpenJobEntity, "get_mrq_template_object", create=True)
-    def test_check_conda_package_version_no_unrealengine_pattern(self, get_mrq_template_mock, show_message_mock, get_engine_version_mock):
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"
+    )
+    def test_check_conda_package_version_conda_packages_no_value(self, get_engine_version_mock):
         # GIVEN
         get_engine_version_mock.return_value = "5.3.0"
-        get_mrq_template_mock.return_value = {
-            "parameterDefinitions": [
-                {"name": OpenJobParameterNames.CONDA_PACKAGES, "default": "somepackage=1.0"}
-            ]
-        }
-        
-        unreal_open_job_entity = UnrealOpenJobEntity(template_class=JobTemplate, file_path="")
+
+        job_parameter_values = [dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="")]
 
         # WHEN
-        result = unreal_open_job_entity.check_conda_package_version()
+        with pytest.raises(exceptions.InvalidUEVersionInCondaPackageParameter):
+            UnrealOpenJob.check_conda_package_version(job_parameter_values)
 
-        # THEN
-        assert result is True
-        get_mrq_template_mock.assert_called_once()
-        show_message_mock.assert_not_called()
-
-    @patch("unreal.SystemLibrary.get_engine_version")
-    @patch("unreal.EditorDialog.show_message")
-    @patch.object(UnrealOpenJobEntity, "get_mrq_template_object", create=True)
-    def test_check_conda_package_version_versions_match(self, get_mrq_template_mock, show_message_mock, get_engine_version_mock):
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"
+    )
+    def test_check_conda_package_version_no_unrealengine_pattern(self, get_engine_version_mock):
         # GIVEN
         get_engine_version_mock.return_value = "5.3.0"
-        get_mrq_template_mock.return_value = {
-            "parameterDefinitions": [
-                {"name": OpenJobParameterNames.CONDA_PACKAGES, "default": "unrealengine=5.3"}
-            ]
-        }
-        
-        unreal_open_job_entity = UnrealOpenJobEntity(template_class=JobTemplate, file_path="")
+
+        job_parameter_values = [
+            dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="somepackage=1.0")
+        ]
 
         # WHEN
-        result = unreal_open_job_entity.check_conda_package_version()
+        with pytest.raises(exceptions.InvalidUEVersionInCondaPackageParameter):
+            UnrealOpenJob.check_conda_package_version(job_parameter_values)
 
-        # THEN
-        assert result is True
-        get_mrq_template_mock.assert_called_once()
-        show_message_mock.assert_not_called()
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"
+    )
+    def test_check_conda_package_version_versions_match(self, get_engine_version_mock):
+        # GIVEN
+        get_engine_version_mock.return_value = "5.3"
 
-    @patch("unreal.SystemLibrary.get_engine_version")
-    @patch("unreal.EditorDialog.show_message")
-    def test_check_conda_package_version_minor_version_difference(self, show_message_mock, get_engine_version_mock):
-    # GIVEN
+        job_parameter_values = [
+            dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="unrealengine=5.3")
+        ]
+
+        # WHEN
+        UnrealOpenJob.check_conda_package_version(job_parameter_values)
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"
+    )
+    def test_check_conda_package_version_minor_version_difference(self, get_engine_version_mock):
+        # GIVEN
         get_engine_version_mock.return_value = "5.3.2"
 
-        unreal_open_job_entity = UnrealOpenJobEntity(template_class=JobTemplate, file_path="")
+        job_parameter_values = [
+            dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="unrealengine=5.3")
+        ]
 
-        unreal_open_job_entity.get_mrq_template_object = lambda: {
-            "parameterDefinitions": [
-                {"name": OpenJobParameterNames.CONDA_PACKAGES, "default": "unrealengine=5.3"}
-            ]
-        }
-
-    # WHEN
-        result = unreal_open_job_entity.check_conda_package_version()
-
-    # THEN
-        assert result is True
-        show_message_mock.assert_not_called()
+        # WHEN
+        UnrealOpenJob.check_conda_package_version(job_parameter_values)

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_check_conda_package_ver.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_check_conda_package_ver.py
@@ -47,7 +47,7 @@ class TestCheckCondaPackageVersion:
         assert UnrealOpenJob.check_conda_package_version(job_parameter_values)
 
         # THEN
-        assert job_parameter_values[0].get("value") == "unrealengine=5.3"
+        assert job_parameter_values[0].get("value") == "unrealengine=5.3 unrealengine-openjd=*.*.*"
 
     @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"
@@ -57,14 +57,20 @@ class TestCheckCondaPackageVersion:
         get_engine_version_mock.return_value = "5.3.0"
 
         job_parameter_values = [
-            dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="somepackage=1.0")
+            dict(
+                name=OpenJobParameterNames.CONDA_PACKAGES,
+                value="somepackage=1.0 unrealengine-openjd=0.5.*",
+            )
         ]
 
         # WHEN
         assert UnrealOpenJob.check_conda_package_version(job_parameter_values)
 
         # THEN
-        assert job_parameter_values[0].get("value") == "unrealengine=5.3 somepackage=1.0"
+        assert (
+            job_parameter_values[0].get("value")
+            == "unrealengine=5.3 somepackage=1.0 unrealengine-openjd=0.5.*"
+        )
 
     @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_check_conda_package_ver.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_check_conda_package_ver.py
@@ -34,7 +34,7 @@ class TestCheckCondaPackageVersion:
         UnrealOpenJob.check_conda_package_version(job_parameter_values)
 
         # THEN
-        assert job_parameter_values[0].get("value") == "unrealengine=5.4"
+        assert job_parameter_values == []
 
     @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"
@@ -46,8 +46,10 @@ class TestCheckCondaPackageVersion:
         job_parameter_values = [dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="")]
 
         # WHEN
-        with pytest.raises(exceptions.InvalidUEVersionInCondaPackageParameter):
-            UnrealOpenJob.check_conda_package_version(job_parameter_values)
+        UnrealOpenJob.check_conda_package_version(job_parameter_values)
+
+        # THEN
+        assert job_parameter_values[0].get("value") == "unrealengine=5.3"
 
     @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"
@@ -61,8 +63,10 @@ class TestCheckCondaPackageVersion:
         ]
 
         # WHEN
-        with pytest.raises(exceptions.InvalidUEVersionInCondaPackageParameter):
-            UnrealOpenJob.check_conda_package_version(job_parameter_values)
+        UnrealOpenJob.check_conda_package_version(job_parameter_values)
+
+        # THEN
+        assert job_parameter_values[0].get("value") == "unrealengine=5.3 somepackage=1.0"
 
     @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"
@@ -77,6 +81,21 @@ class TestCheckCondaPackageVersion:
 
         # WHEN
         UnrealOpenJob.check_conda_package_version(job_parameter_values)
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"
+    )
+    def test_check_conda_package_version_versions_mismatch(self, get_engine_version_mock):
+        # GIVEN
+        get_engine_version_mock.return_value = "5.4"
+
+        job_parameter_values = [
+            dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="unrealengine=5.3")
+        ]
+
+        # WHEN
+        with pytest.raises(exceptions.InvalidUEVersionInCondaPackageParameter):
+            UnrealOpenJob.check_conda_package_version(job_parameter_values)
 
     @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_check_conda_package_ver.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_check_conda_package_ver.py
@@ -3,9 +3,7 @@
 import sys
 from typing import Any
 
-import pytest
 from unittest.mock import MagicMock, patch
-from deadline.unreal_submitter import exceptions
 
 unreal_mock = MagicMock()
 sys.modules["unreal"] = unreal_mock
@@ -31,7 +29,7 @@ class TestCheckCondaPackageVersion:
         job_parameter_values: list[dict[str, Any]] = []
 
         # WHEN
-        UnrealOpenJob.check_conda_package_version(job_parameter_values)
+        assert UnrealOpenJob.check_conda_package_version(job_parameter_values)
 
         # THEN
         assert job_parameter_values == []
@@ -46,7 +44,7 @@ class TestCheckCondaPackageVersion:
         job_parameter_values = [dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="")]
 
         # WHEN
-        UnrealOpenJob.check_conda_package_version(job_parameter_values)
+        assert UnrealOpenJob.check_conda_package_version(job_parameter_values)
 
         # THEN
         assert job_parameter_values[0].get("value") == "unrealengine=5.3"
@@ -63,7 +61,7 @@ class TestCheckCondaPackageVersion:
         ]
 
         # WHEN
-        UnrealOpenJob.check_conda_package_version(job_parameter_values)
+        assert UnrealOpenJob.check_conda_package_version(job_parameter_values)
 
         # THEN
         assert job_parameter_values[0].get("value") == "unrealengine=5.3 somepackage=1.0"
@@ -80,7 +78,7 @@ class TestCheckCondaPackageVersion:
         ]
 
         # WHEN
-        UnrealOpenJob.check_conda_package_version(job_parameter_values)
+        assert UnrealOpenJob.check_conda_package_version(job_parameter_values)
 
     @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"
@@ -94,8 +92,7 @@ class TestCheckCondaPackageVersion:
         ]
 
         # WHEN
-        with pytest.raises(exceptions.InvalidUEVersionInCondaPackageParameter):
-            UnrealOpenJob.check_conda_package_version(job_parameter_values)
+        assert not UnrealOpenJob.check_conda_package_version(job_parameter_values)
 
     @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"
@@ -109,4 +106,4 @@ class TestCheckCondaPackageVersion:
         ]
 
         # WHEN
-        UnrealOpenJob.check_conda_package_version(job_parameter_values)
+        assert UnrealOpenJob.check_conda_package_version(job_parameter_values)

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_check_conda_package_ver.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_check_conda_package_ver.py
@@ -1,0 +1,121 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import sys
+import pytest
+from unittest.mock import  MagicMock, patch
+import unreal
+from openjd.model.v2023_09 import JobTemplate
+
+unreal_mock = MagicMock()
+sys.modules["unreal"] = unreal_mock
+
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity import (  # noqa: E402
+    UnrealOpenJobEntity,
+    OpenJobParameterNames,
+)
+from deadline.unreal_submitter.submitter import UnrealMrqJobSubmitter
+
+
+class TestCheckCondaPackageVersion:
+
+
+    def test_check_conda_package_version_no_conda_packages_param(self):
+        # Change UE version
+        unreal.SystemLibrary.get_engine_version = lambda: "5.3.0"
+        unreal.EditorDialog.show_message = MagicMock()
+
+        open_job_entity = UnrealOpenJobEntity(template_class=JobTemplate, file_path="")
+
+        open_job_entity.get_mrq_template_object = lambda: {"parameterDefinitions": []}
+
+        result = open_job_entity.check_conda_package_version()
+
+        assert result is True
+        unreal.EditorDialog.show_message.assert_not_called()
+
+    @patch("unreal.SystemLibrary.get_engine_version")
+    @patch("unreal.EditorDialog.show_message")
+    @patch.object(UnrealOpenJobEntity, "get_mrq_template_object", create=True)
+    def test_check_conda_package_version_conda_packages_no_value(self, get_mrq_template_mock, show_message_mock, get_engine_version_mock):
+        # GIVEN
+        get_engine_version_mock.return_value = "5.3.0"
+        get_mrq_template_mock.return_value = {
+            "parameterDefinitions": [
+                {"name": OpenJobParameterNames.CONDA_PACKAGES, "default": ""}
+            ]
+        }
+        
+        unreal_open_job_entity = UnrealOpenJobEntity(template_class=JobTemplate, file_path="")
+
+        # WHEN
+        result = unreal_open_job_entity.check_conda_package_version()
+
+        # THEN
+        assert result is True
+        get_mrq_template_mock.assert_called_once()
+        show_message_mock.assert_not_called()
+
+    @patch("unreal.SystemLibrary.get_engine_version")
+    @patch("unreal.EditorDialog.show_message")
+    @patch.object(UnrealOpenJobEntity, "get_mrq_template_object", create=True)
+    def test_check_conda_package_version_no_unrealengine_pattern(self, get_mrq_template_mock, show_message_mock, get_engine_version_mock):
+        # GIVEN
+        get_engine_version_mock.return_value = "5.3.0"
+        get_mrq_template_mock.return_value = {
+            "parameterDefinitions": [
+                {"name": OpenJobParameterNames.CONDA_PACKAGES, "default": "somepackage=1.0"}
+            ]
+        }
+        
+        unreal_open_job_entity = UnrealOpenJobEntity(template_class=JobTemplate, file_path="")
+
+        # WHEN
+        result = unreal_open_job_entity.check_conda_package_version()
+
+        # THEN
+        assert result is True
+        get_mrq_template_mock.assert_called_once()
+        show_message_mock.assert_not_called()
+
+    @patch("unreal.SystemLibrary.get_engine_version")
+    @patch("unreal.EditorDialog.show_message")
+    @patch.object(UnrealOpenJobEntity, "get_mrq_template_object", create=True)
+    def test_check_conda_package_version_versions_match(self, get_mrq_template_mock, show_message_mock, get_engine_version_mock):
+        # GIVEN
+        get_engine_version_mock.return_value = "5.3.0"
+        get_mrq_template_mock.return_value = {
+            "parameterDefinitions": [
+                {"name": OpenJobParameterNames.CONDA_PACKAGES, "default": "unrealengine=5.3"}
+            ]
+        }
+        
+        unreal_open_job_entity = UnrealOpenJobEntity(template_class=JobTemplate, file_path="")
+
+        # WHEN
+        result = unreal_open_job_entity.check_conda_package_version()
+
+        # THEN
+        assert result is True
+        get_mrq_template_mock.assert_called_once()
+        show_message_mock.assert_not_called()
+
+    @patch("unreal.SystemLibrary.get_engine_version")
+    @patch("unreal.EditorDialog.show_message")
+    def test_check_conda_package_version_minor_version_difference(self, show_message_mock, get_engine_version_mock):
+    # GIVEN
+        get_engine_version_mock.return_value = "5.3.2"
+
+        unreal_open_job_entity = UnrealOpenJobEntity(template_class=JobTemplate, file_path="")
+
+        unreal_open_job_entity.get_mrq_template_object = lambda: {
+            "parameterDefinitions": [
+                {"name": OpenJobParameterNames.CONDA_PACKAGES, "default": "unrealengine=5.3"}
+            ]
+        }
+
+    # WHEN
+        result = unreal_open_job_entity.check_conda_package_version()
+
+    # THEN
+        assert result is True
+        show_message_mock.assert_not_called()

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
@@ -126,11 +126,17 @@ class TestUnrealOpenJob:
         assert isinstance(param, UnrealOpenJobParameterDefinition) == found
 
     @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version",
+        return_value="5.4",
+    )
+    @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
         "UnrealOpenJobEntity.get_template_object",
         return_value=fixtures.f_job_template_default(),
     )
-    def test__build_parameter_values(self, get_template_object_mock: Mock):
+    def test__build_parameter_values(
+        self, get_engine_version: Mock, get_template_object_mock: Mock
+    ):
         # GIVEN
         yaml_parameters = fixtures.f_job_template_default()["parameterDefinitions"]
         open_job = UnrealOpenJob(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

It's necessary that CondaPackages parameter should contain same UE version as the version of the project from job is submitted. Therefore the default value define in Template should be updated on submit if its differs

### What was the solution? (How)

Add validation of CondaPackages parameter. 
- If CondaPackages parameter not in OpenJob parameters - skip validation.
- Otherwise check if its value contains unrealengine=x.x (Regex)
   - If contains compare with current UE version of the Project
      - If equals, continue submit. Raise an Error otherwise
   - If its not there, build with current version

### What is the impact of this change?

Job can't be submitted with wrong unreal engine conda package version

### How was this change tested?

Submit Job without CondaPackages parameter - validation skipped
With empty CondaPackages parameter - unrealengine=x.x were added (5.4)
With CondaPackages=unrealengine=5.3 - raise an error (Project was on 5.4)
With CondaPackages=unrealengine=5.4 - validation passed (Project was on 5.4)

- Have you run the unit tests?
Yes

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

Yes

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*