### PR TITLE
fix: Adding a temporary patch to fix pydantic StringConstraints in Un…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For instructions on installing and using this integration, visit the [user guide
 
 This library requires:
 
-1. Python 3.9 or higher; and Unreal Engine 5.4 or higher.
+1. Python 3.9 or higher; and Unreal Engine 5.3 or higher.
 2. Windows operating system.
 
 ## Submitter

--- a/docs/user_guide/setup-cmf-worker.md
+++ b/docs/user_guide/setup-cmf-worker.md
@@ -32,8 +32,8 @@ Select the appropriate branch for your deployment:
 
 **1. Install Unreal Engine**
 1. Download the Epic Games Launcher
-2. Install Unreal Engine 5.4 or higher
-   > **📝 Note**: Unreal Engine 5.4+ is required for Deadline Cloud compatibility
+2. Install Unreal Engine 5.3 or higher
+   > **📝 Note**: Unreal Engine 5.3+ is required for Deadline Cloud compatibility
 
 **2. Install NVIDIA GRID Drivers**
 - Follow the [AWS NVIDIA GRID driver installation guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html#nvidia-GRID-driver)

--- a/docs/user_guide/setup-submitter.md
+++ b/docs/user_guide/setup-submitter.md
@@ -18,7 +18,7 @@ Select the appropriate branch for your deployment:
 If you’re setting up on a brand new Windows EC2 Instance as your submitter, a g5.2xlarge instance with 200 GB of storage will likely be reasonable minimum:
 
 1. Launch EC2 instance with a valid Instance Profile. This is required to download NVIDIA GRID drivers as instructed below.
-1. Download the Epic Installer and install a version of Unreal between versions 5.4 or newer. Note that on version 5.5 with DirectX 11 there's a crash bug which can affect projects rendered using the Deadline Cloud plugin which has been fixed in Unreal's source and can be tracked [here](https://issues.unrealengine.com/issue/UE-276282). Projects in Deadline Cloud should use DirectX 12 with UE 5.5.
+1. Download the Epic Installer and install a version of Unreal between versions 5.3 or newer. Note that on version 5.5 with DirectX 11 there's a crash bug which can affect projects rendered using the Deadline Cloud plugin which has been fixed in Unreal's source and can be tracked [here](https://issues.unrealengine.com/issue/UE-276282). Projects in Deadline Cloud should use DirectX 12 with UE 5.5.
 1. NVIDIA GRID drivers - Follow Windows instructions - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html#nvidia-GRID-driver
 
 ## Windows Long Paths

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -36,7 +36,7 @@ def find_unreal_engine(folder: str, version: Optional[str] = None) -> str:
     version strings which come after the underscore, or checking against a specified version
 
     :param folder: Root UE install folder to list for UE_<version> Unreal Engine version installations
-    :param version: Specific version string to check for, e.g. 5.2
+    :param version: Specific version string to check for, e.g. 5.5
 
     :return: Path to root of latest Unreal Engine installation in folder
     """
@@ -48,8 +48,8 @@ def find_unreal_engine(folder: str, version: Optional[str] = None) -> str:
     if version:
         check_version = version
     else:
-        # Default to 5.2 if no other versions are found
-        check_version = "5.2"
+        # Default to 5.3 if no other versions are found
+        check_version = "5.3"
         for subfolder in os.listdir(folder):
             if subfolder.startswith("UE_"):
                 version = subfolder.split("_")[1]

--- a/src/unreal_plugin/Content/Python/init_unreal.py
+++ b/src/unreal_plugin/Content/Python/init_unreal.py
@@ -77,6 +77,62 @@ def sync_mrq_dependencies(dependencies_descriptor_path: str) -> None:
     asset_registry.scan_paths_synchronous(ue_paths, True, True)
 
 
+def _check_patch_pydantic_py397():
+    """
+    Fix Pydantic's StringConstraints for Python 3.9.7 compatibility to work with
+    default Python in Unreal 5.3 (3.9.7)
+
+    In Python 3.9.7, when a dataclass with frozen=True inherits from a Protocol,
+    the dataclass decorator fails to generate the __init__ method. This function
+    manually generates the proper __init__ for StringConstraints.
+
+    See https://github.com/pydantic/pydantic/issues/7745
+    """
+
+    # Only apply on Python 3.9.7
+    if sys.version_info[:3] != (3, 9, 7):
+        print(f"Skipping Python 3.9.7 patch: Python version is {sys.version_info[:3]}")
+        return
+
+    try:
+        import pydantic.types
+    except ImportError:
+        print("Skipping Python 3.9.7 patch: pydantic not found")
+        # Pydantic not installed, nothing to fix
+        return
+
+    from typing import Pattern, Union
+
+    StringConstraints = pydantic.types.StringConstraints
+
+    # Generate the proper __init__ method with correct type hints
+    def __init__(
+        self: "pydantic.types.StringConstraints",
+        *,
+        strip_whitespace: Optional[bool] = None,
+        to_upper: Optional[bool] = None,
+        to_lower: Optional[bool] = None,
+        strict: Optional[bool] = None,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
+        pattern: Union[str, Pattern[str], None] = None,
+    ) -> None:
+        """Initialize StringConstraints with the given parameters."""
+        # Use object.__setattr__ because frozen=True prevents normal attribute assignment
+        object.__setattr__(self, "strip_whitespace", strip_whitespace)
+        object.__setattr__(self, "to_upper", to_upper)
+        object.__setattr__(self, "to_lower", to_lower)
+        object.__setattr__(self, "strict", strict)
+        object.__setattr__(self, "min_length", min_length)
+        object.__setattr__(self, "max_length", max_length)
+        object.__setattr__(self, "pattern", pattern)
+
+    # Apply the fix - type checkers will complain but this is intentional monkey-patching
+    StringConstraints.__init__ = __init__  # type: ignore
+
+    print("Applied Python 3.9.7 compatibility fix for pydantic.types.StringConstraints")
+
+
 remote_execution = os.getenv("REMOTE_EXECUTION", "False")
 if remote_execution != "True":
 
@@ -115,6 +171,11 @@ if remote_execution != "True":
         DeadlineCloudSettingsLibraryImplementation,  # noqa: F401
         background_init_s3_client,
     )
+
+    # UNREAL 5.3 PATCH - Temp fix to maintain support for system default python
+    # in Unreal 5.3 (3.9.7)
+    _check_patch_pydantic_py397()
+
     from job_library import DeadlineCloudJobBundleLibraryImplementation  # noqa: F401
     from open_job_template_api import (  # noqa: F401
         PythonYamlLibraryImplementation,

--- a/src/unreal_plugin/Content/Python/settings.py
+++ b/src/unreal_plugin/Content/Python/settings.py
@@ -57,7 +57,7 @@ def background_init_s3_client():
     Initialize cache an S3 client based on the current deadline configuration
     within the deadline cloud library
     """
-    logger.info("INIT DEADLINE CLOUD")
+    logger.info("Beginning background_init_s3_client")
     try:
         deadline = api.get_boto3_client("deadline")
         logger.info("Got deadline client successfully")

--- a/src/unreal_plugin/README.md
+++ b/src/unreal_plugin/README.md
@@ -5,7 +5,7 @@
 
 
 ## Requirements
-- Unreal Engine 5.4+
+- Unreal Engine 5.3+
 
 
 ## Installation

--- a/test/deadline_submitter_for_unreal/unit/test_python397_patch.py
+++ b/test/deadline_submitter_for_unreal/unit/test_python397_patch.py
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import os
+import sys
+
+from unittest.mock import patch
+
+# Allow init_unreal import
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "../../../src/unreal_plugin/Content/Python")
+)
+
+
+class TestPython397Patch:
+    """Test the Python 3.9.7 pydantic StringConstraints compatibility patch."""
+
+    @patch("init_unreal.sys.version_info", (3, 10, 0))
+    def test_patch_skipped_on_other_python_versions(self, capsys):
+        """Test that the patch is skipped on Python versions other than 3.9.7."""
+        from init_unreal import _check_patch_pydantic_py397
+
+        _check_patch_pydantic_py397()
+
+        captured = capsys.readouterr()
+        assert "Skipping Python 3.9.7 patch: Python version is (3, 10, 0)" in captured.out
+
+    @patch("init_unreal.sys.version_info", (3, 9, 7))
+    def test_patch_applied_when_all_checks_pass(self, capsys):
+        """Test that the patch is applied when all checks pass."""
+
+        from init_unreal import _check_patch_pydantic_py397
+
+        _check_patch_pydantic_py397()
+
+        captured = capsys.readouterr()
+        assert "Applied Python 3.9.7 compatibility fix" in captured.out


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Changes we've made in the past year exposed a bug affecting older versions of Python - specifically for this plugin this impacts the default version of Python (3.9.7) in Unreal 5.3(.2 - latest).  We'd recently raised our minimum supported version to 5.4 but have had requests to continue supporting 5.3.

See https://github.com/pydantic/pydantic/issues/7745 and linked issues for details on the underlying bug

### What was the solution? (How)
Create a patch to work around the bug.

Update docs to reflect 5.3 support.

### What is the impact of this change?
The integration should work properly with Unreal 5.3

### How was this change tested?
Existing unit tests pass
New unit tests pass
e2e tests pass
manual job submission

### Have you run a render job successfully with these changes?
I've successfully built and submitted a job on 5.3

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*