### PR TITLE
docs: Resolve doc project build errors caused by auth of external link

### DIFF
--- a/docs/user_guide/setup-submitter.md
+++ b/docs/user_guide/setup-submitter.md
@@ -18,7 +18,8 @@ Select the appropriate branch for your deployment:
 If you’re setting up on a brand new Windows EC2 Instance as your submitter, a g5.2xlarge instance with 200 GB of storage will likely be reasonable minimum:
 
 1. Launch EC2 instance with a valid Instance Profile. This is required to download NVIDIA GRID drivers as instructed below.
-1. Download the Epic Installer and install a version of Unreal between versions 5.4 and 5.6. Note that on version 5.5 with DirectX 11 there's a crash bug which can affect projects rendered using the Deadline Cloud plugin which has been fixed in Unreal's source and can be tracked [here](https://issues.unrealengine.com/issue/UE-276282). Projects in Deadline Cloud should use DirectX 12 with UE 5.5.
+1. Download the Epic Installer and install a supported version of Unreal (5.4 - 5.6).
+    - UE 5.5 has a known crash bug when running with the DirectX 11 plugin, see UI issue #UE-276282. If you need DirectX support on UE 5.5, use DirectX 12+.
 1. NVIDIA GRID drivers - Follow Windows instructions - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html#nvidia-GRID-driver
 
 ## Windows Long Paths


### PR DESCRIPTION
docs: Resolve doc project build errors caused by auth of external link

### What was the problem/requirement? (What/Why)
UE doc with external link is causing 403 error when building doc project, see https://github.com/aws-deadline/aws-deadline.github.io/actions/runs/22989177831/job/66746167440

### What was the solution? (How)
The link does not require authentication, but blocks non-human traffic with 403 errors. Remove the direct link from our doc. It's not a critical reference. This is a note for calling out compatibility issue between a popular UE plugin (DirectX) with UE5.5 and provide a workaround.

### What is the impact of this change?
Doc project can be build successfully

### How was this change tested?
NA

- Have you run the unit tests?
No, this is a doc change

### Have you run a render job successfully with these changes?
No, this is a doc change 

### Was this change documented?
Yes, this is a doc change

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*