### PR TITLE
test: add plugins support to e2e test

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -147,7 +147,8 @@ Solution:
         "logs:CreateLogStream",
         "logs:PutLogEvents",
         "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams"
+        "logs:DescribeLogStreams",
+        "logs:GetLogEvents"
       ],
       "Resource": "arn:aws:logs:*:*:log-group:/aws/deadline/*"
     }

--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -812,7 +812,7 @@ def create_readonly_test_project(request) -> Generator[Tuple[str, str], None, No
 
     engine_root = find_engine_root(request.config.getoption("--ueversion"))
     # Source path for the template
-    source_path = os.path.join(engine_root, "Templates\TP_DMXBP")
+    source_path = os.path.join(engine_root, r"Templates\TP_DMXBP")
     if not os.path.exists(source_path):
         pytest.fail(f"Could not find source template at {source_path}")
 
@@ -831,25 +831,6 @@ def create_readonly_test_project(request) -> Generator[Tuple[str, str], None, No
         True,
     )
 
-    yield dest_path, project_path
-
-
-@pytest.fixture(scope="session")
-def create_test_project_with_content_plugins(
-    create_readonly_test_project,
-) -> Generator[Tuple[str, str], None, None]:
-    dest_path, project_path = create_readonly_test_project
-
-    # Add content plugins
-    # 1,3 enabled by default and 2,4 disabled by default
-    add_content_plugins_to_project(dest_path, ["EmptyContentPlugin1", "EmptyContentPlugin3"], True)
-    add_content_plugins_to_project(dest_path, ["EmptyContentPlugin2", "EmptyContentPlugin4"], False)
-
-    # Disable plugin 1 and enable plugin 2 in the project
-    add_plugins_to_project(project_path, ["EmptyContentPlugin1"], False)
-    add_plugins_to_project(project_path, ["EmptyContentPlugin2"], True)
-
-    # As a result, we end up with two active plugins(2,3) and two inactive ones(1,4) via different paths
     yield dest_path, project_path
 
 
@@ -1830,7 +1811,7 @@ def get_last_session_project_plugins(
         return []
 
 
-def _extract_project_plugins_from_log_events(logs_client, log_group, log_stream):
+def _extract_project_plugins_from_log_events(logs_client, log_group, log_stream) -> List[str]:
     """
     Extract unique project plugin names from log events in the specified log group and stream.
     Args:

--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -247,13 +247,71 @@ def get_build_script_args() -> List[str]:
     return ["--install", "--test", "--worker"]
 
 
-def add_plugins_to_project(project_path: str, plugins: List[str]) -> None:
+def add_content_plugins_to_project(project_path: str, plugins: List[str], enabled: bool) -> None:
+    """
+    Add the provided list of content plugins to the uproject at the given project_path.
+
+    Args:
+        project_path: Path to .uproject file to add plugins to
+        plugins: List of string names of content plugins to add to the project
+        enabled: Whether to enable or disable the plugins
+    """
+    for plugin_name in plugins:
+        create_minimal_plugin_structure(
+            project_path, plugin_name, enabled, friendly_name=plugin_name
+        )
+
+
+def create_minimal_plugin_structure(
+    project_path: str,
+    plugin_name: str,
+    enabled: bool,
+    friendly_name: Optional[str] = None,
+    description: str = "Auto-generated plugin",
+) -> None:
+    plugins_root = os.path.join(project_path, "Plugins")
+    plugin_root = os.path.join(plugins_root, plugin_name)
+    content_dir = os.path.join(plugin_root, "Content")
+    resources_dir = os.path.join(plugin_root, "Resources")
+
+    os.makedirs(plugins_root, exist_ok=True)
+    os.makedirs(plugin_root, exist_ok=True)
+    os.makedirs(content_dir, exist_ok=True)
+    os.makedirs(resources_dir, exist_ok=True)
+
+    uplugin = {
+        "FileVersion": 3,
+        "Version": 1,
+        "VersionName": "1.0",
+        "FriendlyName": friendly_name,
+        "Description": description,
+        "Category": "Content",
+        "CreatedBy": "Auto Script",
+        "CreatedByURL": "",
+        "DocsURL": "",
+        "MarketplaceURL": "",
+        "SupportURL": "",
+        "CanContainContent": True,
+        "IsBetaVersion": False,
+        "Installed": False,
+        "EnabledByDefault": enabled,
+        "Modules": [],
+        "Plugins": [],
+    }
+
+    uplugin_path = os.path.join(plugin_root, f"{plugin_name}.uplugin")
+    with open(uplugin_path, "w", encoding="utf-8") as f:
+        json.dump(uplugin, f, indent=2)
+
+
+def add_plugins_to_project(project_path: str, plugins: List[str], enabled: bool) -> None:
     """
     Add the provided list of plugins to the uproject at the given project_path.
 
     Args:
         project_path: Path to .uproject file to add plugins to
         plugins: List of string names of plugins to add to the project
+        enabled: Whether to enable or disable the plugins
     """
     # Read the current .uproject file
     with open(project_path, "r") as f:
@@ -265,7 +323,7 @@ def add_plugins_to_project(project_path: str, plugins: List[str]) -> None:
 
     # Add each plugin if not already present
     for plugin_name in plugins:
-        plugin_entry = {"Name": plugin_name, "Enabled": True}
+        plugin_entry = {"Name": plugin_name, "Enabled": enabled}
         if plugin_entry not in project_data["Plugins"]:
             project_data["Plugins"].append(plugin_entry)
 
@@ -767,7 +825,14 @@ def create_readonly_test_project(request) -> Generator[Tuple[str, str], None, No
 
     # Add our plugins
     project_path = os.path.join(dest_path, "TP_DMXBP.uproject")
-    add_plugins_to_project(project_path, ["UnrealDeadlineCloudService", "MovieRenderPipeline"])
+    add_plugins_to_project(
+        project_path,
+        ["UnrealDeadlineCloudService", "MovieRenderPipeline", "EmptyContentPlugin2"],
+        True,
+    )
+    add_plugins_to_project(project_path, ["EmptyContentPlugin1"], False)
+    add_content_plugins_to_project(dest_path, ["EmptyContentPlugin1", "EmptyContentPlugin3"], True)
+    add_content_plugins_to_project(dest_path, ["EmptyContentPlugin2", "EmptyContentPlugin4"], False)
 
     yield dest_path, project_path
 
@@ -1699,3 +1764,89 @@ def reusable_queue_fleet_association(
         logger.info(
             "Skipping queue-fleet association cleanup (use --cleanup to clean up resources)"
         )
+
+
+def get_last_session_project_plugins(
+    deadline_client: BaseClient, farm_id: str, queue_id: str, job_id: str
+) -> List[str]:
+    """
+    Fetch the last session's project plugins used by a job by parsing its log events.
+
+    Args:
+        deadline_client: The Deadline Cloud client
+        farm_id: The farm ID
+        queue_id: The queue ID
+        job_id: The job ID
+
+    Returns:
+        A sorted list of unique project plugin names used in the last session
+    """
+    try:
+        sessions_response = deadline_client.list_sessions(
+            farmId=farm_id,
+            jobId=job_id,
+            queueId=queue_id,
+        )
+        session_id = sessions_response["sessions"][0]["sessionId"]
+
+        session_response = deadline_client.get_session(
+            farmId=farm_id,
+            jobId=job_id,
+            queueId=queue_id,
+            sessionId=session_id,
+        )
+
+        log_response = session_response["log"]
+
+        # Get job details to find the log group and stream
+        cwl_client = boto3.client("logs", TEST_TARGET_REGION)
+
+        # Extract project plugins from the log events
+        plugin_names = _extract_project_plugins_from_log_events(
+            cwl_client,
+            log_response["options"]["logGroupName"],
+            log_response["options"]["logStreamName"],
+        )
+        return plugin_names
+
+    except Exception as e:
+        logger.warning(f"Error fetching job logs or extracting plugins: {str(e)}")
+        return []
+
+
+def _extract_project_plugins_from_log_events(logs_client, log_group, log_stream):
+    """
+    Extract unique project plugin names from log events in the specified log group and stream.
+    Args:
+        logs_client: The CloudWatch Logs client
+        log_group: The name of the log group
+        log_stream: The name of the log stream
+
+    Returns:
+        A sorted list of unique project plugin names
+    """
+    plugin_names = set()
+    pattern = re.compile(r"Mounting Project plugin\s+(?P<name>.+?)\s*$")
+
+    next_token = None
+    while True:
+        if next_token:
+            resp = logs_client.get_log_events(
+                logGroupName=log_group, logStreamName=log_stream, nextToken=next_token
+            )
+        else:
+            resp = logs_client.get_log_events(logGroupName=log_group, logStreamName=log_stream)
+
+        for ev in resp.get("events", []):
+            msg = ev.get("message", "")
+            for line in msg.splitlines():
+                m = pattern.search(line)
+                if m:
+                    plugin_names.add(m.group("name"))
+
+        new_token = resp.get("nextForwardToken")
+        if not new_token or new_token == next_token:
+            break
+        next_token = new_token
+
+    return sorted(plugin_names)

--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -827,15 +827,27 @@ def create_readonly_test_project(request) -> Generator[Tuple[str, str], None, No
     project_path = os.path.join(dest_path, "TP_DMXBP.uproject")
     add_plugins_to_project(
         project_path,
-        ["UnrealDeadlineCloudService", "MovieRenderPipeline", "EmptyContentPlugin2"],
+        ["UnrealDeadlineCloudService", "MovieRenderPipeline"],
         True,
     )
-    add_plugins_to_project(project_path, ["EmptyContentPlugin1"], False)
-    add_content_plugins_to_project(dest_path, ["EmptyContentPlugin1", "EmptyContentPlugin3"], True)
-    add_content_plugins_to_project(dest_path, ["EmptyContentPlugin2", "EmptyContentPlugin4"], False)
 
     yield dest_path, project_path
 
+@pytest.fixture(scope="session")
+def create_test_project_with_content_plugins(create_readonly_test_project) -> Generator[Tuple[str, str], None, None]:
+    dest_path, project_path = create_readonly_test_project
+
+    # Add content plugins
+    # 1,3 enabled by default and 2,4 disabled by default
+    add_content_plugins_to_project(dest_path, ["EmptyContentPlugin1", "EmptyContentPlugin3"], True)
+    add_content_plugins_to_project(dest_path, ["EmptyContentPlugin2", "EmptyContentPlugin4"], False)
+
+    # Disable plugin 1 and enable plugin 2 in the project
+    add_plugins_to_project(project_path, ["EmptyContentPlugin1"], False)
+    add_plugins_to_project(project_path, ["EmptyContentPlugin2"], True)
+
+    # As a result, we end up with two active plugins(2,3) and two inactive ones(1,4) via different paths
+    yield dest_path, project_path
 
 @pytest.fixture(scope="session")
 def session() -> boto3.Session:
@@ -1826,7 +1838,7 @@ def _extract_project_plugins_from_log_events(logs_client, log_group, log_stream)
         A sorted list of unique project plugin names
     """
     plugin_names = set()
-    pattern = re.compile(r"Mounting Project plugin\s+(?P<name>.+?)\s*$")
+    pattern = re.compile(r"Mounting Project plugin\s+(?P<name>[^\s]+(?:\s+[^\s]+)*)\s*$")
 
     next_token = None
     while True:

--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -833,8 +833,11 @@ def create_readonly_test_project(request) -> Generator[Tuple[str, str], None, No
 
     yield dest_path, project_path
 
+
 @pytest.fixture(scope="session")
-def create_test_project_with_content_plugins(create_readonly_test_project) -> Generator[Tuple[str, str], None, None]:
+def create_test_project_with_content_plugins(
+    create_readonly_test_project,
+) -> Generator[Tuple[str, str], None, None]:
     dest_path, project_path = create_readonly_test_project
 
     # Add content plugins
@@ -848,6 +851,7 @@ def create_test_project_with_content_plugins(create_readonly_test_project) -> Ge
 
     # As a result, we end up with two active plugins(2,3) and two inactive ones(1,4) via different paths
     yield dest_path, project_path
+
 
 @pytest.fixture(scope="session")
 def session() -> boto3.Session:

--- a/test/end_to_end/test_worker_agent.py
+++ b/test/end_to_end/test_worker_agent.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 def test_create_job_with_worker_agent(
     deadline_client,
     build_plugin,
-    create_readonly_test_project,
+    create_test_project_with_content_plugins,
     run_unreal_test,
     deadline_worker_agent,
 ):
@@ -25,7 +25,7 @@ def test_create_job_with_worker_agent(
     # The deadline_worker_agent fixture will start the worker agent before this test runs
     # and will stop it after the test completes
 
-    _, uproject_file = create_readonly_test_project
+    _, uproject_file = create_test_project_with_content_plugins
 
     logger.info(f"Creating job from project {uproject_file}")
     success, output_lines = run_unreal_test("DeadlineCloud.Integration.CreateJob", uproject_file)

--- a/test/end_to_end/test_worker_agent.py
+++ b/test/end_to_end/test_worker_agent.py
@@ -5,6 +5,8 @@ from conftest import (
     extract_job_info_from_test_output,
     wait_for_job_state,
     get_last_session_project_plugins,
+    add_content_plugins_to_project,
+    add_plugins_to_project,
 )
 
 logger = logging.getLogger(__name__)
@@ -13,7 +15,7 @@ logger = logging.getLogger(__name__)
 def test_create_job_with_worker_agent(
     deadline_client,
     build_plugin,
-    create_test_project_with_content_plugins,
+    create_readonly_test_project,
     run_unreal_test,
     deadline_worker_agent,
 ):
@@ -25,7 +27,7 @@ def test_create_job_with_worker_agent(
     # The deadline_worker_agent fixture will start the worker agent before this test runs
     # and will stop it after the test completes
 
-    _, uproject_file = create_test_project_with_content_plugins
+    _, uproject_file = create_readonly_test_project
 
     logger.info(f"Creating job from project {uproject_file}")
     success, output_lines = run_unreal_test("DeadlineCloud.Integration.CreateJob", uproject_file)
@@ -49,6 +51,56 @@ def test_create_job_with_worker_agent(
 
         assert success
 
+        logger.info(f"Job {job_id} SUCCEEDED")
+    else:
+        logger.warning("Could not extract job ID or farm ID from test output")
+        assert False, "Could not extract job information from test output"
+
+
+def test_worker_agent_project_plugins(
+    deadline_client,
+    build_plugin,
+    create_readonly_test_project,
+    run_unreal_test,
+    deadline_worker_agent,
+):
+
+    # The deadline_worker_agent fixture will start the worker agent before this test runs
+    # and will stop it after the test completes
+
+    _, uproject_file = create_readonly_test_project
+
+    # Add content plugins
+    # 1,3 enabled by default and 2,4 disabled by default
+    add_content_plugins_to_project(_, ["EmptyContentPlugin1", "EmptyContentPlugin3"], True)
+    add_content_plugins_to_project(_, ["EmptyContentPlugin2", "EmptyContentPlugin4"], False)
+
+    # Disable plugin 1 and enable plugin 2 in the project
+    add_plugins_to_project(uproject_file, ["EmptyContentPlugin1"], False)
+    add_plugins_to_project(uproject_file, ["EmptyContentPlugin2"], True)
+
+    # As a result, we end up with two active plugins(2,3) and two inactive ones(1,4) via different paths
+
+    logger.info(f"Creating job from project {uproject_file}")
+    success, output_lines = run_unreal_test("DeadlineCloud.Integration.CreateJob", uproject_file)
+    assert success, "Create job test failed"
+
+    # Extract job ID and farm ID from the output
+    job_id, farm_id, queue_id = extract_job_info_from_test_output(output_lines)
+
+    if job_id and farm_id and queue_id:
+
+        # Wait for job completion
+        wait_for_job_state(
+            deadline_client=deadline_client,
+            farm_id=farm_id,
+            job_id=job_id,
+            queue_id=queue_id,
+            expected_states=["SUCCEEDED"],
+            max_wait_time=600,
+            wait_interval=10,
+        )
+
         # Verify which project plugins were loaded by the worker
         worker_project_plugins = get_last_session_project_plugins(
             deadline_client=deadline_client,
@@ -57,15 +109,14 @@ def test_create_job_with_worker_agent(
             job_id=job_id,
         )
 
+        logger.info(f"Worker project plugins: {worker_project_plugins}")
+
         # The worker should have loaded EmptyContentPlugin2 and EmptyContentPlugin3 only
         assert "EmptyContentPlugin1" not in worker_project_plugins
         assert "EmptyContentPlugin2" in worker_project_plugins
         assert "EmptyContentPlugin3" in worker_project_plugins
         assert "EmptyContentPlugin4" not in worker_project_plugins
 
-        logger.info(f"Worker project plugins: {worker_project_plugins}")
-
-        logger.info(f"Job {job_id} SUCCEEDED")
     else:
         logger.warning("Could not extract job ID or farm ID from test output")
         assert False, "Could not extract job information from test output"

--- a/test/end_to_end/test_worker_agent.py
+++ b/test/end_to_end/test_worker_agent.py
@@ -1,7 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import logging
-from conftest import extract_job_info_from_test_output, wait_for_job_state
+from conftest import (
+    extract_job_info_from_test_output,
+    wait_for_job_state,
+    get_last_session_project_plugins,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +48,22 @@ def test_create_job_with_worker_agent(
         )
 
         assert success
+
+        # Verify which project plugins were loaded by the worker
+        worker_project_plugins = get_last_session_project_plugins(
+            deadline_client=deadline_client,
+            farm_id=farm_id,
+            queue_id=queue_id,
+            job_id=job_id,
+        )
+
+        # The worker should have loaded EmptyContentPlugin2 and EmptyContentPlugin3 only
+        assert "EmptyContentPlugin1" not in worker_project_plugins
+        assert "EmptyContentPlugin2" in worker_project_plugins
+        assert "EmptyContentPlugin3" in worker_project_plugins
+        assert "EmptyContentPlugin4" not in worker_project_plugins
+
+        logger.info(f"Worker project plugins: {worker_project_plugins}")
 
         logger.info(f"Job {job_id} SUCCEEDED")
     else:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Automated Project Plugins collecting as Job dependencies should be covered with e2e tests

### What was the solution? (How)

Implement e2e test that check all edge cases:
1. Include Project/Engine plugins, enable and disable them
2. Launch e2e tests
3. After job is finished, parse output and check that expected Plugins were initialized in Unreal Engine session

### What is the impact of this change?

e2e for plugins support implemented

### How was this change tested?

e2e test

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

Yes

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*