### PR TITLE
feat: Adding support for FramesPerTask to set how many frames of rend…

### DIFF
--- a/docs/source/docs_usage/use_cases/create_render_job.rst
+++ b/docs/source/docs_usage/use_cases/create_render_job.rst
@@ -58,6 +58,9 @@ Render Job data asset
    .. image:: ../../images/create_render_job_6.png
 
    a. Executable - Unreal executable name to launch on render node
+   #. FramesPerTask - Divide up the total number of frames to be rendered in the sequence by this value to
+      determine the total number of Deadline Cloud tasks to create, with each task aiming to render this number
+      of frames.
    #. ExtraCmdArgs - Additional CMD arguments to launch Unreal executable with
    #. ExtraCmdArgsFile - Specific file parameter where **ExtraCmdArgs** will be stored.
       Need to avoid **1024 chars limit** on **STRING** parameter. **Filled automatically during the submission**

--- a/docs/user_guide/create-perforce-render-job.md
+++ b/docs/user_guide/create-perforce-render-job.md
@@ -140,6 +140,7 @@ Set up an OpenJD Render Job that orchestrates the entire rendering workflow.
 | `PerforceWorkspaceSpecificationTemplate` | Perforce client spec with `{workspace_name}` token | ✅ | **Leave empty** - Auto-populated |
 | `MrqJobDependenciesDescriptor` | JSON file with MRQ dependencies for sync | ✅ | **Leave empty** - Auto-populated |
 | `ExtraCmdArgsFile` | File for extra args (avoids 1024 char limit) | ❌ | **Optional** - Use default for standard setups |
+| `FramesPerTask` | Number of frames to render per task | ❌ | **Optional** - Use default (0) to divide tasks by shots |
 | `ExtraCmdArgs` | Additional Unreal launch arguments | ❌ | **Optional** - Use default for standard setups |
 | `Executable` | Unreal executable name for render node | ❌ | **Configure** - Use default for standard setups |
 | `CondaPackages` | Conda packages needed to render the job | ❌ | **Configure** - Use default for standard setups |

--- a/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
+++ b/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
@@ -115,6 +115,9 @@ if unreal:
 
 
 class UnrealRenderStepHandler(BaseStepHandler):
+    cached_frame_range_start = None
+    cached_frame_range_end = None
+
     @staticmethod
     def regex_pattern_progress() -> list[re.Pattern]:
         """
@@ -300,6 +303,32 @@ class UnrealRenderStepHandler(BaseStepHandler):
                 shot.enabled = False
         logger.info(f"Shots in task: {[shot.outer_name for shot in shots_chunk]}")
 
+    @staticmethod
+    def get_frame_range(output_settings, level_sequence):
+        if UnrealRenderStepHandler.cached_frame_range_start is None:
+            if output_settings.use_custom_playback_range:
+                UnrealRenderStepHandler.cached_frame_range_start = (
+                    output_settings.custom_start_frame
+                )
+                UnrealRenderStepHandler.cached_frame_range_end = output_settings.custom_end_frame
+                logger.info(
+                    f"Cached custom frame range from {UnrealRenderStepHandler.cached_frame_range_start} to {UnrealRenderStepHandler.cached_frame_range_end}"
+                )
+            else:
+                UnrealRenderStepHandler.cached_frame_range_start = (
+                    level_sequence.get_playback_range().get_start_frame()
+                )
+                UnrealRenderStepHandler.cached_frame_range_end = (
+                    level_sequence.get_playback_range().get_end_frame()
+                )
+                logger.info(
+                    f"Cached level sequence frame range from {UnrealRenderStepHandler.cached_frame_range_start} to {UnrealRenderStepHandler.cached_frame_range_end}"
+                )
+        return (
+            UnrealRenderStepHandler.cached_frame_range_start,
+            UnrealRenderStepHandler.cached_frame_range_end,
+        )
+
     def run_script(self, args: dict) -> bool:
         """
         Create the unreal.MoviePipelineQueue object and render it with the render executor
@@ -311,7 +340,6 @@ class UnrealRenderStepHandler(BaseStepHandler):
         logger.info(
             f"{UnrealRenderStepHandler.run_script.__name__} executing with args: {args} ..."
         )
-
         asset_registry = unreal.AssetRegistryHelpers.get_asset_registry()
         asset_registry.wait_for_completion()
 
@@ -335,10 +363,38 @@ class UnrealRenderStepHandler(BaseStepHandler):
                 job_configuration_path=args.get("job_configuration_path", ""),
             )
 
