### PR TITLE
docs: Added links for monitoring renders and downloading results. Also reorganized user guides

### DIFF
--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -6,18 +6,19 @@ This guide provides step-by-step instructions for using AWS Deadline Cloud with 
 
 ## Getting Started
 
-Follow these guides in order to set up and use AWS Deadline Cloud with Unreal Engine:
+Follow these guides to set up and use AWS Deadline Cloud with Unreal Engine:
 
-### 1. Submitter Plugin
-- **[Setup submitter and submit a job](./setup-submitter.md)** - Install the Unreal Engine submitter plugin and submit your first job
+1. **[Set up submitter plugin](./setup-submitter.md)** - Install the Unreal Engine submitter plugin.
+2. **[Submit a render](./setup-submitter.md/#submit-a-test-render)** - Submit your render to Deadline Cloud.
+3. **[Monitor your renders](https://aws-deadline.github.io/cinema-4d/user-guide/getting-started/#step-3-monitor-your-renders)** - Track your renders in real-time with the Deadline Cloud monitor.
+4. **[Download results](https://aws-deadline.github.io/cinema-4d/user-guide/getting-started/#step-4-download-your-results)** - Completed frames are available for download.
 
-### 2. Customer Managed Fleet (CMF) 
-- **[Setup CMF worker](./setup-cmf-worker.md)** - Configure an EC2 instance as a Customer Managed Fleet (CMF) worker
-
-### 3. Advanced Workflows
-- **Perforce Integration**
-    - **[Perforce Credentials Management](./perforce-credentials-management.md)** - Secure credential management for Perforce integration
-    - **[Submit jobs with Perforce](./create-perforce-render-job.md)** - Create and submit Perforce-integrated render jobs
+## Advanced Workflows
+- Perforce Integration
+    - **[Perforce Credentials Management](./perforce-credentials-management.md)** - Secure credential management for Perforce integration.
+    - **[Submit jobs with Perforce](./create-perforce-render-job.md)** - Create and submit Perforce-integrated render jobs.
+- Customer Managed Fleet (CMF)
+    - **[Set up CMF worker](./setup-cmf-worker.md)** - Configure an EC2 instance as a CMF worker.
 
 ## Support
 

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -10,8 +10,8 @@ Follow these guides to set up and use AWS Deadline Cloud with Unreal Engine:
 
 1. **[Set up submitter plugin](./setup-submitter.md)** - Install the Unreal Engine submitter plugin.
 2. **[Submit a render](./setup-submitter.md/#submit-a-test-render)** - Submit your render to Deadline Cloud.
-3. **[Monitor your renders](https://aws-deadline.github.io/cinema-4d/user-guide/getting-started/#step-3-monitor-your-renders)** - Track your renders in real-time with the Deadline Cloud monitor.
-4. **[Download results](https://aws-deadline.github.io/cinema-4d/user-guide/getting-started/#step-4-download-your-results)** - Completed frames are available for download.
+3. **[Monitor your renders](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/working-with-deadline-monitor.html)** - Track your renders in real-time with the Deadline Cloud monitor.
+4. **[Download results](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/download-finished-output.html)** - Completed frames are available for download.
 
 ## Advanced Workflows
 - Perforce Integration

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,9 +28,9 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Submitter Installation: setup-submitter.md
-  - Setup CMF Worker: setup-cmf-worker.md
   - Perforce - Credentials Management: perforce-credentials-management.md
   - Perforce - Submit Jobs: create-perforce-render-job.md
+  - Set up CMF Worker: setup-cmf-worker.md
 
 plugins:
   - search


### PR DESCRIPTION
docs: Added links for monitoring renders and downloading results. Also reorganized user guides

### What was the problem/requirement? (What/Why)
Added user guide links for monitoring renders and downloading results. Also reorganized user guides based on feedbacks received.

### What was the solution? (How)
Added user guide links for monitoring renders and downloading results. Also reorganized user guides based on feedbacks received.

### What is the impact of this change?
Clearer user guide

### How was this change tested?
Rendered locally. Here is a screenshot:

<img width="771" height="571" alt="Screenshot 2025-10-22 at 11 22 51 AM" src="https://github.com/user-attachments/assets/9eca7d88-d849-4e4e-979d-f47185b59a47" />


### Have you run a render job successfully with these changes?

No, this is just a doc change. 

### Was this change documented?

This is a doc change

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*