### PR TITLE
docs: Add troubleshooting entry for zip download vs. git clone installation errors

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -183,6 +183,27 @@ Solutions:
    - Resubmit the job using the Unreal Engine version that matches the worker node. On Service Managed Fleets - Ensure the Conda package version selected matches your project's version of Unreal Engine
    - Install the correct Unreal Engine version on the worker node and update environment variables to match the job's Unreal Engine version
 
+### Build Fails Because Repository Was Downloaded as a Zip Instead of Cloned
+
+Root Cause: The repository was downloaded as a zip archive from GitHub (e.g. "Download ZIP") instead of being cloned with `git`. GitHub zip downloads do not include the `.git` folder, which `setuptools-scm` requires to determine the package version.
+
+Running `hatch build` directly will show:
+```
+LookupError: Error getting the version from source `vcs`: setuptools-scm was unable to detect version for <path>.
+
+Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.
+```
+
+Running `scripts/build_plugin.py` will show:
+```
+subprocess.CalledProcessError: Command '['hatch', 'build']' returned non-zero exit status 1.
+```
+
+Solution: Clone the repository using `git clone` instead of downloading the zip:
+```bash
+git clone https://github.com/aws-deadline/deadline-cloud-for-unreal-engine.git
+```
+
 ### Missing Deadline Cloud Job Submission Configuration in Movie Render Queue
 
 Issue: When launching Movie Render Queue, Deadline Cloud job submission configurations are not visible.


### PR DESCRIPTION
docs: Add troubleshooting entry for zip download vs. git clone installation errors

### What was the problem/requirement? (What/Why)
A user reported an installation failure caused by downloading the repository as a ZIP archive instead of cloning it via Git (see [issue #262](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/issues/262)). After a root cause investigation meeting with the user, we identified this as a reproducible scenario that other users are likely to encounter. Documenting it proactively will reduce support burden and help users self-serve.

### What was the solution? (How)
Added a new troubleshooting entry that includes:
- Sample error messages users may encounter
- Root cause explanation (ZIP download vs. Git clone)
- Resolution instructions

### What is the impact of this change?
Users and AI agents can now independently diagnose and resolve this installation issue by following the updated troubleshooting guide.

### How was this change tested?
N/A — documentation-only change. No code was modified.

- **Have you run the unit tests?**
No — this is a documentation-only change.

### Have you run a render job successfully with these changes?
No — this is a documentation-only change.

### Was this change documented?
Yes — this *is* the documentation change.

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*