### PR TITLE
chore: Remove unrealengine-openjd version specification so it will always use the latest by default

### DIFF
--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
@@ -29,7 +29,7 @@ parameterDefinitions:
   default: 'UnrealEditor-Cmd'
 - name: CondaPackages
   type: STRING
-  default: unrealengine=5.6 unrealengine-openjd=0.6.*
+  default: unrealengine=5.6 unrealengine-openjd
   userInterface: 
    control: LINE_EDIT
 - name: CondaChannels

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
@@ -27,7 +27,7 @@ parameterDefinitions:
    control: HIDDEN
 - name: CondaPackages
   type: STRING
-  default: unrealengine=5.6 unrealengine-openjd=0.5.*
+  default: unrealengine=5.6 unrealengine-openjd
   userInterface: 
    control: LINE_EDIT
 - name: CondaChannels


### PR DESCRIPTION

chore: Remove unrealengine-openjd version specification so it will always use the latest by default

### What was the problem/requirement? (What/Why)
Remove version numbers for unrealengine-openjd from YAML files to avoid manual updates with each new release

### What was the solution? (How)
Remove version numbers for unrealengine-openjd from YAML files

### What is the impact of this change?
We no longer need to update the version numbers for unrealengine-openjd in YAML files

### How was this change tested?
Manually tested and confirmed it works.

- Have you run the unit tests?
```
Required test coverage of 65.0% reached. Total coverage: 66.88%
============================================================================================================ slowest 5 durations =============================================================================================================
0.50s call     test/test_copyright_headers.py::test_copyright_headers
0.38s call     test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py::TestUnrealAdaptor_on_start::test_init_data_wrong_schema
0.12s call     test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py::TestUnrealAdaptor_on_start::test_unreal_init_timeout
0.11s call     test/deadline_submitter_for_unreal/unit/test_submitter.py::TestUnrealSubmitter::test_submit_jobs
0.10s call     test/deadline_submitter_for_unreal/unit/test_submitter.py::TestUnrealSubmitter::test_cancel_submit_jobs
======================================================================================================= 314 passed, 2 skipped in 9.61s =======================================================================================================
```

### Have you run a render job successfully with these changes?
Yes

### Was this change documented?
No need for documentation

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*