### PR TITLE
fix: Caching and using our deadline client for precache_clients metho…

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -5,6 +5,6 @@ pytest-xdist == 3.*
 twine == 6.*
 mypy == 1.*
 black == 25.*
-ruff == 0.12.*
+ruff == 0.13.*
 types-pyyaml == 6.*
 psutil >= 5.9.0

--- a/src/deadline/unreal_submitter/submitter.py
+++ b/src/deadline/unreal_submitter/submitter.py
@@ -262,7 +262,6 @@ class UnrealSubmitter:
             self._submission_failed_message = ""
 
             job_bundle_path = job.create_job_bundle()
-
             t = threading.Thread(target=self._start_submit, args=(job_bundle_path,), daemon=True)
             t.start()
 

--- a/src/unreal_plugin/Content/Python/init_unreal.py
+++ b/src/unreal_plugin/Content/Python/init_unreal.py
@@ -108,26 +108,21 @@ if remote_execution != "True":
 
     logger.info(f'DEADLINE CLOUD PATH: {os.getenv("DEADLINE_CLOUD")}')
 
-    from deadline.client.api import precache_clients
-
-    def init_s3_client():
-        logger.info("INITIALIZING S3 CLIENT")
-        precache_clients()
-        logger.info("DONE INITIALIZING S3 CLIENT")
-
-    import threading
-
-    threading.Thread(target=init_s3_client, daemon=True, name="S3ClientInit").start()
     # These unused imports are REQUIRED!!!
     # Unreal Engine loads any init_unreal.py it finds in its search paths.
     # These imports finish the setup for the plugin.
-    from settings import DeadlineCloudSettingsLibraryImplementation  # noqa: F401
+    from settings import (
+        DeadlineCloudSettingsLibraryImplementation,  # noqa: F401
+        background_init_s3_client,
+    )
     from job_library import DeadlineCloudJobBundleLibraryImplementation  # noqa: F401
     from open_job_template_api import (  # noqa: F401
         PythonYamlLibraryImplementation,
         ParametersConsistencyCheckerImplementation,
     )
     import remote_executor  # noqa: F401
+
+    background_init_s3_client()
 
     logger.info("DEADLINE CLOUD INITIALIZED")
 

--- a/src/unreal_plugin/Content/Python/settings.py
+++ b/src/unreal_plugin/Content/Python/settings.py
@@ -2,13 +2,14 @@
 
 import sys
 import unreal
-from typing import Any
-
+from typing import Any, Tuple
+import threading
+from botocore.client import BaseClient
 import boto3
 import deadline.client.config as config
 
 from deadline.client import api
-from deadline.client.api import AwsCredentialsSource, AwsAuthenticationStatus
+from deadline.client.api import AwsCredentialsSource, AwsAuthenticationStatus, precache_clients
 from deadline.client.config import config_file
 from deadline.job_attachments.models import FileConflictResolution
 
@@ -49,6 +50,33 @@ def _get_current_os() -> str:
     if sys.platform.startswith("win"):
         return "windows"
     return "Unknown"
+
+
+def background_init_s3_client():
+    """
+    Initialize cache an S3 client based on the current deadline configuration
+    within the deadline cloud library
+    """
+    deadline = api.get_boto3_client("deadline")
+    result_container: dict[str, Tuple[BaseClient, BaseClient]] = {}
+
+    def init_s3_client():
+        logger.info("INITIALIZING S3 CLIENT")
+        result = precache_clients(deadline=deadline)
+        result_container["result"] = result
+        logger.info("DONE INITIALIZING S3 CLIENT")
+
+    thread = threading.Thread(target=init_s3_client, daemon=True, name="S3ClientInit")
+    thread.start()
+    thread.result_container = result_container  # type: ignore[attr-defined]
+    return thread
+
+
+def on_farm_queue_update():
+    """
+    Perform updates based on a change in farm or queue
+    """
+    background_init_s3_client()
 
 
 @unreal.uclass()
@@ -181,6 +209,8 @@ class DeadlineCloudSettingsLibraryImplementation(unreal.DeadlineCloudSettingsLib
             config=None,
         )
         if success_message:
