### PR TITLE
feat: Add amount and attributes name UI validation

### DIFF
--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step_host_requirements.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step_host_requirements.py
@@ -4,8 +4,11 @@ import unreal
 from typing import Any, Optional, Union
 
 from openjd.model import parse_model
-from openjd.model.v2023_09 import HostRequirementsTemplate
-
+from openjd.model.v2023_09 import (
+    HostRequirementsTemplate,
+    AmountRequirementTemplate,
+    AttributeRequirementTemplate,
+)
 
 DEFAULT_HOST_REQUIREMENTS: dict[str, list[Any]] = {
     "amounts": [
@@ -33,6 +36,22 @@ FRIENDLY_NAME_MAP = {
 
 
 class HostRequirementsHelper:
+
+    @staticmethod
+    def validate_name(dict_name: str, name: str) -> str:
+        if HostRequirementsHelper.is_predefined_requirement_by_name(dict_name, name):
+            return "Using predefined names is not allowed"
+
+        try:
+            if dict_name == "amounts":
+                parse_model(model=AmountRequirementTemplate, obj={"name": name, "min": 1})
+            elif dict_name == "attributes":
+                parse_model(
+                    model=AttributeRequirementTemplate, obj={"name": name, "anyOf": ["Test"]}
+                )
+        except Exception as e:
+            return str(e)
+        return ""
 
     @staticmethod
     def is_predefined_requirement_by_name(dict_name: str, name: str) -> bool:

--- a/src/unreal_plugin/Content/Python/job_library.py
+++ b/src/unreal_plugin/Content/Python/job_library.py
@@ -129,3 +129,11 @@ class DeadlineCloudJobBundleLibraryImplementation(unreal.DeadlineCloudJobBundleL
     @unreal.ufunction(override=True)
     def get_job_initial_state_options(self):
         return ["READY", "SUSPENDED"]
+
+    @unreal.ufunction(override=True)
+    def validate_amount_name(self, name) -> str:
+        return HostRequirementsHelper.validate_name("amounts", name)
+
+    @unreal.ufunction(override=True)
+    def validate_attribute_name(self, name) -> str:
+        return HostRequirementsHelper.validate_name("attributes", name)

--- a/src/unreal_plugin/Content/Python/open_job_template_api.py
+++ b/src/unreal_plugin/Content/Python/open_job_template_api.py
@@ -295,9 +295,7 @@ class PythonYamlLibraryImplementation(unreal.PythonYamlLibrary):
             raw_min = item.get("min")
             raw_max = item.get("max")
 
-            if not (raw_min is not None and raw_min >= 0) and not (
-                raw_max is not None and raw_max >= 1
-            ):
+            if (raw_min is None or raw_min < 0) and (raw_max is None or raw_max < 1):
                 continue
 
             if name in result:

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudHostRequirementsDetails.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudHostRequirementsDetails.cpp
@@ -168,10 +168,12 @@ TSharedRef<SWidget> FDeadlineCloudAttributeBuilder::CreateNameWidget(TSharedPtr<
         NameWidget = FDeadlineCloudDetailsWidgetsHelper::CreatePropertyWidgetByType(
             NameHandle, 
             EValueType::STRING, 
-            EValueValidationType::Default, 
+            EValueValidationType::AttributeName, 
             FText::FromString("attr.[.]*")
         );
         NameWidget->SetEnabled(IsEnabledAttr);
+        FName Tag = FName("HostReq.Attr.Custom.Name");
+        NameWidget->AddMetadata(FDriverMetaData::Id(Tag));
     }
 
 	return NameWidget.ToSharedRef();
@@ -282,10 +284,12 @@ TSharedRef<SWidget> FDeadlineCloudAmountBuilder::CreateNameWidget(TSharedPtr<IPr
         NameWidget = FDeadlineCloudDetailsWidgetsHelper::CreatePropertyWidgetByType(
             NameHandle, 
             EValueType::STRING,
-			EValueValidationType::Default,
+			EValueValidationType::AmountName,
 			FText::FromString("amount.[.]*")
         );
         NameWidget->SetEnabled(IsEnabledAttr);
+        FName Tag = FName("HostReq.Amount.Custom.Name");
+        NameWidget->AddMetadata(FDriverMetaData::Id(Tag));
     }
 
 	return NameWidget.ToSharedRef();

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudInputValidationHelper.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudInputValidationHelper.cpp
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 #include "DeadlineCloudJobSettings/DeadlineCloudInputValidationHelper.h"
+#include "PythonAPILibraries/DeadlineCloudJobBundleLibrary.h"
 
 #define LOCTEXT_NAMESPACE "DeadlineWidgets"
 
@@ -45,6 +46,22 @@ FValidatorFunc FDeadlineCloudInputValidationHelper::CreateLengthAndControlValida
     };
 }
 
+FValidatorFunc FDeadlineCloudInputValidationHelper::CreateAmountNameValidator()
+{
+    return [](const FString& Str, FText& Error)
+        {
+            return IsValidAmountName(Str, Error);
+        };
+}
+
+FValidatorFunc FDeadlineCloudInputValidationHelper::CreateAttributeNameValidator()
+{
+    return [](const FString& Str, FText& Error)
+        {
+            return IsValidAttributeName(Str, Error);
+        };
+}
+
 FOnVerifyTextChanged FDeadlineCloudInputValidationHelper::GetStringValidationFunction(EValueValidationType ValidationType)
 {
     using enum EValueValidationType;
@@ -65,6 +82,10 @@ FOnVerifyTextChanged FDeadlineCloudInputValidationHelper::GetStringValidationFun
 
     case EnvParameterValue:
         return MakeValidator(CreateLengthValidator(0, 2048));
+    case AmountName:
+        return MakeValidator(CreateAmountNameValidator());
+    case AttributeName:
+        return MakeValidator(CreateAttributeNameValidator());
 
     default:
         return FOnVerifyTextChanged();
@@ -175,6 +196,48 @@ bool FDeadlineCloudInputValidationHelper::IsValidIdentifier(const FString& InStr
     }
 
     return true;
+}
+
+bool FDeadlineCloudInputValidationHelper::IsValidAttributeName(const FString& InStr, FText& OutError)
+{
+    if (auto Library = UDeadlineCloudJobBundleLibrary::Get())
+    {
+        FString ValidationError = Library->ValidateAttributeName(InStr);
+        
+        if (ValidationError == "")
+        {
+            return true;
+        }
+        else
+        {
+            OutError = FText::FromString(ValidationError);
+            return false;
+        }
+    }
+
+    OutError = LOCTEXT("DeadlineCloudJobBundleLibraryError", "Cannot validate the name: DeadlineCloudJobBundleLibrary are not available");
+    return false;
+}
+
+bool FDeadlineCloudInputValidationHelper::IsValidAmountName(const FString& InStr, FText& OutError)
+{
+    if (auto Library = UDeadlineCloudJobBundleLibrary::Get())
+    {
+        FString ValidationError = Library->ValidateAmountName(InStr);
+
+        if (ValidationError == "")
+        {
+            return true;
+        }
+        else
+        {
+            OutError = FText::FromString(ValidationError);
+            return false;
+        }
+    }
+
+    OutError = LOCTEXT("DeadlineCloudJobBundleLibraryError", "Cannot validate the name: DeadlineCloudJobBundleLibrary are not available");
+    return false;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UI.spec.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UI.spec.cpp
@@ -362,6 +362,76 @@ bool FValidationFunction_JobDescription_Invalid::RunTest(const FString& Paramete
     return true;
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FIsValidAttributeName_Test,
+	"DeadlineCloud.Validation.AttributeName.Integration",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter
+)
+
+bool FIsValidAttributeName_Test::RunTest(const FString& Parameters)
+{
+	FText Error;
+
+	UDeadlineCloudJobBundleLibrary* Library = UDeadlineCloudJobBundleLibrary::Get();
+	if (!Library)
+	{
+		const bool bOk = FDeadlineCloudInputValidationHelper::IsValidAttributeName(TEXT("AnyName"), Error);
+
+		TestFalse("Should fail when library is unavailable", bOk);
+		TestTrue("Should return user-friendly error",
+			Error.ToString().Contains(TEXT("Cannot validate the name")));
+
+		return true;
+	}
+
+	const bool bValidTest = FDeadlineCloudInputValidationHelper::IsValidAttributeName(TEXT("attr.test"), Error);
+	TestTrue("Valid attribute name should pass", bValidTest);
+	TestTrue("Error should be empty on success", Error.IsEmpty());
+	const bool bInvalidTest = FDeadlineCloudInputValidationHelper::IsValidAttributeName(TEXT("attrtest"), Error);
+	TestFalse("Invalid attribute name should not pass", bInvalidTest);
+	TestTrue("Error should contain an error message", !Error.IsEmpty());
+	const bool bPredefinedTest = FDeadlineCloudInputValidationHelper::IsValidAttributeName(TEXT("attr.worker.os.family"), Error);
+	TestFalse("Predefined attribute name should not pass", bInvalidTest);
+	TestTrue("Error should contain an error message", !Error.IsEmpty());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FIsValidAmountName_Test,
+	"DeadlineCloud.Validation.AmountName.Integration",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter
+)
+
+bool FIsValidAmountName_Test::RunTest(const FString& Parameters)
+{
+	FText Error;
+
+	UDeadlineCloudJobBundleLibrary* Library = UDeadlineCloudJobBundleLibrary::Get();
+	if (!Library)
+	{
+		const bool bOk = FDeadlineCloudInputValidationHelper::IsValidAmountName(TEXT("AnyName"), Error);
+
+		TestFalse("Should fail when library is unavailable", bOk);
+		TestTrue("Should return user-friendly error",
+			Error.ToString().Contains(TEXT("Cannot validate the name")));
+
+		return true;
+	}
+
+	const bool bValidTest = FDeadlineCloudInputValidationHelper::IsValidAmountName(TEXT("amount.test"), Error);
+	TestTrue("Valid amount name should pass", bValidTest);
+	TestTrue("Error should be empty on success", Error.IsEmpty());
+	const bool bInvalidTest = FDeadlineCloudInputValidationHelper::IsValidAmountName(TEXT("amounttest"), Error);
+	TestFalse("Invalid amount name should not pass", bInvalidTest);
+	TestTrue("Error should contain an error message", !Error.IsEmpty());
+	const bool bPredefinedTest = FDeadlineCloudInputValidationHelper::IsValidAmountName(TEXT("amount.worker.vcpu"), Error);
+	TestFalse("Predefined amount name should not pass", bInvalidTest);
+	TestTrue("Error should contain an error message", !Error.IsEmpty());
+
+	return true;
+}
+
 static FString ConvertLocalPathToFull(const FString& Path)
 {
 	FString PluginContentDir = IPluginManager::Get().FindPlugin(TEXT("UnrealDeadlineCloudService"))->GetBaseDir();
@@ -432,6 +502,10 @@ AssetType* CreateAsset(
     {
         Asset->OpenEnvFile(OutFullTemplatePath);
     }
+	else if constexpr (std::is_same_v<AssetType, UDeadlineCloudHostRequirements>)
+	{
+		Asset->OpenHostRequirementsFile(OutFullTemplatePath);
+	}
 	return Asset;
 }
 
@@ -473,6 +547,7 @@ UDeadlineCloudStep* CreatedStepDataAsset;
 UDeadlineCloudEnvironment* CreatedEnvironmentDataAsset;
 UDeadlineCloudJob* CreatedJobDataAsset;
 UDeadlineCloudRenderJob* CreatedRenderJobDataAsset;
+UDeadlineCloudHostRequirements* CreatedHostRequirements;
 UMoviePipelineDeadlineCloudExecutorJob* MRQJob;
 FParametersConsistencyCheckResult result;
 
@@ -489,6 +564,8 @@ FString PathToEmptyEnvironmentTemplate;
 FString EmptyEnvTemplate = "/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/launch_ue_environment_UI_empty.yml";
 FString PathToJobTemplate;
 FString JobTemplate = "/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_job_UI.yml";
+FString PathToHostReqTemplate;
+FString HostReqTemplate = "/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/host_requirements_UI.yml";
 
 const FString DetailsPath = "<SStandaloneAssetEditorToolkitHost>//<SDetailsView>";
 const FString ListPath = DetailsPath + "//<SListPanel>";
@@ -701,6 +778,7 @@ void FDeadlinePluginUISpec::Define()
 			FDriverElementRef SavePresetButton = Driver->FindElement(By::Path("#MRQJobSavePresetButton"));
 			FDriverElementRef FileArrayElementText = Driver->FindElement(By::Path("#AttachmentArrayElement.Value//<SFilePathPicker>//<SEditableTextBox>"));
 			FDriverElementRef DirArrayElementText = Driver->FindElement(By::Path("#AttachmentArrayElement.Value//<SPropertyEditorText>//<SEditableTextBox>"));
+
 			auto VisibilityTest = [this](const FString& ParameterName, FDriverElementRef Widget, bool bShouldBeVisible)
 				{
 					ScrollToElement(Driver, List.ToSharedRef(), ScrollBar.ToSharedRef(), Widget, 50);
@@ -750,7 +828,7 @@ void FDeadlinePluginUISpec::Define()
 			VisibilityTest("Variable2", Variable2Widget, true);
 			VisibilityTest("Variable3", Variable3Widget, true);
 			VisibilityTest("HiddenVariable", HiddenVariableWidget, false);
-
+			
 			// always visible with host reqs
 			//VisibilityTest("Default Step category", DefaultStepCategory, true);
 			//VisibilityTest("Empty Step category", EmptyStepCategory, false);
@@ -1177,6 +1255,94 @@ void FDeadlinePluginUISpec::Define()
 		});
     });
 
+	Describe("DeadlineCloudHostRequirementsUI", [this]()
+		{
+			BeforeEach([this]() {
+				CreatedHostRequirements = CreateAndOpenAsset<UDeadlineCloudHostRequirements>(HostReqTemplate, PathToHostReqTemplate);
+				CreatedHostRequirements->AddToRoot();
+				});
+
+			It("HostRequirementsUI", EAsyncExecution::ThreadPool, FTimespan::FromSeconds(120), [this]() {
+				if (!InitForDataAsset(CreatedHostRequirements))
+				{
+					return;
+				}
+
+				ExpandAllProperties(DetailsPath, Driver);
+
+				FDriverElementRef CustomAmountNameWidget = Driver->FindElement(By::Path("#HostReq.Amount.Custom.Name//<SEditableTextBox>"));
+				FDriverElementRef CustomAttrNameWidget = Driver->FindElement(By::Path("#HostReq.Attr.Custom.Name//<SEditableTextBox>"));
+
+				auto FindStringKeyRef =
+					[](auto& Map, const FString& KeyToFind) -> FString*
+					{
+						for (auto It = Map.CreateIterator(); It; ++It)
+						{
+							if (It.Key() == KeyToFind)
+							{
+								return &It.Key();
+							}
+						}
+
+						return nullptr;
+					};
+
+				ScrollToElement(Driver, List.ToSharedRef(), ScrollBar.ToSharedRef(), CustomAmountNameWidget, 50);
+				bool bCustomAmountNameWidgetExists = CustomAmountNameWidget->Exists();
+				TestTrue("CustomAmountNameWidget widget should exist", bCustomAmountNameWidgetExists);
+
+				if (bCustomAmountNameWidgetExists)
+				{
+					FString* AmountKey = FindStringKeyRef(CreatedHostRequirements->HostRequirements.Amounts, "amount.test");
+					if (AmountKey == nullptr)
+					{
+						TestTrue("Amount Custom Key should exist", false);
+					}
+					else
+					{
+						FString OldValue = *AmountKey;
+						InputText(CustomAmountNameWidget, "InvalidNameTest", true);
+						TestTrue("New key should not exist", FindStringKeyRef(CreatedHostRequirements->HostRequirements.Amounts, "amount.test") != nullptr);
+
+						InputText(CustomAmountNameWidget, "amount.custom", true);
+						TestTrue("New key should exist", FindStringKeyRef(CreatedHostRequirements->HostRequirements.Amounts, "amount.custom") != nullptr);
+					}
+				}
+
+				ScrollToElement(Driver, List.ToSharedRef(), ScrollBar.ToSharedRef(), CustomAttrNameWidget, 50);
+				bool bCustomAttrNameWidgetExists = CustomAttrNameWidget->Exists();
+				TestTrue("CustomAmountNameWidget widget should exist", bCustomAttrNameWidgetExists);
+
+				if (bCustomAttrNameWidgetExists)
+				{
+					FString* AttrKey = FindStringKeyRef(CreatedHostRequirements->HostRequirements.Attributes, "attr.test");
+					if (AttrKey == nullptr)
+					{
+						TestTrue("Attr Custom Key should exist", false);
+					}
+					else
+					{
+						FString OldValue = *AttrKey;
+						InputText(CustomAttrNameWidget, "InvalidNameTest", true);
+						TestTrue("New key should not exist", FindStringKeyRef(CreatedHostRequirements->HostRequirements.Attributes, "attr.test") != nullptr);
+
+						InputText(CustomAttrNameWidget, "attr.custom", true);
+						TestTrue("New key should exist", FindStringKeyRef(CreatedHostRequirements->HostRequirements.Attributes, "attr.custom") != nullptr);
+					}
+				}
+
+				});
+
+			AfterEach([this]()
+				{
+					auto* Editor = GEditor->GetEditorSubsystem<UAssetEditorSubsystem>();
+					Editor->CloseAllAssetEditors();
+
+					CreatedHostRequirements->RemoveFromRoot();
+					CreatedHostRequirements = nullptr;
+				});
+		});
+
 	Describe("DeadlineCloudSavePresetWidget", [this]()
     {
 		BeforeEach([this]() {
@@ -1245,6 +1411,8 @@ void FDeadlinePluginUISpec::Define()
 			MRQJob = nullptr;
 		});
     });
+
+
 
 	AfterEach([this]() {
 		Driver.Reset();

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/host_requirements_UI.yml
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/host_requirements_UI.yml
@@ -1,0 +1,24 @@
+hostRequirements:
+  amounts:
+    - name: amount.worker.vcpu
+      min: 32
+    - name: amount.worker.memory
+      min: 8
+    - name: amount.worker.gpu
+      min: 1
+    - name: amount.worker.gpu.memory
+      min: 8
+      max: 24
+    - name: amount.worker.disk.scratch
+      max: 16
+    - name: amount.test
+      max: 16
+
+  attributes:
+    - name: attr.worker.os.family
+      anyOf: [windows]
+    - name: attr.worker.cpu.arch
+      anyOf: [x86_64]
+    - name: attr.test
+      allOf: [test]    
+      

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudInputValidationHelper.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudInputValidationHelper.h
@@ -32,10 +32,15 @@ public:
     /** Identifier with error message */
     static bool IsValidIdentifier(const FString& InStr, FText& OutError, const FText& FieldName = FText::FromString(TEXT("Identifier")));
 
+    static bool IsValidAttributeName(const FString& InStr, FText& OutError);
+    static bool IsValidAmountName(const FString& InStr, FText& OutError);
+
 private:
 
     static FValidatorFunc CreateLengthValidator(int32 Min, int32 Max);
     static FValidatorFunc CreateLengthAndIdentifierValidator(int32 Min, int32 Max);
     static FValidatorFunc CreateLengthAndControlValidator(int32 Min, int32 Max, TSet<TCHAR> ExcludeList);
+    static FValidatorFunc CreateAmountNameValidator();
+    static FValidatorFunc CreateAttributeNameValidator();
 
 };

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudJobBundleLibrary.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudJobBundleLibrary.h
@@ -60,4 +60,10 @@ public:
 
 	UFUNCTION(BlueprintImplementableEvent)
 	FString GetRequirementFriendlyName(const FString& Name);
+
+	UFUNCTION(BlueprintImplementableEvent)
+	FString ValidateAmountName(const FString& Name);
+
+	UFUNCTION(BlueprintImplementableEvent)
+	FString ValidateAttributeName(const FString& Name);
 };

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/PythonYamlLibrary.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/PythonYamlLibrary.h
@@ -33,7 +33,9 @@ enum class EValueValidationType : uint8
 	JobDescription,
     JobParameterValue,
 	StepParameterValue,
-	EnvParameterValue
+	EnvParameterValue,
+	AmountName,
+	AttributeName,
 };
 
 UENUM(BlueprintType)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Need to add UI validators for Custom Host Requirement attributes and amounts name fields to give more clear reason why Job is invalid than Pydantic validation errors

### What was the solution? (How)

Add UI validators

### What is the impact of this change?

User can now see the validation errors in the UI that appears as a tip over the "name" field

### How was this change tested?

- Have you run the unit tests?
- Yes

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

Yes

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*