### PR TITLE
chore: Set default version of unrealengine openjd to 0.5.*

### DIFF
--- a/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
@@ -27,7 +27,7 @@ parameterDefinitions:
    control: HIDDEN
 - name: CondaPackages
   type: STRING
-  default: unrealengine=5.6 unrealengine-openjd=0.6.*
+  default: unrealengine=5.6 unrealengine-openjd=0.5.*
   userInterface: 
    control: LINE_EDIT
 - name: CondaChannels


### PR DESCRIPTION
chore: Set default version of unrealengine openjd to 0.5.*

### What was the problem/requirement? (What/Why)

unrealengine-openjd 0.6.* release is delayed. We want to keep the default value at 0.5.* until 0.6.* is released

### What was the solution? (How)

Update the default value of unrealengine-openjd version

### What is the impact of this change?

User will default to use the unrealengine-openjd 0.5.* 

### How was this change tested?

- Have you run the unit tests?
```
Required test coverage of 65.0% reached. Total coverage: 66.88%
============================================================================================================ slowest 5 durations =============================================================================================================
0.45s call     test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py::TestUnrealAdaptor_on_start::test_init_data_wrong_schema
0.12s call     test/test_copyright_headers.py::test_copyright_headers
0.12s call     test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py::TestUnrealAdaptor_on_start::test_unreal_init_timeout
0.11s call     test/deadline_submitter_for_unreal/unit/test_submitter.py::TestUnrealSubmitter::test_cancel_submit_jobs
0.11s call     test/deadline_submitter_for_unreal/unit/test_submitter.py::TestUnrealSubmitter::test_submit_jobs
======================================================================================================= 314 passed, 2 skipped in 9.73s =======================================================================================================
```

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

No need for documentation

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*