+        output_settings = None
+        if "chunk_id" in args:
+            chunk_id: int = args["chunk_id"]
         for job in subsystem.get_queue().get_jobs():
-            if "chunk_size" in args and "chunk_id" in args:
+            if args.get("frames_per_task") and "chunk_id" in args:
+                frames_per_task: int = args["frames_per_task"]
+                if not output_settings:
+                    output_settings = job.get_configuration().find_or_add_setting_by_class(
+                        unreal.MoviePipelineOutputSetting
+                    )
+                level_sequence = unreal.EditorAssetLibrary.load_asset(
+                    unreal.SystemLibrary.conv_soft_object_reference_to_string(
+                        unreal.SystemLibrary.conv_soft_obj_path_to_soft_obj_ref(job.sequence)
+                    )
+                )
+                frame_range_start, frame_range_end = self.get_frame_range(
+                    output_settings, level_sequence
+                )
+
+                output_settings.custom_start_frame = frame_range_start + (
+                    chunk_id * frames_per_task
+                )
+                output_settings.custom_end_frame = min(
+                    output_settings.custom_start_frame + frames_per_task, frame_range_end
+                )
+                level_sequence.set_playback_start(output_settings.custom_start_frame)
+                level_sequence.set_playback_end(output_settings.custom_end_frame)
+                logger.info(
+                    f"Rendering custom frame range from {output_settings.custom_start_frame} to {output_settings.custom_end_frame} with sequence playback start {level_sequence.get_playback_start()} end {level_sequence.get_playback_end()}"
+                )
+            elif "chunk_size" in args and "chunk_id" in args:
                 chunk_size: int = args["chunk_size"]