+            on_farm_queue_update()
+
             unreal.EditorDialog.show_message(
                 "Deadline Cloud", success_message, unreal.AppMsgType.OK, unreal.AppReturnType.OK
             )
@@ -240,15 +270,23 @@ class DeadlineCloudSettingsLibraryImplementation(unreal.DeadlineCloudSettingsLib
             config=config_parser,
         )
 
+        farm_queue_update = False
+
+        farm_id = config.get_setting("defaults.farm_id")
         farm = self.find_entity_by_name(settings.profile.default_farm, cache.farms_cache_list)
         if farm is not None:
             logger.info(f"Update default farm: {farm.id} -- {farm.name}")
             config.set_setting("defaults.farm_id", farm.id, config=config_parser)
+            if farm.id != farm_id:
+                farm_queue_update = True
 
+        queue_id = config.get_setting("defaults.queue_id")
         queue = self.find_entity_by_name(settings.farm.default_queue, cache.queues_cache_list)
         if queue is not None:
             logger.info(f"Update default queue: {queue.id} -- {queue.name}")
             config.set_setting("defaults.queue_id", queue.id, config=config_parser)
+            if queue.id != queue_id:
+                farm_queue_update = True
 
         storage_profile = self.find_entity_by_name(
             settings.farm.default_storage_profile, cache.storage_profiles_cache_list
@@ -290,3 +328,6 @@ class DeadlineCloudSettingsLibraryImplementation(unreal.DeadlineCloudSettingsLib
         )
 
         config_file.write_config(config_parser)
+
+        if farm_queue_update:
+            on_farm_queue_update()

--- a/test/deadline_submitter_for_unreal/unit/conftest.py
+++ b/test/deadline_submitter_for_unreal/unit/conftest.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+@pytest.fixture
+def aws_test_config():
+    """Fixture that mocks common deadline clients"""
+    with patch("boto3.Session.client") as mock_client:
+
+        def client_side_effect(service_name, **kwargs):
+            if service_name == "deadline":
+                return MagicMock()
+            return mock_client.return_value
+
+        mock_client.side_effect = client_side_effect
+        yield

--- a/test/deadline_submitter_for_unreal/unit/test_settings.py
+++ b/test/deadline_submitter_for_unreal/unit/test_settings.py
@@ -1,0 +1,50 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import sys
+import os
+from unittest.mock import patch
+
+
+# Add the settings module to path since it's not in the standard package structure
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "../../../src/unreal_plugin/Content/Python")
+)
+
+
+class TestBackgroundInitS3Client:
+    """Test the background_init_s3_client function"""
+
+    def test_background_init_s3_client_consistency(self, aws_test_config):
+        """Test that background_init_s3_client produces consistent results with direct precache_clients calls"""
+        from settings import background_init_s3_client
+        from deadline.client.api import precache_clients
+
+        # Call background_init_s3_client and get the thread
+        thread = background_init_s3_client()
+
+        # Wait for the thread to complete
+        thread.join(timeout=10.0)
+
+        # Get the result from the thread
+        first_result = thread.result_container.get("result")
+
+        # Call precache_clients again without parameters
+        second_result = precache_clients()
+
+        # Verify that both calls return the same client objects
+        assert first_result == second_result
+        assert first_result is not None
+        assert second_result is not None
+
+
+class TestOnFarmQueueUpdate:
+    """Test the on_farm_queue_update function"""
+
+    @patch("settings.background_init_s3_client")
+    def test_on_farm_queue_update_calls_background_init(self, mock_background_init):
+        """Test that on_farm_queue_update calls background_init_s3_client"""
+        from settings import on_farm_queue_update
+
+        on_farm_queue_update()
+
+        mock_background_init.assert_called_once()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A potential race condition when creating our deadline clients and storing them with lru_cache can potentially invalidate our precache_clients call when ran in a background thread, meaning at submission time the s3 client and service discovery would occur again, delaying initial submission.

### What was the solution? (How)
Cache our deadline client and use it in our precache_clients call.

### What is the impact of this change?
Significantly faster (~30 seconds) initial submissions in cases where the race condition occurred.

### How was this change tested?
Local testing and timing

- Have you run the unit tests?
Yes

### Have you run a render job successfully with these changes?
Yes

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*