### PR TITLE
fix: Job attachment file and folder picker should be enabled

### DIFF
--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.cpp
@@ -444,6 +444,11 @@ void FDeadlineCloudAttachmentArrayBuilder::OnGenerateEntry(
     TSharedPtr<SWidget> NameWidget;
     TSharedPtr<SWidget> ValueWidget;
     PropertyRow.GetDefaultWidgets(NameWidget, ValueWidget);
+
+	FString PropertyName = ElementProperty->GetProperty()->GetName();
+    FName Tag = FName("AttachmentArrayElement.Value");
+    ValueWidget->AddMetadata(FDriverMetaData::Id(Tag));
+
     PropertyRow.CustomWidget(true)
         .NameContent()
         .HAlign(HAlign_Fill)

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.cpp
@@ -474,8 +474,6 @@ void FDeadlineCloudAttachmentArrayCustomization::CustomizeHeader(
 
     UMoviePipelineDeadlineCloudExecutorJob* OuterJob = FPropertyAvailabilityHandler::GetOuterJob(InPropertyHandle);
 
-    const FName PropertyPath = *InPropertyHandle->GetProperty()->GetPathName();
-
     ArrayBuilder = FDeadlineCloudAttachmentArrayBuilder::MakeInstance(ArrayHandle.ToSharedRef());
     ArrayBuilder->GenerateWrapperStructHeaderRowContent(InHeaderRow, InPropertyHandle->CreatePropertyNameWidget());
 }

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.cpp
@@ -445,7 +445,6 @@ void FDeadlineCloudAttachmentArrayBuilder::OnGenerateEntry(
     TSharedPtr<SWidget> ValueWidget;
     PropertyRow.GetDefaultWidgets(NameWidget, ValueWidget);
 
-	FString PropertyName = ElementProperty->GetProperty()->GetName();
     FName Tag = FName("AttachmentArrayElement.Value");
     ValueWidget->AddMetadata(FDriverMetaData::Id(Tag));
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.cpp
@@ -237,7 +237,13 @@ void FDeadlineCloudAttachmentDetailsCustomization::CustomizeChildren(
                         return bVisible
                             ? EVisibility::Visible
                             : EVisibility::Hidden;
-                    }));
+                    }))
+                .IsEnabled(
+                    TAttribute<bool>::CreateLambda([this, OuterJob]()
+                        {
+                            return false;
+                        })
+                );
     }
     else
     { 
@@ -467,25 +473,10 @@ void FDeadlineCloudAttachmentArrayCustomization::CustomizeHeader(
     const TSharedPtr<IPropertyHandle> ArrayHandle = InPropertyHandle->GetChildHandle("Paths", false);
 
     UMoviePipelineDeadlineCloudExecutorJob* OuterJob = FPropertyAvailabilityHandler::GetOuterJob(InPropertyHandle);
-    PropertyOverrideHandler = MakeShared<FPropertyAvailabilityHandler>(OuterJob);
 
     const FName PropertyPath = *InPropertyHandle->GetProperty()->GetPathName();
 
     ArrayBuilder = FDeadlineCloudAttachmentArrayBuilder::MakeInstance(ArrayHandle.ToSharedRef());
-    if (PropertyOverrideHandler->GetOuterJob(InPropertyHandle))
-    {
-        ArrayBuilder->OnIsEnabled.BindLambda([this, PropertyPath]()
-            {
-                return this->PropertyOverrideHandler->IsPropertyRowEnabledInMovieRenderJob(PropertyPath);
-            });
-    }
-    else
-    {
-        ArrayBuilder->OnIsEnabled.BindLambda([this, PropertyPath]()
-            {
-                return this->PropertyOverrideHandler->IsPropertyRowEnabledInDataAsset(PropertyPath);
-            });
-    }
     ArrayBuilder->GenerateWrapperStructHeaderRowContent(InHeaderRow, InPropertyHandle->CreatePropertyNameWidget());
 }
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UI.spec.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UI.spec.cpp
@@ -613,6 +613,7 @@ void FDeadlinePluginUISpec::Define()
 			CreatedRenderJobDataAsset->Environments.Add(CreatedEnvironmentDataAsset);
 
 			CreatedRenderJobDataAsset->JobPresetStruct.JobAttachments.InputFiles.Files.Paths.Add(FFilePath("C:/Temp/InputFile1.txt"));
+			CreatedRenderJobDataAsset->JobPresetStruct.JobAttachments.InputDirectories.Directories.Paths.Add(FDirectoryPath("C:/Temp/InputDir1"));
 
 			ShowTestEnvironmentParameters();
 			ShowTestStepParameters();
@@ -698,9 +699,8 @@ void FDeadlinePluginUISpec::Define()
 			FDriverElementRef EmptyStepEnvCategory = Driver->FindElement(By::Path("#MRQStepEnvHeader.Empty"));
 
 			FDriverElementRef SavePresetButton = Driver->FindElement(By::Path("#MRQJobSavePresetButton"));
-			
-			FDriverElementRef FileArrayElementText = Driver->FindElement(By::Path("#AttachmentArrayElement.Value//<SEditableTextBox>"));
-
+			FDriverElementRef FileArrayElementText = Driver->FindElement(By::Path("#AttachmentArrayElement.Value//<SFilePathPicker>//<SEditableTextBox>"));
+			FDriverElementRef DirArrayElementText = Driver->FindElement(By::Path("#AttachmentArrayElement.Value//<SPropertyEditorText>//<SEditableTextBox>"));
 			auto VisibilityTest = [this](const FString& ParameterName, FDriverElementRef Widget, bool bShouldBeVisible)
 				{
 					ScrollToElement(Driver, List.ToSharedRef(), ScrollBar.ToSharedRef(), Widget, 50);
@@ -715,18 +715,24 @@ void FDeadlinePluginUISpec::Define()
 					}
 				};
 
