### PR TITLE
fix: Using parse_model to parse HostRequirementsTemplate and better h…

### DIFF
--- a/src/deadline/unreal_submitter/job_submit_wrapper.py
+++ b/src/deadline/unreal_submitter/job_submit_wrapper.py
@@ -101,8 +101,6 @@ def main():
 
         error_msg = f"{str(e)}\n{traceback.format_exc()}"
         print(json.dumps({"type": "error", "message": error_msg}), flush=True)
-        # Also print to stderr for additional debugging
-        print(f"ERROR: {error_msg}", file=sys.stderr, flush=True)
         sys.exit(1)
 
 

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step_host_requirements.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step_host_requirements.py
@@ -4,6 +4,7 @@ import unreal
 from typing import Any, Optional
 
 from openjd.model.v2023_09 import HostRequirementsTemplate
+from openjd.model import parse_model
 
 
 class HostRequirementsHelper:
@@ -30,7 +31,7 @@ class HostRequirementsHelper:
             # hardware requirements are currently all amount
             requirements["amounts"] = hardware_requirements
 
-        return HostRequirementsTemplate(**requirements)
+        return parse_model(model=HostRequirementsTemplate, obj=requirements)
 
     @staticmethod
     def get_os_requirements(

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step_host_requirements.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step_host_requirements.py
@@ -1,0 +1,96 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import sys
+from unittest.mock import Mock, MagicMock, patch
+
+unreal_mock = MagicMock()
+sys.modules["unreal"] = unreal_mock
+
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job_step_host_requirements import (  # noqa: E402
+    HostRequirementsHelper,
+)
+
+
+class TestHostRequirementsHelper:
+
+    def test_u_host_requirements_to_openjd_host_requirements_with_os_requirements(self):
+        """Test that u_host_requirements_to_openjd_host_requirements returns valid HostRequirementsTemplate with OS requirements"""
+        # GIVEN
+        mock_host_reqs = Mock()
+        mock_host_reqs.run_on_all_worker_nodes = False
+        mock_host_reqs.operating_system = "linux"
+        mock_host_reqs.cpu_architecture = "x86_64"
+
+        # Mock hardware requirements to return empty
+        with patch.object(HostRequirementsHelper, "get_hardware_requirements", return_value=[]):
+            # WHEN
+            result = HostRequirementsHelper.u_host_requirements_to_openjd_host_requirements(
+                mock_host_reqs
+            )
+
+            # THEN
+            assert result is not None
+            # Verify the result has the expected structure for OS requirements
+            assert hasattr(result, "attributes")
+
+    def test_u_host_requirements_to_openjd_host_requirements_with_hardware_requirements(self):
+        """Test that u_host_requirements_to_openjd_host_requirements returns valid HostRequirementsTemplate with hardware requirements"""
+        # GIVEN
+        mock_host_reqs = Mock()
+        mock_host_reqs.run_on_all_worker_nodes = False
+
+        # Mock OS requirements to return empty
+        with patch.object(HostRequirementsHelper, "get_os_requirements", return_value=[]):
+            # Mock hardware requirements to return valid data
+            hardware_reqs = [{"name": "amount.worker.vcpu", "min": 2}]
+            with patch.object(
+                HostRequirementsHelper, "get_hardware_requirements", return_value=hardware_reqs
+            ):
+                # WHEN
+                result = HostRequirementsHelper.u_host_requirements_to_openjd_host_requirements(
+                    mock_host_reqs
+                )
+
+                # THEN
+                assert result is not None
+                # Verify the result has the expected structure for hardware requirements
+                assert hasattr(result, "amounts")
+
+    def test_u_host_requirements_to_openjd_host_requirements_with_both_requirements(self):
+        """Test that u_host_requirements_to_openjd_host_requirements returns valid HostRequirementsTemplate with both OS and hardware requirements"""
+        # GIVEN
+        mock_host_reqs = Mock()
+        mock_host_reqs.run_on_all_worker_nodes = False
+
+        # Mock both OS and hardware requirements
+        os_reqs = [{"name": "attr.worker.os.family", "anyOf": ["linux"]}]
+        hardware_reqs = [{"name": "amount.worker.vcpu", "min": 2}]
+
+        with patch.object(HostRequirementsHelper, "get_os_requirements", return_value=os_reqs):
+            with patch.object(
+                HostRequirementsHelper, "get_hardware_requirements", return_value=hardware_reqs
+            ):
+                # WHEN
+                result = HostRequirementsHelper.u_host_requirements_to_openjd_host_requirements(
+                    mock_host_reqs
+                )
+
+                # THEN
+                assert result is not None
+                # Verify the result has both attributes and amounts
+                assert hasattr(result, "attributes")
+                assert hasattr(result, "amounts")
+
+    def test_u_host_requirements_to_openjd_host_requirements_run_on_all_nodes(self):
+        """Test that u_host_requirements_to_openjd_host_requirements returns None when run_on_all_worker_nodes is True"""
+        # GIVEN
+        mock_host_reqs = Mock()
+        mock_host_reqs.run_on_all_worker_nodes = True
+
+        # WHEN
+        result = HostRequirementsHelper.u_host_requirements_to_openjd_host_requirements(
+            mock_host_reqs
+        )
+
+        # THEN
+        assert result is None


### PR DESCRIPTION
Fixes: #248 

### What was the problem/requirement? (What/Why)

- HostRequirementsTemplate was being instantiated directly rather than using parse_model, causing internal pydantic errors due to missing parsing context.
- In some cases errors during bundle submission could result in the submission subprocess hanging.

### What was the solution? (How)

- Use parse_model for parsing HostRequirementsTemplate
- Remove unnecessary stderr prints

### What is the impact of this change?

- Setting host requirements should no longer cause a failure to submit
- Errors encountered during submission should display and end the submission properly

### How was this change tested?

- Manual testing
- New unit tests added which pass
- E2E tests pass

### Have you run a render job successfully with these changes?
Yes

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*