### PR TITLE
docs: Add reference to existing doc

### DIFF
--- a/docs/user_guide/create-perforce-render-job.md
+++ b/docs/user_guide/create-perforce-render-job.md
@@ -180,6 +180,7 @@ Set up an OpenJD Render Job that orchestrates the entire rendering workflow.
 ### Performance Optimization
 
 **Chunk Size Configuration:**
+
 | Chunk Size | Use Case | Performance Impact |
 |------------|----------|-------------------|
 | 1-2 shots | Complex shots, detailed review needed | Lower throughput, higher quality control |

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -20,6 +20,8 @@ Follow these guides to set up and use AWS Deadline Cloud with Unreal Engine:
 - Customer Managed Fleet (CMF)
     - **[Set up CMF worker](./setup-cmf-worker.md)** - Configure an EC2 instance as a CMF worker.
 
+**Note:** We're currently migrating our documentation to this site. In the meantime, you can find additional user guides in the [deadline-cloud-for-unreal-engine GitHub repository](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine). To view these guides locally, follow the [Building the docs](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/blob/mainline/DEVELOPMENT.md#building-the-docs) instructions in our development guide.
+
 ## Support
 
 For additional help and resources:

--- a/docs/user_guide/setup-submitter.md
+++ b/docs/user_guide/setup-submitter.md
@@ -172,7 +172,7 @@ This example will use the Meerkat Demo from the Unreal Marketplace:
 	1. In "Deadline Cloud Workstation Configuration" section,
 		1. Under "Global Settings", ensure your AWS Profile is set correctly to your DCM Profile
 		1. Under "Profile", ensure your Default Farm is set to your farm
-		1. Under "Farm" ensure your Default Queue is set to your CMF you set up
+		1. Under "Farm", ensure your Default Queue is set to a queue that is associated with the fleet you set up above.
 1. Exit the Project Settings window
 1. Click on "Windows"/"Cinematics", select "Movie Render Queue"
 	1. Click "+Render", and select "Main_SEQ"


### PR DESCRIPTION
docs: Add reference to existing doc

### What was the problem/requirement? (What/Why)
The [new user guide site](https://aws-deadline.github.io/unreal-engine/user-guide/) currently focuses on essential documentation only. User feedback indicated we should reference our existing documentation, which is more comprehensive. While we plan to eventually migrate all documentation to the new user guide website, providing a reference to existing docs would help users access additional resources during the transition period.

### What was the solution? (How)
Added a paragraph about our existing documentation to bridge the gap between the streamlined user guide and comprehensive documentation.

### What is the impact of this change?
Users can now easily discover and access additional documentation when they need more detailed information beyond the basic workflow provided in the user guide.

### How was this change tested?
Checked in localhost

---
<img width="692" height="621" alt="Screenshot 2025-10-23 at 1 54 33 PM" src="https://github.com/user-attachments/assets/fe5e9010-199c-46ec-b825-4849c199dd9a" />

---

- Have you run the unit tests?
No, this is doc change

### Have you run a render job successfully with these changes?
No, this is a doc change

### Was this change documented?
Yes, this is doc change

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*