### PR TITLE
chore: correct supported UE version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For instructions on installing and using this integration, visit the [user guide
 
 This library requires:
 
-1. Python 3.9 or higher; and Unreal Engine 5.3 or higher.
+1. Python 3.9 or higher; and Unreal Engine 5.4 or higher.
 2. Windows operating system.
 
 ## Submitter

--- a/docs/user_guide/setup-cmf-worker.md
+++ b/docs/user_guide/setup-cmf-worker.md
@@ -32,8 +32,8 @@ Select the appropriate branch for your deployment:
 
 **1. Install Unreal Engine**
 1. Download the Epic Games Launcher
-2. Install Unreal Engine 5.3 or higher
-   > **📝 Note**: Unreal Engine 5.3+ is required for Deadline Cloud compatibility
+2. Install Unreal Engine 5.4 or higher
+   > **📝 Note**: Unreal Engine 5.4+ is required for Deadline Cloud compatibility
 
 **2. Install NVIDIA GRID Drivers**
 - Follow the [AWS NVIDIA GRID driver installation guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html#nvidia-GRID-driver)

--- a/docs/user_guide/setup-submitter.md
+++ b/docs/user_guide/setup-submitter.md
@@ -18,7 +18,7 @@ Select the appropriate branch for your deployment:
 If you’re setting up on a brand new Windows EC2 Instance as your submitter, a g5.2xlarge instance with 200 GB of storage will likely be reasonable minimum:
 
 1. Launch EC2 instance with a valid Instance Profile. This is required to download NVIDIA GRID drivers as instructed below.
-1. Download the Epic Installer and install a version of Unreal between versions 5.3 or newer. Note that on version 5.5 with DirectX 11 there's a crash bug which can affect projects rendered using the Deadline Cloud plugin which has been fixed in Unreal's source and can be tracked [here](https://issues.unrealengine.com/issue/UE-276282). Projects in Deadline Cloud should use DirectX 12 with UE 5.5.
+1. Download the Epic Installer and install a version of Unreal between versions 5.4 and 5.6. Note that on version 5.5 with DirectX 11 there's a crash bug which can affect projects rendered using the Deadline Cloud plugin which has been fixed in Unreal's source and can be tracked [here](https://issues.unrealengine.com/issue/UE-276282). Projects in Deadline Cloud should use DirectX 12 with UE 5.5.
 1. NVIDIA GRID drivers - Follow Windows instructions - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html#nvidia-GRID-driver
 
 ## Windows Long Paths

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -48,8 +48,8 @@ def find_unreal_engine(folder: str, version: Optional[str] = None) -> str:
     if version:
         check_version = version
     else:
-        # Default to 5.3 if no other versions are found
-        check_version = "5.3"
+        # Default to 5.6 if no other versions are found
+        check_version = "5.6"
         for subfolder in os.listdir(folder):
             if subfolder.startswith("UE_"):
                 version = subfolder.split("_")[1]

--- a/src/deadline/unreal_submitter/unreal_dependency_collector.py
+++ b/src/deadline/unreal_submitter/unreal_dependency_collector.py
@@ -163,7 +163,7 @@ class DependencyCollector:
 
     def _sync_assets(self, asset_paths: list[str]):
         """
-        Sync given asset paths via `unreal.SourceControl <https://dev.epicgames.com/documentation/en-us/unreal-engine/python-api/class/SourceControl?application_version=5.3#unreal.SourceControl>`__
+        Sync given asset paths via `unreal.SourceControl <https://dev.epicgames.com/documentation/en-us/unreal-engine/python-api/class/SourceControl?application_version=5.6#unreal.SourceControl>`__
 
         :param asset_paths: List of assets to sync
         """

--- a/src/unreal_plugin/README.md
+++ b/src/unreal_plugin/README.md
@@ -5,7 +5,7 @@
 
 
 ## Requirements
-- Unreal Engine 5.3+
+- Unreal Engine 5.4+
 
 
 ## Installation

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_check_conda_package_ver.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_check_conda_package_ver.py
@@ -39,7 +39,7 @@ class TestCheckCondaPackageVersion:
     )
     def test_check_conda_package_version_conda_packages_no_value(self, get_engine_version_mock):
         # GIVEN
-        get_engine_version_mock.return_value = "5.3.0"
+        get_engine_version_mock.return_value = "5.4.0"
 
         job_parameter_values = [dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="")]
 
@@ -47,14 +47,14 @@ class TestCheckCondaPackageVersion:
         assert UnrealOpenJob.check_conda_package_version(job_parameter_values)
 
         # THEN
-        assert job_parameter_values[0].get("value") == "unrealengine=5.3 unrealengine-openjd=*.*.*"
+        assert job_parameter_values[0].get("value") == "unrealengine=5.4 unrealengine-openjd=*.*.*"
 
     @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.SystemLibrary.get_engine_version"
     )
     def test_check_conda_package_version_no_unrealengine_pattern(self, get_engine_version_mock):
         # GIVEN
-        get_engine_version_mock.return_value = "5.3.0"
+        get_engine_version_mock.return_value = "5.4.0"
 
         job_parameter_values = [
             dict(
@@ -69,7 +69,7 @@ class TestCheckCondaPackageVersion:
         # THEN
         assert (
             job_parameter_values[0].get("value")
-            == "unrealengine=5.3 somepackage=1.0 unrealengine-openjd=0.5.*"
+            == "unrealengine=5.4 somepackage=1.0 unrealengine-openjd=0.5.*"
         )
 
     @patch(
@@ -77,10 +77,10 @@ class TestCheckCondaPackageVersion:
     )
     def test_check_conda_package_version_versions_match(self, get_engine_version_mock):
         # GIVEN
-        get_engine_version_mock.return_value = "5.3"
+        get_engine_version_mock.return_value = "5.4"
 
         job_parameter_values = [
-            dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="unrealengine=5.3")
+            dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="unrealengine=5.4")
         ]
 
         # WHEN
@@ -91,10 +91,10 @@ class TestCheckCondaPackageVersion:
     )
     def test_check_conda_package_version_versions_mismatch(self, get_engine_version_mock):
         # GIVEN