-                chunk_id: int = args["chunk_id"]
                 UnrealRenderStepHandler.enable_shots_by_chunk(
                     render_job=job,
                     task_chunk_size=chunk_size,

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
@@ -298,7 +298,8 @@ class OpenJobStepParameterNames:
     :cvar OUTPUT_PATH: Local path where Unreal Render Executor will place output files
 
     :cvar ADAPTOR_HANDLER: Handler name to run the jobs on Adaptor (render/custom)
-    :cvar TASK_CHUNK_SIZE: Count of the shots per OpenJD Step's Task
+    :cvar FRAMES_PER_TASK: If set, each task will render this number of frames
+    :cvar TASK_CHUNK_SIZE: Count of the shots per OpenJD Step's Task unless FRAMES_PER_TASK set
     :cvar TASK_CHUNK_ID: Chunk number that should be rendered at OpenJD Step's Task
     """
 
@@ -310,5 +311,6 @@ class OpenJobStepParameterNames:
     OUTPUT_PATH = "OutputPath"
 
     ADAPTOR_HANDLER = "Handler"
+    FRAMES_PER_TASK = "FramesPerTask"
     TASK_CHUNK_SIZE = "ChunkSize"
     TASK_CHUNK_ID = "ChunkId"

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
@@ -448,6 +448,7 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
     def _get_chunk_ids_count(self) -> int:
         """
         Get number of shot chunks
+        as count of total number of frames divided by FramesPerTask if set, or
         as count of enabled shots in level sequence divided by chuck size parameter value.
         If no chunk size parameter value is 0, return 1
 
@@ -473,10 +474,36 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
         chunk_size_parameter = self.open_job._find_extra_parameter(
             parameter_name=OpenJobStepParameterNames.TASK_CHUNK_SIZE, parameter_type="INT"
         )
+        frames_per_task_parameter = self.open_job._find_extra_parameter(
+            parameter_name=OpenJobStepParameterNames.FRAMES_PER_TASK, parameter_type="INT"
+        )
+        if frames_per_task_parameter and frames_per_task_parameter.value > 0:
+            logger.info(f"Rendering shots of frame range {frames_per_task_parameter.value}")
+            level_sequence = self._load_level_sequence(self.mrq_job)
+            output_settings = self._load_output_settings(self.mrq_job)
 
+            if output_settings.use_custom_playback_range:
+                total_frame_range = (
+                    output_settings.custom_end_frame - output_settings.custom_start_frame
+                )
+                logger.info(
+                    f"Output settings at submission has range {output_settings.custom_start_frame} - {output_settings.custom_end_frame} ({total_frame_range} frames)"
+                )
+            else:
+
+                total_frame_range = (
+                    level_sequence.get_playback_range().get_end_frame()
+                    - level_sequence.get_playback_range().get_start_frame()
+                )
+                logger.info(
+                    f"Level sequence at submission has range {level_sequence.get_playback_range()} ({total_frame_range} frames)"
+                )
+            task_chunk_ids_count = math.ceil(total_frame_range / frames_per_task_parameter.value)
+            return task_chunk_ids_count
         if chunk_size_parameter is None:
             raise ValueError(
-                f'Render Job\'s parameter "{OpenJobStepParameterNames.TASK_CHUNK_SIZE}" '
+                f'Render Job\'s parameter "{OpenJobStepParameterNames.TASK_CHUNK_SIZE}"'
+                f' or "{OpenJobStepParameterNames.FRAMES_PER_TASK}" '
                 f"must be provided in extra parameters or template"
             )
 
@@ -487,6 +514,18 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
         task_chunk_ids_count = math.ceil(len(enabled_shots) / chunk_size)
 
         return task_chunk_ids_count
+
+    def _load_level_sequence(self, mrq_job):
+        """Load the level sequence asset from the MRQ job."""
+        return unreal.EditorAssetLibrary.load_asset(
+            unreal.SystemLibrary.conv_soft_object_reference_to_string(
+                unreal.SystemLibrary.conv_soft_obj_path_to_soft_obj_ref(mrq_job.sequence)
+            )
+        )
+
+    def _load_output_settings(self, mrq_job):
+        """Load the output settings from the MRQ job configuration."""
+        return mrq_job.get_configuration().find_setting_by_class(unreal.MoviePipelineOutputSetting)
 
     def _get_render_arguments_type(self) -> Optional["RenderUnrealOpenJobStep.RenderArgsType"]:
         """

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
@@ -27,6 +27,9 @@ parameterDefinitions:
 - name: Executable
   type: STRING
   default: 'UnrealEditor-Cmd'
+- name: FramesPerTask
+  type: INT
+  default: 0
 - name: CondaPackages
   type: STRING
   default: unrealengine=5.6 unrealengine-openjd=0.6.*

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_step.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_step.yml
@@ -21,6 +21,7 @@ script:
     data: |
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
+      frames_per_task: {{Param.FramesPerTask}}
       chunk_size: {{Param.ChunkSize}}
       chunk_id: {{Task.Param.ChunkId}}
       output_path: {{Task.Param.OutputPath}}

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
@@ -25,6 +25,9 @@ parameterDefinitions:
   default: 'UnrealEditor-Cmd'
   userInterface: 
    control: HIDDEN
+- name: FramesPerTask
+  type: INT
+  default: 0
 - name: CondaPackages
   type: STRING
   default: unrealengine=5.6 unrealengine-openjd=0.6.*

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_step.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_step.yml
@@ -18,6 +18,7 @@ script:
     data: |
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
+      frames_per_task: {{Param.FramesPerTask}}
       chunk_size: {{Param.ChunkSize}}
       chunk_id: {{Task.Param.ChunkId}}
   actions:

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_step_mpq.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_step_mpq.yml
@@ -10,6 +10,9 @@ parameterSpace:
   - name: MoviePipelineQueuePath
     type: PATH
     range: []
+  - name: FramesPerTask
+    type: INT
+    range: [0]
   - name: ChunkSize
     type: INT
     range: [1]

--- a/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_job.yml
@@ -23,6 +23,10 @@ parameterDefinitions:
 - name: Executable
   type: STRING
   default: 'UnrealEditor-Cmd'
+- name: FramesPerTask
+  type: INT
+  default: 0
 - name: ChunkSize
   type: INT
   default: 1
+

--- a/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_step.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_step.yml
@@ -21,6 +21,7 @@ script:
     data: |
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
+      frames_per_task: {{Param.FramesPerTask}}
       chunk_size: {{Param.ChunkSize}}
       chunk_id: {{Task.Param.ChunkId}}
       output_path: {{Task.Param.OutputPath}}

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step.yml
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step.yml
@@ -7,6 +7,9 @@ parameterSpace:
   - name: QueueManifestPath
     type: PATH
     range: []
+  - name: FramesPerTask
+    type: INT
+    range: []
   - name: ChunkSize
     type: INT
     range: []
@@ -21,6 +24,7 @@ script:
     data: |
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
+      frames_per_task: {{Task.Param.FramesPerTask}}
       chunk_size: {{Task.Param.ChunkSize}}
       chunk_id: {{Task.Param.ChunkId}}
   actions:

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step_UI.yml
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step_UI.yml
@@ -34,6 +34,7 @@ script:
     data: |
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
+      frames_per_task: {{Task.Param.FramesPerTask}}
       chunk_size: {{Task.Param.ChunkSize}}
       chunk_id: {{Task.Param.ChunkId}}
   actions:

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step_UI_empty.yml
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step_UI_empty.yml
@@ -14,6 +14,7 @@ script:
     data: |
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
+      frames_per_task: {{Task.Param.FramesPerTask}}
       chunk_size: {{Task.Param.ChunkSize}}
       chunk_id: {{Task.Param.ChunkId}}
   actions:

--- a/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_frames_per_task.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_frames_per_task.py
@@ -1,0 +1,273 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import sys
+import pytest
+from unittest.mock import MagicMock, patch
+
+unreal_mock = MagicMock()
+unreal_mock.log = MagicMock()
+sys.modules["unreal"] = unreal_mock
+
+
+@pytest.fixture()
+def unreal_render_step_handler():
+    from deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler import (
+        UnrealRenderStepHandler,
+    )
+
+    # Clear cached values before each test
+    UnrealRenderStepHandler.cached_frame_range_start = None
+    UnrealRenderStepHandler.cached_frame_range_end = None
+    return UnrealRenderStepHandler()
+
+
+class TestUnrealRenderStepHandlerFramesPerTask:
+
+    @pytest.mark.parametrize(
+        "use_custom_range, custom_start, custom_end, sequence_start, sequence_end, expected_start, expected_end",
+        [
+            (True, 10, 50, 1, 100, 10, 50),  # Custom range used
+            (False, 10, 50, 1, 100, 1, 100),  # Sequence range used
+            (True, 0, 30, 5, 25, 0, 30),  # Custom range overrides sequence
+        ],
+    )
+    def test_get_frame_range_caching(
+        self,
+        unreal_render_step_handler,
+        use_custom_range,
+        custom_start,
+        custom_end,
+        sequence_start,
+        sequence_end,
+        expected_start,
+        expected_end,
+    ):
+        # GIVEN
+        output_settings = MagicMock()
+        output_settings.use_custom_playback_range = use_custom_range
+        output_settings.custom_start_frame = custom_start
+        output_settings.custom_end_frame = custom_end
+
+        playback_range = MagicMock()
+        playback_range.get_start_frame.return_value = sequence_start
+        playback_range.get_end_frame.return_value = sequence_end
+
+        level_sequence = MagicMock()
+        level_sequence.get_playback_range.return_value = playback_range
+
+        # WHEN - First call should cache values
+        with patch(
+            "deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler.logger.info"
+        ) as log_mock:
+            start1, end1 = unreal_render_step_handler.get_frame_range(
+                output_settings, level_sequence
+            )
+
+            # THEN
+            assert start1 == expected_start
+            assert end1 == expected_end
+            assert log_mock.called
+
+            # WHEN - Second call should use cached values
+            log_mock.reset_mock()
+
+            start2, end2 = unreal_render_step_handler.get_frame_range(
+                output_settings, level_sequence
+            )
+
+            # THEN - Should return same values without logging
+            assert start2 == expected_start
+            assert end2 == expected_end
+            assert not log_mock.called
+
+    def test_get_frame_range_custom_playback_logging(self, unreal_render_step_handler):
+        # GIVEN
+        output_settings = MagicMock()
+        output_settings.use_custom_playback_range = True
+        output_settings.custom_start_frame = 5
+        output_settings.custom_end_frame = 25
+
+        level_sequence = MagicMock()
+
+        # WHEN
+        with patch(
+            "deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler.logger.info"
+        ) as log_mock:
+            unreal_render_step_handler.get_frame_range(output_settings, level_sequence)
+
+            # THEN
+            log_mock.assert_called_with("Cached custom frame range from 5 to 25")
+
+    def test_get_frame_range_sequence_playback_logging(self, unreal_render_step_handler):
+        # GIVEN
+        output_settings = MagicMock()
+        output_settings.use_custom_playback_range = False
+
+        playback_range = MagicMock()
+        playback_range.get_start_frame.return_value = 1
+        playback_range.get_end_frame.return_value = 100
+
+        level_sequence = MagicMock()
+        level_sequence.get_playback_range.return_value = playback_range
+
+        # WHEN
+        with patch(
+            "deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler.logger.info"
+        ) as log_mock:
+            unreal_render_step_handler.get_frame_range(output_settings, level_sequence)
+
+            # THEN
+            log_mock.assert_called_with("Cached level sequence frame range from 1 to 100")
+
+    @pytest.mark.parametrize(
+        "chunk_id, frames_per_task, frame_start, frame_end, expected_start, expected_end",
+        [
+            (0, 10, 1, 100, 1, 11),  # First chunk
+            (1, 10, 1, 100, 11, 21),  # Second chunk
+            (9, 10, 1, 100, 91, 100),  # Last chunk (clamped to end)
+            (0, 50, 10, 30, 10, 30),  # Single chunk covers entire range
+            (2, 5, 0, 20, 10, 15),  # Middle chunk
+        ],
+    )
+    def test_frames_per_task_calculation_logic(
+        self,
+        unreal_render_step_handler,
+        chunk_id,
+        frames_per_task,
+        frame_start,
+        frame_end,
+        expected_start,
+        expected_end,
+    ):
+        """Test the frame calculation logic without full run_script execution"""
+        # GIVEN
+        output_settings = MagicMock()
+        level_sequence = MagicMock()
+
+        # Mock frame range method
+        with patch.object(
+            unreal_render_step_handler, "get_frame_range", return_value=(frame_start, frame_end)
+        ):
+            # WHEN - Simulate the frame calculation logic from run_script
+            frame_range_start, frame_range_end = unreal_render_step_handler.get_frame_range(
+                output_settings, level_sequence
+            )
+
+            calculated_start = frame_range_start + (chunk_id * frames_per_task)
+            calculated_end = min(calculated_start + frames_per_task, frame_range_end)
+
+            # THEN
+            assert calculated_start == expected_start
+            assert calculated_end == expected_end
+
+    def test_frames_per_task_vs_chunk_size_precedence(self, unreal_render_step_handler):
+        """Test that frames_per_task takes precedence over chunk_size in argument processing"""
+        # GIVEN
+        args_with_frames_per_task = {
+            "frames_per_task": 10,
+            "chunk_id": 1,
+            "chunk_size": 5,  # This should be ignored
+        }
+
+        args_with_chunk_size_only = {
+            "chunk_size": 5,
+            "chunk_id": 1,
+        }
+
+        args_no_chunking: dict[str, int] = {}
+
+        # WHEN/THEN - Test precedence logic
+        # frames_per_task should be used when present
+        assert (
+            args_with_frames_per_task.get("frames_per_task")
+            and "chunk_id" in args_with_frames_per_task
+        )
+
+        # chunk_size should be used when frames_per_task is not present
+        assert (
+            not args_with_chunk_size_only.get("frames_per_task")
+            and "chunk_size" in args_with_chunk_size_only
+        )
+
+        # No chunking when neither is present
+        assert not args_no_chunking.get("frames_per_task") and "chunk_size" not in args_no_chunking
+
+    def test_frame_range_caching_behavior(self, unreal_render_step_handler):
+        """Test that frame range caching works correctly across multiple calls"""
+        # GIVEN
+        output_settings = MagicMock()
+        output_settings.use_custom_playback_range = True
+        output_settings.custom_start_frame = 10
+        output_settings.custom_end_frame = 50
+
+        level_sequence = MagicMock()
+
+        # WHEN - Multiple calls to get_frame_range
+        start1, end1 = unreal_render_step_handler.get_frame_range(output_settings, level_sequence)
+        start2, end2 = unreal_render_step_handler.get_frame_range(output_settings, level_sequence)
+        start3, end3 = unreal_render_step_handler.get_frame_range(output_settings, level_sequence)
+
+        # THEN - All calls should return the same cached values
+        assert start1 == start2 == start3 == 10
+        assert end1 == end2 == end3 == 50
+
+        # Verify the cached values are stored in class variables
+        assert unreal_render_step_handler.cached_frame_range_start == 10
+        assert unreal_render_step_handler.cached_frame_range_end == 50
+
+    def test_frame_range_edge_cases(self, unreal_render_step_handler):
+        """Test edge cases for frame range calculations"""
+        # Test case 1: chunk_id * frames_per_task exceeds total range
+        output_settings = MagicMock()
+        level_sequence = MagicMock()
+
+        with patch.object(unreal_render_step_handler, "get_frame_range", return_value=(1, 50)):
+            frame_range_start, frame_range_end = unreal_render_step_handler.get_frame_range(
+                output_settings, level_sequence
+            )
+
+            # chunk_id=10, frames_per_task=10 would start at frame 101, but range only goes to 50
+            chunk_id = 10
+            frames_per_task = 10
+
+            calculated_start = frame_range_start + (chunk_id * frames_per_task)  # 1 + 100 = 101
+            calculated_end = min(
+                calculated_start + frames_per_task, frame_range_end
+            )  # min(111, 50) = 50
+
+            assert calculated_start == 101
+            assert calculated_end == 50  # Clamped to range end
+
+    def test_static_method_behavior(self, unreal_render_step_handler):
+        """Test that get_frame_range is a static method and caching works across instances"""
+        # GIVEN
+        from deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler import (
+            UnrealRenderStepHandler,
+        )
+
+        # Clear any existing cache
+        UnrealRenderStepHandler.cached_frame_range_start = None
+        UnrealRenderStepHandler.cached_frame_range_end = None
+
+        handler1 = UnrealRenderStepHandler()
+        handler2 = UnrealRenderStepHandler()
+
+        output_settings = MagicMock()
+        output_settings.use_custom_playback_range = True
+        output_settings.custom_start_frame = 20
+        output_settings.custom_end_frame = 80
+
+        level_sequence = MagicMock()
+
+        # WHEN - Call from first instance
+        start1, end1 = handler1.get_frame_range(output_settings, level_sequence)
+
+        # THEN - Second instance should use the same cached values
+        start2, end2 = handler2.get_frame_range(output_settings, level_sequence)
+
+        assert start1 == start2 == 20
+        assert end1 == end2 == 80
+
+        # Both instances should see the same cached values
+        assert handler1.cached_frame_range_start == handler2.cached_frame_range_start == 20
+        assert handler1.cached_frame_range_end == handler2.cached_frame_range_end == 80

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_entity_frames_per_task.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_entity_frames_per_task.py
@@ -1,0 +1,53 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity import (
+    OpenJobStepParameterNames,
+)
+
+
+class TestOpenJobStepParameterNamesFramesPerTask:
+    """Test that the new FRAMES_PER_TASK parameter is properly defined."""
+
+    def test_frames_per_task_parameter_exists(self):
+        # GIVEN/WHEN/THEN
+        assert hasattr(OpenJobStepParameterNames, "FRAMES_PER_TASK")
+        assert OpenJobStepParameterNames.FRAMES_PER_TASK == "FramesPerTask"
+
+    def test_all_parameter_names_are_strings(self):
+        # GIVEN
+        parameter_names = [
+            OpenJobStepParameterNames.QUEUE_MANIFEST_PATH,
+            OpenJobStepParameterNames.MOVIE_PIPELINE_QUEUE_PATH,
+            OpenJobStepParameterNames.LEVEL_SEQUENCE_PATH,
+            OpenJobStepParameterNames.LEVEL_PATH,
+            OpenJobStepParameterNames.MRQ_JOB_CONFIGURATION_PATH,
+            OpenJobStepParameterNames.OUTPUT_PATH,
+            OpenJobStepParameterNames.ADAPTOR_HANDLER,
+            OpenJobStepParameterNames.FRAMES_PER_TASK,
+            OpenJobStepParameterNames.TASK_CHUNK_SIZE,
+            OpenJobStepParameterNames.TASK_CHUNK_ID,
+        ]
+
+        # WHEN/THEN
+        for param_name in parameter_names:
+            assert isinstance(param_name, str)
+            assert len(param_name) > 0
+
+    def test_frames_per_task_unique_value(self):
+        # GIVEN
+        all_parameter_values = [
+            OpenJobStepParameterNames.QUEUE_MANIFEST_PATH,
+            OpenJobStepParameterNames.MOVIE_PIPELINE_QUEUE_PATH,
+            OpenJobStepParameterNames.LEVEL_SEQUENCE_PATH,
+            OpenJobStepParameterNames.LEVEL_PATH,
+            OpenJobStepParameterNames.MRQ_JOB_CONFIGURATION_PATH,
+            OpenJobStepParameterNames.OUTPUT_PATH,
+            OpenJobStepParameterNames.ADAPTOR_HANDLER,
+            OpenJobStepParameterNames.FRAMES_PER_TASK,
+            OpenJobStepParameterNames.TASK_CHUNK_SIZE,
+            OpenJobStepParameterNames.TASK_CHUNK_ID,
+        ]
+
+        # WHEN/THEN - All parameter values should be unique
+        assert len(all_parameter_values) == len(set(all_parameter_values))
+        assert OpenJobStepParameterNames.FRAMES_PER_TASK in all_parameter_values

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step.py
@@ -306,7 +306,8 @@ class TestRenderUnrealOpenJobStep:
 
         # THEN
         assert (
-            f'Render Job\'s parameter "{OpenJobStepParameterNames.TASK_CHUNK_SIZE}" '
+            f'Render Job\'s parameter "{OpenJobStepParameterNames.TASK_CHUNK_SIZE}" or '
+            f'"{OpenJobStepParameterNames.FRAMES_PER_TASK}" '
             f"must be provided" in str(exception_info.value)
         )
 

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step_frames_per_task.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step_frames_per_task.py
@@ -1,0 +1,183 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import sys
+import pytest
+from unittest.mock import MagicMock, patch
+
+unreal_mock = MagicMock()
+sys.modules["unreal"] = unreal_mock
+
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job import (  # noqa: E402
+    UnrealOpenJob,
+    UnrealOpenJobParameterDefinition,
+)
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job_step import (  # noqa: E402
+    RenderUnrealOpenJobStep,
+)
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity import (  # noqa: E402
+    OpenJobStepParameterNames,
+)
+
+
+class TestRenderUnrealOpenJobStepFramesPerTask:
+
+    @pytest.mark.parametrize(
+        "frames_per_task, total_frames, expected_task_count",
+        [
+            (10, 100, 10),  # Even division
+            (10, 95, 10),  # Rounds up
+            (10, 105, 11),  # Rounds up
+            (25, 100, 4),  # Even division
+            (30, 100, 4),  # Rounds up
+            (1, 50, 50),  # One frame per task
+            (100, 50, 1),  # More frames per task than total
+        ],
+    )
+    def test_get_chunk_ids_count_frames_per_task_custom_range(
+        self, frames_per_task, total_frames, expected_task_count
+    ):
+        # GIVEN
+        frames_per_task_param = UnrealOpenJobParameterDefinition(
+            OpenJobStepParameterNames.FRAMES_PER_TASK, "INT", frames_per_task
+        )
+        job = UnrealOpenJob(file_path="", name="TestJob", extra_parameters=[frames_per_task_param])
+
+        mrq_job_mock = MagicMock()
+        render_step = RenderUnrealOpenJobStep(file_path="", mrq_job=mrq_job_mock)
+        render_step.open_job = job
+
+        # Mock output settings with custom range
+        output_settings_mock = MagicMock()
+        output_settings_mock.use_custom_playback_range = True
+        output_settings_mock.custom_start_frame = 10
+        output_settings_mock.custom_end_frame = 10 + total_frames
+
+        with patch.object(render_step, "_load_output_settings", return_value=output_settings_mock):
+            # WHEN
+            task_count = render_step._get_chunk_ids_count()
+
+            # THEN
+            assert task_count == expected_task_count
+
+    @pytest.mark.parametrize(
+        "frames_per_task, sequence_start, sequence_end, expected_task_count",
+        [
+            (10, 1, 100, 10),  # 99 frames (100-1), 10 per task = ceil(9.9) = 10
+            (15, 5, 50, 3),  # 45 frames (50-5), 15 per task = ceil(3.0) = 3
+            (20, 0, 39, 2),  # 39 frames (39-0), 20 per task = ceil(1.95) = 2
+            (50, 10, 30, 1),  # 20 frames (30-10), 50 per task = ceil(0.4) = 1
+        ],
+    )
+    def test_get_chunk_ids_count_frames_per_task_sequence_range(
+        self, frames_per_task, sequence_start, sequence_end, expected_task_count
+    ):
+        # GIVEN
+        frames_per_task_param = UnrealOpenJobParameterDefinition(
+            OpenJobStepParameterNames.FRAMES_PER_TASK, "INT", frames_per_task
+        )
+        job = UnrealOpenJob(file_path="", name="TestJob", extra_parameters=[frames_per_task_param])
+
+        mrq_job_mock = MagicMock()
+        render_step = RenderUnrealOpenJobStep(file_path="", mrq_job=mrq_job_mock)
+        render_step.open_job = job
+
+        # Mock level sequence and output settings
+        level_sequence_mock = MagicMock()
+        playback_range_mock = MagicMock()
+        playback_range_mock.get_start_frame.return_value = sequence_start
+        playback_range_mock.get_end_frame.return_value = sequence_end
+        level_sequence_mock.get_playback_range.return_value = playback_range_mock
+
+        output_settings_mock = MagicMock()
+        output_settings_mock.use_custom_playback_range = False
+
+        with (
+            patch.object(render_step, "_load_level_sequence", return_value=level_sequence_mock),
+            patch.object(render_step, "_load_output_settings", return_value=output_settings_mock),
+        ):
+
+            # WHEN
+            task_count = render_step._get_chunk_ids_count()
+
+            # THEN
+            assert task_count == expected_task_count
+
+    def test_get_chunk_ids_count_frames_per_task_precedence_over_chunk_size(self):
+        # GIVEN - Both FramesPerTask and ChunkSize provided, FramesPerTask should take precedence
+        frames_per_task_param = UnrealOpenJobParameterDefinition(
+            OpenJobStepParameterNames.FRAMES_PER_TASK, "INT", 25
+        )
+        chunk_size_param = UnrealOpenJobParameterDefinition(
+            OpenJobStepParameterNames.TASK_CHUNK_SIZE, "INT", 5
+        )
+        job = UnrealOpenJob(
+            file_path="", name="TestJob", extra_parameters=[frames_per_task_param, chunk_size_param]
+        )
+
+        mrq_job_mock = MagicMock()
+        render_step = RenderUnrealOpenJobStep(file_path="", mrq_job=mrq_job_mock)
+        render_step.open_job = job
+
+        # Mock output settings with custom range (99 frames)
+        output_settings_mock = MagicMock()
+        output_settings_mock.use_custom_playback_range = True
+        output_settings_mock.custom_start_frame = 1
+        output_settings_mock.custom_end_frame = 100
+
+        with patch.object(render_step, "_load_output_settings", return_value=output_settings_mock):
+            # WHEN
+            task_count = render_step._get_chunk_ids_count()
+
+            # THEN - Should use FramesPerTask: 99 frames / 25 per task = 4 tasks (math.ceil(3.96))
+            assert task_count == 4
+
+    def test_get_chunk_ids_count_frames_per_task_fallback_to_chunk_size(self):
+        # GIVEN - FramesPerTask is 0, should fall back to ChunkSize
+        frames_per_task_param = UnrealOpenJobParameterDefinition(
+            OpenJobStepParameterNames.FRAMES_PER_TASK, "INT", 0
+        )
+        chunk_size_param = UnrealOpenJobParameterDefinition(
+            OpenJobStepParameterNames.TASK_CHUNK_SIZE, "INT", 5
+        )
+        job = UnrealOpenJob(
+            file_path="", name="TestJob", extra_parameters=[frames_per_task_param, chunk_size_param]
+        )
+
+        # Mock MRQ job with shots
+        shot_info = []
+        for _ in range(10):  # 10 shots
+            shot_info_mock = MagicMock()
+            shot_info_mock.enabled = True
+            shot_info.append(shot_info_mock)
+
+        mrq_job_mock = MagicMock()
+        mrq_job_mock.shot_info = shot_info
+
+        render_step = RenderUnrealOpenJobStep(file_path="", mrq_job=mrq_job_mock)
+        render_step.open_job = job
+
+        # WHEN
+        task_count = render_step._get_chunk_ids_count()
+
+        # THEN - Should use chunk size logic: 10 shots / 5 per chunk = 2 tasks
+        assert task_count == 2
+
+    def test_get_chunk_ids_count_frames_per_task_no_fallback_error(self):
+        # GIVEN - FramesPerTask is 0 and no ChunkSize parameter
+        frames_per_task_param = UnrealOpenJobParameterDefinition(
+            OpenJobStepParameterNames.FRAMES_PER_TASK, "INT", 0
+        )
+        job = UnrealOpenJob(file_path="", name="TestJob", extra_parameters=[frames_per_task_param])
+
+        mrq_job_mock = MagicMock()
+        mrq_job_mock.shot_info = []
+
+        render_step = RenderUnrealOpenJobStep(file_path="", mrq_job=mrq_job_mock)
+        render_step.open_job = job
+
+        # WHEN/THEN - Should raise ValueError about missing parameters
+        with pytest.raises(ValueError) as exception_info:
+            render_step._get_chunk_ids_count()
+
+        assert OpenJobStepParameterNames.TASK_CHUNK_SIZE in str(exception_info.value)
+        assert OpenJobStepParameterNames.FRAMES_PER_TASK in str(exception_info.value)


### PR DESCRIPTION
Fixes: #191 

### What was the problem/requirement? (What/Why)
The integration only supported dividing up rendering sequences by shots - it didn't support an out of the box way of dividing up rendering jobs by frames.

### What was the solution? (How)
Add a FramesPerTask parameter which, if set, controls the number of frames each task should attempt to render.  By default this will divide up the total frames in the level sequence selected for the job by FramesPerTask to figure out how many tasks should be created.  This can also be overridden with the Unreal "Use Custom Playback Range" control - selecting your own Custom Start and End frame.

### What is the impact of this change?
Customers can render by ranges of frames instead of just shots.

### How was this change tested?
New unit tests added which pass.
Manual testing.
E2E tests pass.

### Have you run a render job successfully with these changes?
Yes

### Was this change documented?
Yes

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*