### PR TITLE
chore: fix formatting in user guide

### DIFF
--- a/docs/user_guide/create-perforce-render-job.md
+++ b/docs/user_guide/create-perforce-render-job.md
@@ -180,6 +180,7 @@ Set up an OpenJD Render Job that orchestrates the entire rendering workflow.
 ### Performance Optimization
 
 **Chunk Size Configuration:**
+
 | Chunk Size | Use Case | Performance Impact |
 |------------|----------|-------------------|
 | 1-2 shots | Complex shots, detailed review needed | Lower throughput, higher quality control |


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The markdown renderer in the central user guide site seems to behave differently from the GitHub one and does not render a table correctly.

### What was the solution? (How)
Add a new line.

### What is the impact of this change?
Fixes some formatting on: http://localhost:8000/unreal-engine/user-guide/create-perforce-render-job/

### How was this change tested?
Built the common docs locally

### Have you run a render job successfully with these changes?
n/a

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*