-        get_engine_version_mock.return_value = "5.4"
+        get_engine_version_mock.return_value = "5.5"
 
         job_parameter_values = [
-            dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="unrealengine=5.3")
+            dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="unrealengine=5.4")
         ]
 
         # WHEN
@@ -105,10 +105,10 @@ class TestCheckCondaPackageVersion:
     )
     def test_check_conda_package_version_minor_version_difference(self, get_engine_version_mock):
         # GIVEN
-        get_engine_version_mock.return_value = "5.3.2"
+        get_engine_version_mock.return_value = "5.4.4"
 
         job_parameter_values = [
-            dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="unrealengine=5.3")
+            dict(name=OpenJobParameterNames.CONDA_PACKAGES, value="unrealengine=5.4")
         ]
 
         # WHEN


### PR DESCRIPTION
chore: correct supported UE version

### What was the problem/requirement? (What/Why)
We do not support UE5.3 but our doc and code comments incorrectly state that we do. 

### What was the solution? (How)
Update doc and code comments to reflect what we support

### What is the impact of this change?
Better documentations

### How was this change tested?
- `hatch build`
- `hatch run test`

- Have you run the unit tests?
Yes

```
Required test coverage of 65.0% reached. Total coverage: 68.49%
================================================================ slowest 5 durations =================================================================
0.17s call     test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py::TestUnrealAdaptor_on_start::test_init_data_wrong_schema
0.11s call     test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py::TestUnrealAdaptor_on_start::test_unreal_init_timeout
0.09s call     test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py::TestUnrealAdaptor_on_cleanup::test_raises_if_unreal_not_running
0.08s call     test/test_copyright_headers.py::test_copyright_headers
0.07s call     test/deadline_submitter_for_unreal/unit/test_python397_patch.py::TestPython397Patch::test_patch_skipped_on_other_python_versions
=========================================================== 382 passed, 2 skipped in 6.72s ===========================================================
```

### Have you run a render job successfully with these changes?
No, this change only update doc and unit test. 

### Was this change documented?
This included the doc changes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*