### PR TITLE
ci: add changelog section for performance improvements

### DIFF
--- a/.semantic_release/CHANGELOG.md.j2
+++ b/.semantic_release/CHANGELOG.md.j2
@@ -22,4 +22,11 @@
         {% endfor %}
     {% endif %}
 
+    {% if "performance improvements" in release["elements"] %}
+### Performance Improvements
+        {% for commit in release["elements"]["performance improvements"] %}
+* {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(":")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+        {% endfor %}
+    {% endif %}
+
 {% endfor %}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,7 @@ We ask that you use these commit types in your commit titles:
 * `refactor` - When the pull request is implementing only a refactor of existing code;
 * `ci` - When the pull request is implementing a change to the CI infrastructure of the packge;
 * `chore` - When the pull request is a generic maintenance task.
+* `perf` - When the pull request is a performance improvement.
 
 We also require that the type in your conventional commit title end in an exclaimation point (e.g. `feat!` or `fix!`)
 if the pull request should be considered to be a breaking change in some way. Please also include a "BREAKING CHANGE" footer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ patch_tags = [
   "feat",
   "fix",
   "refactor",
+  "perf",
 ]
 
 [tool.semantic_release.publish]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There is no development/release workflow for communicating performance improvements.

### What was the solution? (How)

[Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standardizes the `perf: ...` commit type for this purpose.

This followed a previous work in aws-deadline/deadline-cloud#870:

1.  adds a section to the changelog template for performance improvements
2. adds `perf` commits to the `patch_tags` setting of `python-semantic-release` so that they are considered as part of bumping a version for release
3. adds developer-facing documentation for using the `perf:` commit type for performance improvements

### What is the impact of this change?

Developers can use `perf: ...` [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to communicate performance improvements when changelogs are automatically generated as part of the release

### How was this change tested?

1.  Set my local `mainline` branch to this commit
2. Added example commits using the `perf: ...` commit summary message
3. Ran:
    ```
    hatch run release:deps
    hatch run release:bump
    ```
4.  confirmed that rendered `CHANGELOG.md` contained the expected "Performance Improvements" section correctly

>   ## 1.0.0 (2025-10-23)
>   
>   
>   ### Features
>   * Persistent Data Asset (#195) ([`5e6d1cc`](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/commit/5e6d1cc00287a9c6761b0f70859b208f89f2e70a))
>   * Persistent data asset ([`5e6d1cc`](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/commit/5e6d1cc00287a9c6761b0f70859b208f89f2e70a))
>   
>   ### Bug Fixes
>   * Switching job submission to run through a subprocess which is handled by a wrapper script which feeds status updates back to Unreal through stdout/prints for improved performance (#222) ([`6a6af2e`](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/commit/6a6af2ee69f587ccdb947e68eabea87f2b0b5e3e))
>   
>   ### Performance Improvements
>   * a performance improvement ([`579ecc1`](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/commit/579ecc1c492ecc47272c1f560d09e269cc55ab86))

### Have you run a render job successfully with these changes?

N/A

### Was this change documented?

Yes. I added documentation for the `perf:` commit type to `CONTRIBUTING.md`.

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*