### PR TITLE
fix: Logging configuration issue

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -165,3 +165,15 @@ Root Cause: Version mismatch between the Unreal Engine version used to submit th
 Solutions:
    - Resubmit the job using the Unreal Engine version that matches the worker node. On Service Managed Fleets - Ensure the Conda package version selected matches your project's version of Unreal Engine
    - Install the correct Unreal Engine version on the worker node and update environment variables to match the job's Unreal Engine version
+
+### Missing Deadline Cloud Job Submission Configuration in Movie Render Queue
+
+Issue: When launching Movie Render Queue, Deadline Cloud job submission configurations are not visible.
+
+Root Cause: Movie Render Pipeline project settings were not properly configured.
+
+Solution: Configure Movie Render Pipeline settings as described in [Submit a Test Render](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/blob/mainline/SETUP_SUBMITTER.md#submit-a-test-render):
+   - Under "Edit"/"Project Settings" search for the "Movie Render Pipeline" section
+     - For "Default Remote Executor", select "MoviePipelineDeadlineCloudRemoteExecutor"
+     - For "Default Executor Job", select "MoviePipelineDeadlineCloudExecutorJob"
+     - Under "Default Job Settings Classes", click add icon, and add "DeadlineCloudRenderStepSetting"

--- a/src/deadline/unreal_logger/logger.py
+++ b/src/deadline/unreal_logger/logger.py
@@ -45,8 +45,8 @@ def get_logger() -> logging.Logger:
     if not UNREAL_HANDLER_ADDED and UNREAL_INITIALIZED:
         add_unreal_handler(unreal_logger)
         UNREAL_HANDLER_ADDED = True
-    else:
-        # Add console handler when running outside Unreal Engine
+
+    if not UNREAL_HANDLER_ADDED:
         console_handler = logging.StreamHandler()
         console_handler.setLevel(logging.DEBUG)
         unreal_logger.addHandler(console_handler)

--- a/src/unreal_plugin/Content/Python/init_unreal.py
+++ b/src/unreal_plugin/Content/Python/init_unreal.py
@@ -122,7 +122,10 @@ if remote_execution != "True":
     )
     import remote_executor  # noqa: F401
 
-    background_init_s3_client()
+    try:
+        background_init_s3_client()
+    except Exception as e:
+        logger.error(f"Failed to run background_init_s3_client: {e}")
 
     logger.info("DEADLINE CLOUD INITIALIZED")
 