-			ScrollToElement(Driver, List.ToSharedRef(), ScrollBar.ToSharedRef(), FileArrayElementText, 50);
-			if (FileArrayElementText->IsVisible())
-			{
-				InputText(FileArrayElementText, "Test", true);
-				TestTrue("File Array Element Text shoud be editable", "Test" == MRQJob->PresetOverrides.JobAttachments.InputFiles.Files.Paths[0].FilePath);
-			}
-			else
-			{
-				TestTrue("File Array Element Text widget should be visible", false);
-			}
+			auto EditableTextTest = [this](const FString& ParameterName, FDriverElementRef Widget, const FString& ExpectedValue)
+				{
+					ScrollToElement(Driver, List.ToSharedRef(), ScrollBar.ToSharedRef(), Widget, 50);
+					if (Widget->IsVisible() && Widget->IsInteractable())
+					{
+						InputText(Widget, "Test", true);
+						TestTrue(ParameterName + " should be editable", "Test" == ExpectedValue);
+					}
+					else
+					{
+						TestTrue(ParameterName + " widget should be visible and interactable", false);
+					}
+				};
 
 			VisibilityTest("SavePresetButton", SavePresetButton, true);
+
+			EditableTextTest("File Array Element Text", FileArrayElementText, MRQJob->PresetOverrides.JobAttachments.InputFiles.Files.Paths[0].FilePath);
+			EditableTextTest("Dir Array Element Text", DirArrayElementText, MRQJob->PresetOverrides.JobAttachments.InputDirectories.Directories.Paths[0].Path);
 
 			VisibilityTest("StringParameters", StringParametersWidget, true);
 			VisibilityTest("PathParameters", PathParametersWidget, true);
@@ -763,6 +769,7 @@ void FDeadlinePluginUISpec::Define()
 
 				CreatedEmptyStepDataAsset->RemoveFromRoot();
 				CreatedEmptyStepDataAsset = nullptr;
+
 				CreatedEmptyEnvironmentDataAsset->RemoveFromRoot();
 				CreatedEmptyEnvironmentDataAsset = nullptr;
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UI.spec.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UI.spec.cpp
@@ -612,6 +612,8 @@ void FDeadlinePluginUISpec::Define()
 			CreatedRenderJobDataAsset->Steps.Add(CreatedEmptyStepDataAsset);
 			CreatedRenderJobDataAsset->Environments.Add(CreatedEnvironmentDataAsset);
 
+			CreatedRenderJobDataAsset->JobPresetStruct.JobAttachments.InputFiles.Files.Paths.Add(FFilePath("C:/Temp/InputFile1.txt"));
+
 			ShowTestEnvironmentParameters();
 			ShowTestStepParameters();
 
@@ -696,6 +698,8 @@ void FDeadlinePluginUISpec::Define()
 			FDriverElementRef EmptyStepEnvCategory = Driver->FindElement(By::Path("#MRQStepEnvHeader.Empty"));
 
 			FDriverElementRef SavePresetButton = Driver->FindElement(By::Path("#MRQJobSavePresetButton"));
+			
+			FDriverElementRef FileArrayElementText = Driver->FindElement(By::Path("#AttachmentArrayElement.Value//<SEditableTextBox>"));
 
 			auto VisibilityTest = [this](const FString& ParameterName, FDriverElementRef Widget, bool bShouldBeVisible)
 				{
@@ -710,6 +714,17 @@ void FDeadlinePluginUISpec::Define()
 						TestFalse(ParameterName + " widget should be hidden", bIsVisible);
 					}
 				};
+
+			ScrollToElement(Driver, List.ToSharedRef(), ScrollBar.ToSharedRef(), FileArrayElementText, 50);
+			if (FileArrayElementText->IsVisible())
+			{
+				InputText(FileArrayElementText, "Test", true);
+				TestTrue("File Array Element Text shoud be editable", "Test" == MRQJob->PresetOverrides.JobAttachments.InputFiles.Files.Paths[0].FilePath);
+			}
+			else
+			{
+				TestTrue("File Array Element Text widget should be visible", false);
+			}
 
 			VisibilityTest("SavePresetButton", SavePresetButton, true);
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.h
@@ -160,9 +160,6 @@ public:
 private:
 	/** Attachment arrays UI handler */
 	TSharedPtr<FDeadlineCloudAttachmentArrayBuilder> ArrayBuilder;
-
-	/** Handles overridden settings in UI */
-	TSharedPtr<FPropertyAvailabilityHandler> PropertyOverrideHandler;
 };
 
 /**


### PR DESCRIPTION

Fixes: *https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/issues/221*

### What was the problem/requirement? (What/Why)

Unable to include additional video media files

### What was the solution? (How)

Update UI handling for attachment arrays and property availability in Deadline Cloud Job Preset

### What is the impact of this change?

Bug addressed

### How was this change tested?

- Have you run the unit tests?
- Yes

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*