### PR TITLE
fix(workaround): DO NOT MERGE. This is a workaround for OCIO config

### DIFF
--- a/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
@@ -40,4 +40,9 @@ parameterDefinitions:
   default: 1
   userInterface: 
    control: HIDDEN
-
+- name: OCIO_DIR
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: IN
+  userInterface: 
+   control: CHOOSE_DIRECTORY


### PR DESCRIPTION
Fix(workaround): DO NOT MERGE. This is a workaround for OCIO config issue

⚠️ DO NOT MERGE THIS PR ⚠️

This PR provides a temporary workaround for the OCIO rendering issue described in #221. Users are experiencing problems rendering projects with OCIO assets due to the submitter plugin not including assets referenced in MRQ settings. An internal ticket has been created to address the root cause.

Rendering Comparison:
Before (left): rendering result without this workaround
After (right): rendering result with this workaround

<img width="3063" height="951" alt="Screenshot 2025-10-22 at 3 11 30 PM" src="https://github.com/user-attachments/assets/42c6bb87-1840-4137-b1d6-c1d1640d0dc4" />


### Workaround Implementation Steps
**Step 1: Install the Updated Submitter Plugin**
1. Pull this PR to your local environment
2. **Important:** Close Unreal Engine completely before proceeding
3. Run the installation command:
```
python scripts/build_plugin.py --install
```

**Step 2: Organize OCIO Assets**
1. Launch Unreal Engine and open your project
2. In the "Content Browser", create a new folder. I named it "OCIO" in my test
3. In the file explorer, copy your OCIO assets into this folder. Example: Add the "aces_1.2" folder downloaded and extracted from https://github.com/colour-science/OpenColorIO-Configs/releases/tag/v1.2 to "Content/OCIO/" folder
4. Return to Unreal Engine and create an OpenColorIO Configuration data asset inside the OCIO folder

<img width="614" height="280" alt="Screenshot 2025-10-22 at 4 23 13 PM" src="https://github.com/user-attachments/assets/2f37489a-b96c-48e2-af18-6cf6ee3149bd" />

<img width="1129" height="231" alt="Screenshot 2025-10-22 at 4 25 27 PM" src="https://github.com/user-attachments/assets/34a582ee-64ef-4ca4-bb17-5b247cd5f13c" />


5. Configure the OCIO data asset:
  - Select your config.ocio file (e.g., from the "Content/OCIO/aces_1.2" folder above)
  - Choose your desired color spaces and display-views
  - Save the configuration

**Step 3: Submit Render Jobs with OCIO Support**
1. In Movie Render Queue, add OCIO settings:
  - Click "+ Setting" → Select "Color Output"
  
<img width="730" height="712" alt="Screenshot 2025-10-22 at 4 29 42 PM" src="https://github.com/user-attachments/assets/2c5bde6d-19ec-4178-971d-255b78f9aeae" />

  - Choose the OpenColorIO configuration created in Step 2
  - Select transform source and destination
  - Click Accept
  
<img width="920" height="646" alt="Screenshot 2025-10-22 at 4 30 50 PM" src="https://github.com/user-attachments/assets/7c8db821-0c52-40de-94ea-5911fb5082be" />

2. (Optional) Save these settings as a preset for future use

3. In the "Job Template Overrides" section on the right:
  - Check the "OCIO_DIR" option
  - Use the absolute path of the "Content/OCIO" folder created above
  - Submit your render job as normal
  
<img width="626" height="417" alt="Screenshot 2025-10-22 at 4 48 28 PM" src="https://github.com/user-attachments/assets/dd82cb5d-8ce3-4a24-9c21-9797ac172b6a" />


### Technical Notes
Tested Environment: Unreal Engine 5.6.1
Purpose: This workaround ensures OCIO-related assets are properly included during job submission
Timeline: This is a temporary solution while we develop a permanent fix

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*