--- a/src/unreal_plugin/Content/Python/settings.py
+++ b/src/unreal_plugin/Content/Python/settings.py
@@ -57,14 +57,24 @@ def background_init_s3_client():
     Initialize cache an S3 client based on the current deadline configuration
     within the deadline cloud library
     """
-    deadline = api.get_boto3_client("deadline")
+    logger.info("INIT DEADLINE CLOUD")
+    try:
+        deadline = api.get_boto3_client("deadline")
+        logger.info("Got deadline client successfully")
+    except Exception as e:
+        logger.error(f"Failed to get deadline client: {e}")
+        return None
+
     result_container: dict[str, Tuple[BaseClient, BaseClient]] = {}
 
     def init_s3_client():
-        logger.info("INITIALIZING S3 CLIENT")
-        result = precache_clients(deadline=deadline)
-        result_container["result"] = result
-        logger.info("DONE INITIALIZING S3 CLIENT")
+        try:
+            logger.info("INITIALIZING S3 CLIENT")
+            result = precache_clients(deadline=deadline)
+            result_container["result"] = result
+            logger.info("DONE INITIALIZING S3 CLIENT")
+        except Exception as e:
+            logger.error(f"Failed to initialize S3 client: {e}")
 
     thread = threading.Thread(target=init_s3_client, daemon=True, name="S3ClientInit")
     thread.start()

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -16,17 +16,13 @@
 
 UMoviePipelineDeadlineCloudExecutorJob::UMoviePipelineDeadlineCloudExecutorJob()
 {
-	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob constructor called"));
-
+	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob constructor called"));
 	if (GEngine)
 	{
-		// // If a Job Preset is not already defined, assign the default preset
+		// If a Job Preset is not already defined, assign the default preset
 		if (!JobPreset) {
-			UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: GEngine available, checking JobPreset"));
-			// // If a Job Preset is not already defined, assign the default preset
-			if (!JobPreset) {
-				JobPreset = CreateDefaultJobPresetFromTemplates(JobPreset);
-			}
+			UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: GEngine available, checking JobPreset"));
+			JobPreset = CreateDefaultJobPresetFromTemplates(JobPreset);
 		}
 	}
 }
@@ -63,15 +59,12 @@ void UMoviePipelineDeadlineCloudExecutorJob::SetPropertyRowEnabledInMovieRenderJ
 
 void UMoviePipelineDeadlineCloudExecutorJob::PostInitProperties()
 {
-	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: PostInitProperties called"));
+	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: PostInitProperties called"));
 	Super::PostInitProperties();
 
 #if WITH_EDITOR
 	if (!HasAnyFlags(RF_ClassDefaultObject)){
-		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Calling JobPresetChanged"));
 		JobPresetChanged();
-	} else {
-		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Skipping JobPresetChanged (ClassDefaultObject)"));
 	}
 #endif // WITH_EDITOR
 }
@@ -163,16 +156,16 @@ void UMoviePipelineDeadlineCloudExecutorJob::UpdateAttachmentFields()
 
 void UMoviePipelineDeadlineCloudExecutorJob::JobPresetChanged()
 {
-	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: JobPresetChanged called"));
+	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: JobPresetChanged called"));
 	const UDeadlineCloudJob* SelectedJobPreset = this->JobPreset;
 
 	if (!SelectedJobPreset)
 	{
-		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: JobPreset is null, creating default in JobPresetChanged"));
+		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: JobPreset is null, creating default in JobPresetChanged"));
 		this->JobPreset = CreateDefaultJobPresetFromTemplates(JobPreset);
 		SelectedJobPreset = this->JobPreset;
 	} else {
-		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: JobPreset exists in JobPresetChanged"));
+		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: JobPreset exists in JobPresetChanged"));
 	}
 
 	this->PresetOverrides.HostRequirements = SelectedJobPreset->JobPresetStruct.HostRequirements;
@@ -220,7 +213,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 	// Check file on disk
 	if (!FPaths::FileExists(FilePath))
 	{
-		UE_LOG(LogTemp, Warning, TEXT("Dependency file missing: %s"), *FilePath);
+		UE_LOG(LogTemp, Log, TEXT("Dependency file missing: %s"), *FilePath);
 		return false;
 	}
 
@@ -228,7 +221,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 	FString LongPackagePath;
 	if (!FPackageName::TryConvertFilenameToLongPackageName(FilePath, LongPackagePath))
 	{
-		UE_LOG(LogTemp, Warning, TEXT("Could not convert to package path: %s"), *FilePath);
+		UE_LOG(LogTemp, Log, TEXT("Could not convert to package path: %s"), *FilePath);
 		return false;
 	}
 
@@ -238,7 +231,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 
 	if (!AssetData.IsValid())
 	{
-		UE_LOG(LogTemp, Warning, TEXT("AssetRegistry has no info about: %s (from file %s)"), *LongPackagePath, *FilePath);
+		UE_LOG(LogTemp, Log, TEXT("AssetRegistry has no info about: %s (from file %s)"), *LongPackagePath, *FilePath);
 		return false;
 	}
 
@@ -250,7 +243,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 	 // Check directory on disk
 	 if (!FPaths::DirectoryExists(DirectoryPath))
 	 {
-		 UE_LOG(LogTemp, Warning, TEXT("Dependency directory missing: %s"), *DirectoryPath);
+		 UE_LOG(LogTemp, Log, TEXT("Dependency directory missing: %s"), *DirectoryPath);
 		 return false;
 	 }
 	 return true;
@@ -422,11 +415,11 @@ TArray<FString> UMoviePipelineDeadlineCloudExecutorJob::GetJobInitialStateOption
 
 UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJobPresetFromTemplates(UDeadlineCloudRenderJob* Preset)
 {
-	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates called"));
+	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates called"));
 
 	if (Preset == nullptr)
 	{
-		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Creating new UDeadlineCloudRenderJob"));
+		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Creating new UDeadlineCloudRenderJob"));
 
 		Preset = NewObject<UDeadlineCloudRenderJob>();
 
@@ -434,29 +427,13 @@ UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJo
 		FString StepTemplate = "/Content/Python/openjd_templates/render_step.yml";
 		FString EnvTemplate = "/Content/Python/openjd_templates/launch_ue_environment.yml";
 
-		// Get plugin base directory with error checking
-        TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("UnrealDeadlineCloudService"));
-        if (!Plugin.IsValid())
-        {
-            UE_LOG(LogTemp, Error, TEXT("DeadlineCloud: Plugin 'UnrealDeadlineCloudService' not found"));
-            return Preset;
-        }
-
-        FString PluginContentDir = Plugin->GetBaseDir();
-        UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Plugin base directory: %s"), *PluginContentDir);
-		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Plugin base directory (absolute): %s"), *FPaths::ConvertRelativePathToFull(PluginContentDir));
+		FString PluginContentDir = IPluginManager::Get().FindPlugin(TEXT("UnrealDeadlineCloudService"))->GetBaseDir();
 
 		FString PathToJobTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), DefaultTemplate);
 		FPaths::NormalizeDirectoryName(PathToJobTemplate);
-		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Looking for job template at: %s"), *PathToJobTemplate);
-		// Verify template file exists
-        if (!FPaths::FileExists(PathToJobTemplate))
-        {
-            UE_LOG(LogTemp, Error, TEXT("DeadlineCloud: Job template not found at: %s"), *PathToJobTemplate);
-            return Preset;
-        }
+		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Looking for job template at: %s"), *PathToJobTemplate);
 
-		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Job template found, opening file"));
+		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Job template found, opening file"));
 		Preset->PathToTemplate.FilePath = PathToJobTemplate;
 		Preset->OpenJobFile(PathToJobTemplate);
 
@@ -464,13 +441,7 @@ UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJo
 		PresetStep = NewObject<UDeadlineCloudRenderStep>();
 		FString PathToStepTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), StepTemplate);
 		FPaths::NormalizeDirectoryName(PathToStepTemplate);
-		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Looking for step template at: %s"), *PathToStepTemplate);
-		// Verify template file exists
-		if (!FPaths::FileExists(PathToStepTemplate))
-        {
-            UE_LOG(LogTemp, Error, TEXT("DeadlineCloud: Step template not found at: %s"), *PathToStepTemplate);
-            return Preset;
-        }
+		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Looking for step template at: %s"), *PathToStepTemplate);
 
 		PresetStep->PathToTemplate.FilePath = PathToStepTemplate;
 		PresetStep->OpenStepFile(PathToStepTemplate);
@@ -480,7 +451,7 @@ UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJo
 		PresetEnv = NewObject<UDeadlineCloudEnvironment>();
 		FString PathToEnvTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), EnvTemplate);
 		FPaths::NormalizeDirectoryName(PathToEnvTemplate);
-		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Looking for env template at: %s"), *PathToEnvTemplate);
+		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Looking for env template at: %s"), *PathToEnvTemplate);
 		// Verify template file exists
 		if (!FPaths::FileExists(PathToEnvTemplate))
         {
@@ -491,9 +462,9 @@ UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJo
 		PresetEnv->PathToTemplate.FilePath = PathToEnvTemplate;
 		PresetEnv->OpenEnvFile(PathToEnvTemplate);
 		Preset->Environments.Add(PresetEnv);
-		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates completed successfully"));
+		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates completed successfully"));
 	}
-	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates returning preset"));
+	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates returning preset"));
 	return Preset;
 }
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -16,12 +16,12 @@
 
 UMoviePipelineDeadlineCloudExecutorJob::UMoviePipelineDeadlineCloudExecutorJob()
 {
-	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob constructor called"));
+	UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob constructor called"));
 	if (GEngine)
 	{
 		// If a Job Preset is not already defined, assign the default preset
 		if (!JobPreset) {
-			UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Assigning the default JobPreset"));
+			UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Assigning the default JobPreset"));
 			JobPreset = CreateDefaultJobPresetFromTemplates(JobPreset);
 		}
 	}
@@ -59,7 +59,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::SetPropertyRowEnabledInMovieRenderJ
 
 void UMoviePipelineDeadlineCloudExecutorJob::PostInitProperties()
 {
-	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: PostInitProperties called"));
+	UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: PostInitProperties called"));
 	Super::PostInitProperties();
 
 #if WITH_EDITOR
@@ -156,16 +156,16 @@ void UMoviePipelineDeadlineCloudExecutorJob::UpdateAttachmentFields()
 
 void UMoviePipelineDeadlineCloudExecutorJob::JobPresetChanged()
 {
-	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: JobPresetChanged called"));
+	UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: JobPresetChanged called"));
 	const UDeadlineCloudJob* SelectedJobPreset = this->JobPreset;
 
 	if (!SelectedJobPreset)
 	{
-		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: JobPreset is null, creating default in JobPresetChanged"));
+		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: JobPreset is null, creating default in JobPresetChanged"));
 		this->JobPreset = CreateDefaultJobPresetFromTemplates(JobPreset);
 		SelectedJobPreset = this->JobPreset;
 	} else {
-		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: JobPreset exists in JobPresetChanged"));
+		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: JobPreset exists in JobPresetChanged"));
 	}
 
 	this->PresetOverrides.HostRequirements = SelectedJobPreset->JobPresetStruct.HostRequirements;
@@ -203,7 +203,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 		}
 	}
 
-	UE_LOG(LogTemp, Log, TEXT("Deadline Cloud job changed: %s"),
+	UE_LOG(LogTemp, Display, TEXT("Deadline Cloud job changed: %s"),
 		*PropertyChangedEvent.Property->GetPathName());
 	}
 }
@@ -254,11 +254,11 @@ void UMoviePipelineDeadlineCloudExecutorJob::CollectDependencies()
 
 	if (GEngine)
 	{
-		UE_LOG(LogTemp, Log, TEXT("Running Garbage Collection before dependency update..."));
+		UE_LOG(LogTemp, Display, TEXT("Running Garbage Collection before dependency update..."));
 		GEngine->ForceGarbageCollection();
 		
 	}
-	UE_LOG(LogTemp, Log, TEXT("MoviePipelineDeadlineCloudExecutorJob :: Collecting dependencies"));
+	UE_LOG(LogTemp, Display, TEXT("MoviePipelineDeadlineCloudExecutorJob :: Collecting dependencies"));
 	PresetOverrides.JobAttachments.InputFiles.AutoDetected.Paths.Empty();
 	AsyncTask(ENamedThreads::GameThread, [this]()
 		{
@@ -278,7 +278,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::CollectDependencies()
 					DependencyFiles.Add(Item);
 				}
 				
-				UE_LOG(LogTemp, Log, TEXT("Added %d dependency files:"), DependencyFiles.Num());
+				UE_LOG(LogTemp, Display, TEXT("Added %d dependency files:"), DependencyFiles.Num());
 			}
 			else
 			{
@@ -309,7 +309,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::CollectPluginsDependencies()
 					PresetOverrides.JobAttachments.InputDirectories.AutoDetectedDirectories.Paths.Add(Item);
 				}
 
-				UE_LOG(LogTemp, Log, TEXT("Added %d dependency directories:"), Plugins.Num());
+				UE_LOG(LogTemp, Display, TEXT("Added %d dependency directories:"), Plugins.Num());
 			}
 			else
 			{
@@ -345,7 +345,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::UpdateInputDirectoriesProperty()
 void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeChainProperty(FPropertyChangedChainEvent& PropertyChangedEvent)
 {
 	Super::PostEditChangeChainProperty(PropertyChangedEvent);
-	UE_LOG(LogTemp, Log, TEXT("Show auto detected: %s"), *GET_MEMBER_NAME_CHECKED(FDeadlineCloudFileAttachmentsStruct, bShowAutoDetected).ToString());
+	UE_LOG(LogTemp, Display, TEXT("Show auto detected: %s"), *GET_MEMBER_NAME_CHECKED(FDeadlineCloudFileAttachmentsStruct, bShowAutoDetected).ToString());
 	if (PropertyChangedEvent.GetPropertyName() == "bShowAutoDetected")
 	{
 		static const FName InputFilesName = GET_MEMBER_NAME_CHECKED(FDeadlineCloudAttachmentsStruct, InputFiles);
@@ -370,7 +370,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeChainProperty(FProper
 	{
 		UpdateInputFilesProperty();
 	}
-	UE_LOG(LogTemp, Log, TEXT("Changed property name: %s"), *PropertyChangedEvent.GetPropertyName().ToString());
+	UE_LOG(LogTemp, Display, TEXT("Changed property name: %s"), *PropertyChangedEvent.GetPropertyName().ToString());
 }
 
 TArray<FString> UMoviePipelineDeadlineCloudExecutorJob::GetCpuArchitectures()
@@ -415,11 +415,11 @@ TArray<FString> UMoviePipelineDeadlineCloudExecutorJob::GetJobInitialStateOption
 
 UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJobPresetFromTemplates(UDeadlineCloudRenderJob* Preset)
 {
-	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates called"));
+	UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates called"));
 
 	if (Preset == nullptr)
 	{
-		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Creating new UDeadlineCloudRenderJob"));
+		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Creating new UDeadlineCloudRenderJob"));
 
 		Preset = NewObject<UDeadlineCloudRenderJob>();
 
@@ -431,9 +431,9 @@ UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJo
 
 		FString PathToJobTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), DefaultTemplate);
 		FPaths::NormalizeDirectoryName(PathToJobTemplate);
-		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Looking for job template at: %s"), *PathToJobTemplate);
+		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Looking for job template at: %s"), *PathToJobTemplate);
 
-		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Job template found, opening file"));
+		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Job template found, opening file"));
 		Preset->PathToTemplate.FilePath = PathToJobTemplate;
 		Preset->OpenJobFile(PathToJobTemplate);
 
@@ -441,7 +441,7 @@ UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJo
 		PresetStep = NewObject<UDeadlineCloudRenderStep>();
 		FString PathToStepTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), StepTemplate);
 		FPaths::NormalizeDirectoryName(PathToStepTemplate);
-		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Looking for step template at: %s"), *PathToStepTemplate);
+		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Looking for step template at: %s"), *PathToStepTemplate);
 
 		PresetStep->PathToTemplate.FilePath = PathToStepTemplate;
 		PresetStep->OpenStepFile(PathToStepTemplate);
@@ -451,12 +451,12 @@ UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJo
 		PresetEnv = NewObject<UDeadlineCloudEnvironment>();
 		FString PathToEnvTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), EnvTemplate);
 		FPaths::NormalizeDirectoryName(PathToEnvTemplate);
-		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Looking for env template at: %s"), *PathToEnvTemplate);
+		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Looking for env template at: %s"), *PathToEnvTemplate);
 
 		PresetEnv->PathToTemplate.FilePath = PathToEnvTemplate;
 		PresetEnv->OpenEnvFile(PathToEnvTemplate);
 		Preset->Environments.Add(PresetEnv);
-		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates completed successfully"));
+		UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates completed successfully"));
 	}
 	return Preset;
 }

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -21,7 +21,7 @@ UMoviePipelineDeadlineCloudExecutorJob::UMoviePipelineDeadlineCloudExecutorJob()
 	{
 		// If a Job Preset is not already defined, assign the default preset
 		if (!JobPreset) {
-			UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: GEngine available, checking JobPreset"));
+			UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Assigning the default JobPreset"));
 			JobPreset = CreateDefaultJobPresetFromTemplates(JobPreset);
 		}
 	}
@@ -213,7 +213,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 	// Check file on disk
 	if (!FPaths::FileExists(FilePath))
 	{
-		UE_LOG(LogTemp, Log, TEXT("Dependency file missing: %s"), *FilePath);
+		UE_LOG(LogTemp, Warning, TEXT("Dependency file missing: %s"), *FilePath);
 		return false;
 	}
 
@@ -221,7 +221,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 	FString LongPackagePath;
 	if (!FPackageName::TryConvertFilenameToLongPackageName(FilePath, LongPackagePath))
 	{
-		UE_LOG(LogTemp, Log, TEXT("Could not convert to package path: %s"), *FilePath);
+		UE_LOG(LogTemp, Warning, TEXT("Could not convert to package path: %s"), *FilePath);
 		return false;
 	}
 
@@ -231,7 +231,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 
 	if (!AssetData.IsValid())
 	{
-		UE_LOG(LogTemp, Log, TEXT("AssetRegistry has no info about: %s (from file %s)"), *LongPackagePath, *FilePath);
+		UE_LOG(LogTemp, Warning, TEXT("AssetRegistry has no info about: %s (from file %s)"), *LongPackagePath, *FilePath);
 		return false;
 	}
 
@@ -243,7 +243,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::PostEditChangeProperty(FPropertyCha
 	 // Check directory on disk
 	 if (!FPaths::DirectoryExists(DirectoryPath))
 	 {
-		 UE_LOG(LogTemp, Log, TEXT("Dependency directory missing: %s"), *DirectoryPath);
+		 UE_LOG(LogTemp, Warning, TEXT("Dependency directory missing: %s"), *DirectoryPath);
 		 return false;
 	 }
 	 return true;
@@ -452,19 +452,12 @@ UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJo
 		FString PathToEnvTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), EnvTemplate);
 		FPaths::NormalizeDirectoryName(PathToEnvTemplate);
 		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Looking for env template at: %s"), *PathToEnvTemplate);
-		// Verify template file exists
-		if (!FPaths::FileExists(PathToEnvTemplate))
-        {
-            UE_LOG(LogTemp, Error, TEXT("DeadlineCloud: Environment template not found at: %s"), *PathToEnvTemplate);
-            return Preset;
-        }
 
 		PresetEnv->PathToTemplate.FilePath = PathToEnvTemplate;
 		PresetEnv->OpenEnvFile(PathToEnvTemplate);
 		Preset->Environments.Add(PresetEnv);
 		UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates completed successfully"));
 	}
-	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates returning preset"));
 	return Preset;
 }
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -16,11 +16,17 @@
 
 UMoviePipelineDeadlineCloudExecutorJob::UMoviePipelineDeadlineCloudExecutorJob()
 {
+	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob constructor called"));
+
 	if (GEngine)
 	{
 		// // If a Job Preset is not already defined, assign the default preset
 		if (!JobPreset) {
-			JobPreset = CreateDefaultJobPresetFromTemplates(JobPreset);
+			UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: GEngine available, checking JobPreset"));
+			// // If a Job Preset is not already defined, assign the default preset
+			if (!JobPreset) {
+				JobPreset = CreateDefaultJobPresetFromTemplates(JobPreset);
+			}
 		}
 	}
 }
@@ -57,11 +63,15 @@ void UMoviePipelineDeadlineCloudExecutorJob::SetPropertyRowEnabledInMovieRenderJ
 
 void UMoviePipelineDeadlineCloudExecutorJob::PostInitProperties()
 {
+	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: PostInitProperties called"));
 	Super::PostInitProperties();
 
 #if WITH_EDITOR
 	if (!HasAnyFlags(RF_ClassDefaultObject)){
-	JobPresetChanged();
+		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Calling JobPresetChanged"));
+		JobPresetChanged();
+	} else {
+		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Skipping JobPresetChanged (ClassDefaultObject)"));
 	}
 #endif // WITH_EDITOR
 }
@@ -153,12 +163,16 @@ void UMoviePipelineDeadlineCloudExecutorJob::UpdateAttachmentFields()
 
 void UMoviePipelineDeadlineCloudExecutorJob::JobPresetChanged()
 {
+	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: JobPresetChanged called"));
 	const UDeadlineCloudJob* SelectedJobPreset = this->JobPreset;
 
 	if (!SelectedJobPreset)
 	{
+		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: JobPreset is null, creating default in JobPresetChanged"));
 		this->JobPreset = CreateDefaultJobPresetFromTemplates(JobPreset);
 		SelectedJobPreset = this->JobPreset;
+	} else {
+		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: JobPreset exists in JobPresetChanged"));
 	}
 
 	this->PresetOverrides.HostRequirements = SelectedJobPreset->JobPresetStruct.HostRequirements;
@@ -408,18 +422,41 @@ TArray<FString> UMoviePipelineDeadlineCloudExecutorJob::GetJobInitialStateOption
 
 UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJobPresetFromTemplates(UDeadlineCloudRenderJob* Preset)
 {
+	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates called"));
+
 	if (Preset == nullptr)
 	{
+		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Creating new UDeadlineCloudRenderJob"));
+
 		Preset = NewObject<UDeadlineCloudRenderJob>();
 
 		FString DefaultTemplate = "/Content/Python/openjd_templates/render_job.yml";
 		FString StepTemplate = "/Content/Python/openjd_templates/render_step.yml";
 		FString EnvTemplate = "/Content/Python/openjd_templates/launch_ue_environment.yml";
 
-		FString  PluginContentDir = IPluginManager::Get().FindPlugin(TEXT("UnrealDeadlineCloudService"))->GetBaseDir();
+		// Get plugin base directory with error checking
+        TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("UnrealDeadlineCloudService"));
+        if (!Plugin.IsValid())
+        {
+            UE_LOG(LogTemp, Error, TEXT("DeadlineCloud: Plugin 'UnrealDeadlineCloudService' not found"));
+            return Preset;
+        }
+
+        FString PluginContentDir = Plugin->GetBaseDir();
+        UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Plugin base directory: %s"), *PluginContentDir);
+		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Plugin base directory (absolute): %s"), *FPaths::ConvertRelativePathToFull(PluginContentDir));
 
 		FString PathToJobTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), DefaultTemplate);
 		FPaths::NormalizeDirectoryName(PathToJobTemplate);
+		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Looking for job template at: %s"), *PathToJobTemplate);
+		// Verify template file exists
+        if (!FPaths::FileExists(PathToJobTemplate))
+        {
+            UE_LOG(LogTemp, Error, TEXT("DeadlineCloud: Job template not found at: %s"), *PathToJobTemplate);
+            return Preset;
+        }
+
+		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Job template found, opening file"));
 		Preset->PathToTemplate.FilePath = PathToJobTemplate;
 		Preset->OpenJobFile(PathToJobTemplate);
 
@@ -427,6 +464,14 @@ UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJo
 		PresetStep = NewObject<UDeadlineCloudRenderStep>();
 		FString PathToStepTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), StepTemplate);
 		FPaths::NormalizeDirectoryName(PathToStepTemplate);
+		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Looking for step template at: %s"), *PathToStepTemplate);
+		// Verify template file exists
+		if (!FPaths::FileExists(PathToStepTemplate))
+        {
+            UE_LOG(LogTemp, Error, TEXT("DeadlineCloud: Step template not found at: %s"), *PathToStepTemplate);
+            return Preset;
+        }
+
 		PresetStep->PathToTemplate.FilePath = PathToStepTemplate;
 		PresetStep->OpenStepFile(PathToStepTemplate);
 		Preset->Steps.Add(PresetStep);
@@ -435,11 +480,20 @@ UDeadlineCloudRenderJob* UMoviePipelineDeadlineCloudExecutorJob::CreateDefaultJo
 		PresetEnv = NewObject<UDeadlineCloudEnvironment>();
 		FString PathToEnvTemplate = FPaths::Combine(FPaths::ConvertRelativePathToFull(PluginContentDir), EnvTemplate);
 		FPaths::NormalizeDirectoryName(PathToEnvTemplate);
+		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Looking for env template at: %s"), *PathToEnvTemplate);
+		// Verify template file exists
+		if (!FPaths::FileExists(PathToEnvTemplate))
+        {
+            UE_LOG(LogTemp, Error, TEXT("DeadlineCloud: Environment template not found at: %s"), *PathToEnvTemplate);
+            return Preset;
+        }
+
 		PresetEnv->PathToTemplate.FilePath = PathToEnvTemplate;
 		PresetEnv->OpenEnvFile(PathToEnvTemplate);
 		Preset->Environments.Add(PresetEnv);
-
+		UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates completed successfully"));
 	}
+	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: CreateDefaultJobPresetFromTemplates returning preset"));
 	return Preset;
 }
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
@@ -14,18 +14,19 @@
 
 void FUnrealDeadlineCloudServiceModule::StartupModule()
 {
-	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: UE Install Path: %s"), *FPaths::EngineDir());
+	UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: UE Install Path: %s"), *FPaths::EngineDir());
 
 	// Verify the executor class is available
     UClass* ExecutorClass = UMoviePipelineDeadlineCloudExecutorJob::StaticClass();
-    if (ExecutorClass){
-        UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob class found: %s"), *ExecutorClass->GetName());
+    if (ExecutorClass)
+	{
+        UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob class found: %s"), *ExecutorClass->GetName());
     } else {
         UE_LOG(LogTemp, Error, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob class NOT found"));
     }
 
     FPropertyEditorModule& PropertyModule = FModuleManager::GetModuleChecked<FPropertyEditorModule>("PropertyEditor");
-    UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: PropertyEditor module loaded"));
+    UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: PropertyEditor module loaded"));
     
 	PropertyModule.RegisterCustomClassLayout(
         UDeadlineCloudDeveloperSettings::StaticClass()->GetFName(),
@@ -40,19 +41,19 @@ void FUnrealDeadlineCloudServiceModule::StartupModule()
 	PropertyModule.RegisterCustomClassLayout(
 		UDeadlineCloudStep::StaticClass()->GetFName(),
 		FOnGetDetailCustomizationInstance::CreateStatic(&FDeadlineCloudStepDetails::MakeInstance));
-    UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: UDeadlineCloudStep registered"));
+    UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: UDeadlineCloudStep registered"));
 
 	PropertyModule.RegisterCustomClassLayout(
 		UDeadlineCloudEnvironment::StaticClass()->GetFName(),
 		FOnGetDetailCustomizationInstance::CreateStatic(&FDeadlineCloudEnvironmentDetails::MakeInstance));
-    UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: UDeadlineCloudEnvironment registered"));
+    UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: UDeadlineCloudEnvironment registered"));
 
 
 	PropertyModule.RegisterCustomClassLayout(
 		UMoviePipelineDeadlineCloudExecutorJob::StaticClass()->GetFName(),
 		FOnGetDetailCustomizationInstance::CreateStatic(&FMoviePipelineDeadlineCloudExecutorJobCustomization::MakeInstance)
 	);
-	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Registered UMoviePipelineDeadlineCloudExecutorJob customization"));
+	UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: Registered UMoviePipelineDeadlineCloudExecutorJob customization"));
 
 	// Job details properties customization
 	PropertyModule.RegisterCustomPropertyTypeLayout(
@@ -118,7 +119,7 @@ void FUnrealDeadlineCloudServiceModule::StartupModule()
 	);
 
 	PropertyModule.NotifyCustomizationModuleChanged();
-	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: All customizations registered, module startup complete"));
+	UE_LOG(LogTemp, Display, TEXT("DeadlineCloud: All customizations registered, module startup complete"));
 }
 
 void FUnrealDeadlineCloudServiceModule::ShutdownModule()

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
@@ -14,30 +14,48 @@
 
 void FUnrealDeadlineCloudServiceModule::StartupModule()
 {
+	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: UE Install Path: %s"), *FPaths::EngineDir());
+
+	// Verify the executor class is available
+    UClass* ExecutorClass = UMoviePipelineDeadlineCloudExecutorJob::StaticClass();
+    if (ExecutorClass)
+    {
+        UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob class found: %s"), *ExecutorClass->GetName());
+    }
+    else
+    {
+        UE_LOG(LogTemp, Error, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob class NOT found"));
+    }
+
     FPropertyEditorModule& PropertyModule = FModuleManager::GetModuleChecked<FPropertyEditorModule>("PropertyEditor");
-    PropertyModule.RegisterCustomClassLayout(
+    UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: PropertyEditor module loaded"));
+    
+	PropertyModule.RegisterCustomClassLayout(
         UDeadlineCloudDeveloperSettings::StaticClass()->GetFName(),
         FOnGetDetailCustomizationInstance::CreateStatic(&FDeadlineCloudSettingsDetails::MakeInstance)
     );
+
     //job step, environment object details
     PropertyModule.RegisterCustomClassLayout(
         UDeadlineCloudJob::StaticClass()->GetFName(),
-		FOnGetDetailCustomizationInstance::CreateStatic(&FDeadlineCloudJobDetails::MakeInstance));
+               FOnGetDetailCustomizationInstance::CreateStatic(&FDeadlineCloudJobDetails::MakeInstance));
 
 	PropertyModule.RegisterCustomClassLayout(
 		UDeadlineCloudStep::StaticClass()->GetFName(),
 		FOnGetDetailCustomizationInstance::CreateStatic(&FDeadlineCloudStepDetails::MakeInstance));
+    UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: UDeadlineCloudStep registered"));
 
 	PropertyModule.RegisterCustomClassLayout(
 		UDeadlineCloudEnvironment::StaticClass()->GetFName(),
 		FOnGetDetailCustomizationInstance::CreateStatic(&FDeadlineCloudEnvironmentDetails::MakeInstance));
-
+    UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: UDeadlineCloudEnvironment registered"));
 
 
 	PropertyModule.RegisterCustomClassLayout(
 		UMoviePipelineDeadlineCloudExecutorJob::StaticClass()->GetFName(),
 		FOnGetDetailCustomizationInstance::CreateStatic(&FMoviePipelineDeadlineCloudExecutorJobCustomization::MakeInstance)
 	);
+	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Registered UMoviePipelineDeadlineCloudExecutorJob customization"));
 
 	// Job details properties customization
 	PropertyModule.RegisterCustomPropertyTypeLayout(
@@ -103,6 +121,7 @@ void FUnrealDeadlineCloudServiceModule::StartupModule()
 	);
 
 	PropertyModule.NotifyCustomizationModuleChanged();
+	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: All customizations registered, module startup complete"));
 }
 
 void FUnrealDeadlineCloudServiceModule::ShutdownModule()

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
@@ -18,12 +18,9 @@ void FUnrealDeadlineCloudServiceModule::StartupModule()
 
 	// Verify the executor class is available
     UClass* ExecutorClass = UMoviePipelineDeadlineCloudExecutorJob::StaticClass();
-    if (ExecutorClass)
-    {
+    if (ExecutorClass){
         UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob class found: %s"), *ExecutorClass->GetName());
-    }
-    else
-    {
+    } else {
         UE_LOG(LogTemp, Error, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob class NOT found"));
     }
 
@@ -38,7 +35,7 @@ void FUnrealDeadlineCloudServiceModule::StartupModule()
     //job step, environment object details
     PropertyModule.RegisterCustomClassLayout(
         UDeadlineCloudJob::StaticClass()->GetFName(),
-            FOnGetDetailCustomizationInstance::CreateStatic(&FDeadlineCloudJobDetails::MakeInstance));
+        FOnGetDetailCustomizationInstance::CreateStatic(&FDeadlineCloudJobDetails::MakeInstance));
 
 	PropertyModule.RegisterCustomClassLayout(
 		UDeadlineCloudStep::StaticClass()->GetFName(),

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
@@ -14,13 +14,13 @@
 
 void FUnrealDeadlineCloudServiceModule::StartupModule()
 {
-	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: UE Install Path: %s"), *FPaths::EngineDir());
+	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: UE Install Path: %s"), *FPaths::EngineDir());
 
 	// Verify the executor class is available
     UClass* ExecutorClass = UMoviePipelineDeadlineCloudExecutorJob::StaticClass();
     if (ExecutorClass)
     {
-        UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob class found: %s"), *ExecutorClass->GetName());
+        UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: UMoviePipelineDeadlineCloudExecutorJob class found: %s"), *ExecutorClass->GetName());
     }
     else
     {
@@ -28,7 +28,7 @@ void FUnrealDeadlineCloudServiceModule::StartupModule()
     }
 
     FPropertyEditorModule& PropertyModule = FModuleManager::GetModuleChecked<FPropertyEditorModule>("PropertyEditor");
-    UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: PropertyEditor module loaded"));
+    UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: PropertyEditor module loaded"));
     
 	PropertyModule.RegisterCustomClassLayout(
         UDeadlineCloudDeveloperSettings::StaticClass()->GetFName(),
@@ -38,24 +38,24 @@ void FUnrealDeadlineCloudServiceModule::StartupModule()
     //job step, environment object details
     PropertyModule.RegisterCustomClassLayout(
         UDeadlineCloudJob::StaticClass()->GetFName(),
-               FOnGetDetailCustomizationInstance::CreateStatic(&FDeadlineCloudJobDetails::MakeInstance));
+            FOnGetDetailCustomizationInstance::CreateStatic(&FDeadlineCloudJobDetails::MakeInstance));
 
 	PropertyModule.RegisterCustomClassLayout(
 		UDeadlineCloudStep::StaticClass()->GetFName(),
 		FOnGetDetailCustomizationInstance::CreateStatic(&FDeadlineCloudStepDetails::MakeInstance));
-    UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: UDeadlineCloudStep registered"));
+    UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: UDeadlineCloudStep registered"));
 
 	PropertyModule.RegisterCustomClassLayout(
 		UDeadlineCloudEnvironment::StaticClass()->GetFName(),
 		FOnGetDetailCustomizationInstance::CreateStatic(&FDeadlineCloudEnvironmentDetails::MakeInstance));
-    UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: UDeadlineCloudEnvironment registered"));
+    UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: UDeadlineCloudEnvironment registered"));
 
 
 	PropertyModule.RegisterCustomClassLayout(
 		UMoviePipelineDeadlineCloudExecutorJob::StaticClass()->GetFName(),
 		FOnGetDetailCustomizationInstance::CreateStatic(&FMoviePipelineDeadlineCloudExecutorJobCustomization::MakeInstance)
 	);
-	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: Registered UMoviePipelineDeadlineCloudExecutorJob customization"));
+	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: Registered UMoviePipelineDeadlineCloudExecutorJob customization"));
 
 	// Job details properties customization
 	PropertyModule.RegisterCustomPropertyTypeLayout(
@@ -121,7 +121,7 @@ void FUnrealDeadlineCloudServiceModule::StartupModule()
 	);
 
 	PropertyModule.NotifyCustomizationModuleChanged();
-	UE_LOG(LogTemp, Warning, TEXT("DeadlineCloud: All customizations registered, module startup complete"));
+	UE_LOG(LogTemp, Log, TEXT("DeadlineCloud: All customizations registered, module startup complete"));
 }
 
 void FUnrealDeadlineCloudServiceModule::ShutdownModule()


### PR DESCRIPTION

Fixes: Logging configuration issue

### What was the problem/requirement? (What/Why)
While investigating an plugin installing issue, we discovered the following problems,
- False positive error logs were being generated due to misconfigured logging settings
- Users encountering Movie Render Queue (MRQ) setup failures due to missing critical configuration steps
- Limited troubleshooting visibility for installation issues

### What was the solution? (How)
- Corrected logging configuration to eliminate false positive errors
- Created a dedicated troubleshooting guide for MRQ setup, highlighting critical configuration steps
- Implemented additional logging points to improve system observability

### What is the impact of this change?
- Cleaner, more accurate log outputs that reflect true system state
- Reduced MRQ setup failures through better documentation and guidance
- Enhanced ability to diagnose and resolve installation issues with improved logging coverage

### How was this change tested?
Ran unit tests, e2e tests, also manually submitted jobs.

E2E test result:
```
=================================================================== slowest 5 durations ===================================================================
401.66s call     test/end_to_end/test_worker_agent.py::test_worker_agent_project_plugins
361.42s call     test/end_to_end/test_worker_agent.py::test_create_job_with_worker_agent
301.09s setup    test/end_to_end/test_create_job.py::test_create_job
91.62s call     test/end_to_end/test_create_job.py::test_create_job
10.32s setup    test/end_to_end/test_worker_agent.py::test_create_job_with_worker_agent
============================================================= 3 passed in 1176.16s (0:19:36) ==============================================================
```

- Have you run the unit tests?
```
Required test coverage of 65.0% reached. Total coverage: 66.88%
=================================================================== slowest 5 durations ===================================================================
0.58s call     test/deadline_submitter_for_unreal/unit/test_settings.py::TestBackgroundInitS3Client::test_background_init_s3_client_consistency
0.35s call     test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py::TestUnrealAdaptor_on_start::test_init_data_wrong_schema
0.12s call     test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py::TestUnrealAdaptor_on_start::test_unreal_init_timeout
0.11s call     test/deadline_submitter_for_unreal/unit/test_submitter.py::TestUnrealSubmitter::test_submit_jobs
0.11s call     test/deadline_submitter_for_unreal/unit/test_submitter.py::TestUnrealSubmitter::test_cancel_submit_jobs
============================================================= 315 passed, 1 skipped in 8.14s ==============================================================
```

### Have you run a render job successfully with these changes?
Yes, submitted jobs from my dev box and a machine to reproduce customer issue, both job rendered successfully

### Was this change documented?
Added troubleshooting guide as part of this PR

### Is this a breaking change?
No
