### PR TITLE
feat: Adding persistent perforce workspace support

### DIFF
--- a/src/deadline/unreal_perforce_utils/app.py
+++ b/src/deadline/unreal_perforce_utils/app.py
@@ -1,5 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+import dataclasses
+import hashlib
 import os
 import json
 import pprint
@@ -12,6 +14,147 @@ from deadline.unreal_logger import get_logger
 from deadline.unreal_perforce_utils import perforce, exceptions, secret_manager
 
 logger = get_logger()
+
+
+@dataclasses.dataclass
+class WorkspaceInfoFile:
+    """Registry of previously created Perforce workspaces, stored as JSON alongside the workspace root."""
+
+    stream_workspaces: dict[str, str] = dataclasses.field(default_factory=dict)
+    view_workspace: Optional[str] = None
+
+    @staticmethod
+    def load(path: str) -> "WorkspaceInfoFile":
+        """Load from JSON file. Returns empty registry on missing/corrupt file."""
+        try:
+            with open(path, "r") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            logger.info(f"Workspace info file not found at {path}, starting with empty registry.")
+            return WorkspaceInfoFile()
+        except json.JSONDecodeError:
+            logger.warning(
+                f"Workspace info file at {path} contains invalid JSON, starting with empty registry."
+            )
+            return WorkspaceInfoFile()
+        except OSError as e:
+            logger.warning(
+                f"Could not read workspace info file at {path}: {e}. Starting with empty registry."
+            )
+            return WorkspaceInfoFile()
+
+        # Validate types — fall back to empty on bad data
+        stream_workspaces = data.get("stream_workspaces", {})
+        view_workspace = data.get("view_workspace")
+
+        if not isinstance(stream_workspaces, dict) or not all(
+            isinstance(k, str) and isinstance(v, str) for k, v in stream_workspaces.items()
+        ):
+            logger.warning(f"Invalid stream_workspaces in {path}, starting with empty registry.")
+            return WorkspaceInfoFile()
+
+        if view_workspace is not None and not isinstance(view_workspace, str):
+            logger.warning(f"Invalid view_workspace in {path}, starting with empty registry.")
+            return WorkspaceInfoFile()
+
+        return WorkspaceInfoFile(
+            stream_workspaces=stream_workspaces,
+            view_workspace=view_workspace,
+        )
+
+    def save(self, path: str) -> None:
+        """Write to JSON file with sorted keys."""
+        data = {
+            "stream_workspaces": self.stream_workspaces,
+            "view_workspace": self.view_workspace,
+        }
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w") as f:
+                json.dump(data, f, sort_keys=True)
+        except OSError as e:
+            logger.error(f"Could not write workspace info file at {path}: {e}")
+
+    def lookup_stream(self, stream_path: str) -> Optional[str]:
+        """Return workspace name for stream path, or None."""
+        return self.stream_workspaces.get(stream_path)
+
+    def lookup_view(self) -> Optional[str]:
+        """Return the single shared view workspace name, or None."""
+        return self.view_workspace
+
+    def register_stream(self, stream_path: str, workspace_name: str) -> None:
+        """Add stream_path -> workspace_name mapping."""
+        self.stream_workspaces[stream_path] = workspace_name
+
+    def register_view(self, workspace_name: str) -> None:
+        """Set the single shared view workspace name."""
+        self.view_workspace = workspace_name
+
+
+def merge_view_mappings(existing_views: list[str], new_views: list[str]) -> list[str]:
+    """
+    Merge new view mappings into existing ones.
+    Appends any mappings from new_views not already present in existing_views.
+    Returns the merged list.
+    """
+    merged = list(existing_views)
+    for view in new_views:
+        if view not in merged:
+            merged.append(view)
+    return merged
+
+
+@dataclasses.dataclass
+class _ResolvedWorkspace:
+    name: str
+    reusing: bool
+
+
+def _stream_path_to_name_component(stream_path: str) -> str:
+    """
+    Convert a P4 stream path like ``//MeerkatDemo/Mainline`` into a human-readable
+    string safe for use in P4 client names and directory names.
+
+    Strips leading ``//``, replaces ``/`` with ``_``, and appends a short hash
+    suffix to avoid collisions when different stream paths produce the same
+    readable portion (e.g. ``//A_B/C`` vs ``//A/B_C``).
+
+    Example: ``//MeerkatDemo/Mainline`` → ``MeerkatDemo_Mainline_a3f2``
+    """
+    readable = stream_path.lstrip("/").replace("/", "_")
+    short_hash = hashlib.sha256(stream_path.encode()).hexdigest()[:4]
+    return f"{readable}_{short_hash}"
+
+
+def _resolve_workspace_name(
+    specification_template: dict,
+    project_name: str,
+    workspace_info: Optional[WorkspaceInfoFile],
+) -> _ResolvedWorkspace:
+    """Determine workspace name, consulting the registry if available."""
+    if workspace_info is not None:
+        if "Stream" in specification_template:
+            stream_path = specification_template["Stream"]
+            existing = workspace_info.lookup_stream(stream_path)
+            if existing:
+                logger.info(f"Reusing existing stream workspace: {existing}")
+                return _ResolvedWorkspace(name=existing, reusing=True)
+            stream_component = _stream_path_to_name_component(stream_path)
+            name = get_workspace_name(project_name=stream_component)
+            workspace_info.register_stream(stream_path, name)
+            return _ResolvedWorkspace(name=name, reusing=False)
+
+        if "View" in specification_template:
+            existing = workspace_info.lookup_view()
+            if existing:
+                logger.info(f"Reusing existing view workspace: {existing}")
+                return _ResolvedWorkspace(name=existing, reusing=True)
+            name = get_workspace_name(project_name=project_name)
+            workspace_info.register_view(name)
+            return _ResolvedWorkspace(name=name, reusing=False)
+
+    return _ResolvedWorkspace(name=get_workspace_name(project_name=project_name), reusing=False)
 
 
 def get_workspace_name(project_name: str) -> str:
@@ -73,6 +216,10 @@ def create_perforce_workspace_from_template(
     Replace ``{workspace_name}`` token in the template with the real workspace name in
     ``"Client"`` and ``"View"`` fields
 
+    When ``P4_CLIENTS_ROOT_DIRECTORY`` is set, consults a workspace registry file
+    (``workspace_info.json``) to reuse previously created workspaces instead of
+    always creating new ones.
+
     :param specification_template: Workspace specification template dictionary
     :param project_name: Name of the project to build workspace name
     :param overridden_workspace_root: Workspace local path root (Optional, root from template is used by default)
@@ -88,7 +235,18 @@ def create_perforce_workspace_from_template(
         f"Overridden workspace root: {overridden_workspace_root}"
     )
 
-    workspace_name = get_workspace_name(project_name=project_name)
+    persistent_root = os.getenv("P4_CLIENTS_ROOT_DIRECTORY")
+    workspace_info = None
+    workspace_info_path = None
+
+    if persistent_root:
+        # NOTE: Assumes single worker/session/adaptor per clients root — no file locking needed.
+        workspace_info_path = os.path.join(persistent_root, "workspace_info.json")
+        workspace_info = WorkspaceInfoFile.load(workspace_info_path)
+
+    resolved = _resolve_workspace_name(specification_template, project_name, workspace_info)
+    workspace_name = resolved.name
+    reusing = resolved.reusing
 
     specification_template["Client"] = specification_template["Client"].replace(
         "{workspace_name}", workspace_name
@@ -106,15 +264,33 @@ def create_perforce_workspace_from_template(
             f"{os.getenv('P4_CLIENTS_ROOT_DIRECTORY', os.getcwd())}/{workspace_name}"
         )
 
+    # Clear Host lock for reusable workspaces so they can be used from any host
+    if persistent_root:
+        specification_template["Host"] = ""
+
     logger.info(f"Specification: {specification_template}")
 
+    connection = perforce.PerforceConnection()
+
+    if reusing and "View" in specification_template:
+        # Stream workspaces: no view merge needed — P4 derives the view from the stream definition.
+        # View workspaces: merge with existing spec to preserve mappings from prior jobs.
+        existing_spec = connection.p4.fetch_client(workspace_name)
+        existing_views = existing_spec.get("View", [])
+        new_views = specification_template["View"]
+        merged_views = merge_view_mappings(existing_views, new_views)
+        specification_template["View"] = merged_views
+
     perforce_client = perforce.PerforceClient(
-        connection=perforce.PerforceConnection(),
+        connection=connection,
         name=workspace_name,
         specification=specification_template,
     )
 
     perforce_client.save()
+
+    if workspace_info is not None and workspace_info_path is not None:
+        workspace_info.save(workspace_info_path)
 
     logger.info("Perforce workspace created!")
     logger.info(pprint.pformat(perforce_client.spec))
@@ -363,8 +539,8 @@ def clear_workspace_files(
 def delete_workspace(workspace_name: Optional[str] = None, project_name: Optional[str] = None):
     """
     Clear workspace files in the depot and delete the workspace.
-    If the `P4_CLIENTS_ROOT_DIRECTORY` environment variable is set, skip deletion. This indicates
-    that the workspaces are located in a permanent directory and should not be deleted.
+    If the `P4_CLIENTS_ROOT_DIRECTORY` environment variable is set, skip deletion — workspaces
+    under that root are intended to be reused across jobs.
 
     Roll back all possible changes in reverse order:
     Delete worksapce <- Delete local files <- Revert changes
@@ -378,7 +554,9 @@ def delete_workspace(workspace_name: Optional[str] = None, project_name: Optiona
     """
 
     if "P4_CLIENTS_ROOT_DIRECTORY" in os.environ:
-        logger.info("P4_CLIENTS_ROOT_DIRECTORY variable found. Skip deleting the workspace")
+        logger.info(
+            "P4_CLIENTS_ROOT_DIRECTORY is set — skipping workspace deletion (reusable workspace)"
+        )
         return
 
     logger.info(f"Deleting workspace for the project: {project_name}")

--- a/test/deadline_perforce_utils_for_unreal/test_workspace_info.py
+++ b/test/deadline_perforce_utils_for_unreal/test_workspace_info.py
@@ -1,0 +1,560 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deadline.unreal_perforce_utils.app import (
+    WorkspaceInfoFile,
+    _stream_path_to_name_component,
+    create_perforce_workspace_from_template,
+    merge_view_mappings,
+)
+
+
+class TestWorkspaceInfoFileProperties:
+    """Tests for WorkspaceInfoFile and merge_view_mappings."""
+
+    @pytest.mark.parametrize(
+        "stream_workspaces, view_workspace",
+        [
+            ({}, None),
+            ({"//Stream/Main": "ws_1"}, None),
+            ({}, "ws_2"),
+            (
+                {"//Stream/Main": "ws_1", "//Stream/Dev": "ws_2"},
+                "ws_shared",
+            ),
+            ({"//a/b": "x", "//c/d": "y", "//e/f": "z"}, "w_view"),
+        ],
+    )
+    def test_serialization_round_trip(self, stream_workspaces, view_workspace, tmp_path):
+        """
+        Property 1: WorkspaceInfoFile serialization round-trip.
+        Validates: Requirements 1.5, 7.3
+        """
+        original = WorkspaceInfoFile(
+            stream_workspaces=stream_workspaces,
+            view_workspace=view_workspace,
+        )
+
+        file_path = str(tmp_path / "workspace_info.json")
+        original.save(file_path)
+        loaded = WorkspaceInfoFile.load(file_path)
+
+        assert loaded.stream_workspaces == original.stream_workspaces
+        assert loaded.view_workspace == original.view_workspace
+
+    @pytest.mark.parametrize(
+        "stream_workspaces, view_workspace",
+        [
+            ({}, None),
+            ({"//S/M": "ws1"}, "ws2"),
+            (
+                {"//a/b": "x", "//c/d": "y"},
+                "w_shared",
+            ),
+        ],
+    )
+    def test_serialized_schema_invariant(self, stream_workspaces, view_workspace, tmp_path):
+        """
+        Property 2: Serialized schema invariant.
+        Validates: Requirements 1.2, 7.1, 7.2
+        """
+        info = WorkspaceInfoFile(
+            stream_workspaces=stream_workspaces,
+            view_workspace=view_workspace,
+        )
+
+        file_path_1 = str(tmp_path / "workspace_info_1.json")
+        info.save(file_path_1)
+
+        with open(file_path_1, "r") as f:
+            raw_content_1 = f.read()
+        parsed = json.loads(raw_content_1)
+
+        assert set(parsed.keys()) == {"stream_workspaces", "view_workspace"}
+        assert isinstance(parsed["stream_workspaces"], dict)
+        for k, v in parsed["stream_workspaces"].items():
+            assert isinstance(k, str)
+            assert isinstance(v, str)
+        assert parsed["view_workspace"] is None or isinstance(parsed["view_workspace"], str)
+
+        # Deterministic: serialize twice, get identical output
+        file_path_2 = str(tmp_path / "workspace_info_2.json")
+        info.save(file_path_2)
+        with open(file_path_2, "r") as f:
+            raw_content_2 = f.read()
+        assert raw_content_1 == raw_content_2
+
+    @pytest.mark.parametrize(
+        "stream_workspaces, lookup_key",
+        [
+            ({"//MeerkatDemo/Mainline": "ws_meerkat"}, "//MeerkatDemo/Mainline"),
+            (
+                {"//A/B": "ws_a", "//C/D": "ws_c", "//E/F": "ws_e"},
+                "//C/D",
+            ),
+        ],
+    )
+    def test_stream_workspace_reuse_returns_registered_name(self, stream_workspaces, lookup_key):
+        """
+        Property 3: Stream workspace reuse returns registered name.
+        Validates: Requirements 2.1, 2.2
+        """
+        info = WorkspaceInfoFile(stream_workspaces=stream_workspaces)
+        assert info.lookup_stream(lookup_key) == stream_workspaces[lookup_key]
+
+    def test_stream_workspace_lookup_missing_returns_none(self):
+        info = WorkspaceInfoFile(stream_workspaces={"//A/B": "ws"})
+        assert info.lookup_stream("//missing") is None
+
+    @pytest.mark.parametrize(
+        "view_workspace",
+        [
+            "ws_meerkat",
+            "ws_shared_view",
+        ],
+    )
+    def test_view_workspace_reuse_returns_registered_name(self, view_workspace):
+        """
+        Property 4: View workspace reuse returns registered name.
+        Validates: Requirements 3.1, 3.2
+        """
+        info = WorkspaceInfoFile(view_workspace=view_workspace)
+        assert info.lookup_view() == view_workspace
+
+    def test_view_workspace_lookup_missing_returns_none(self):
+        info = WorkspaceInfoFile()
+        assert info.lookup_view() is None
+
+    @pytest.mark.parametrize(
+        "initial_streams, initial_view, new_stream_key, new_stream_val, new_view_val",
+        [
+            ({}, None, "//New/Stream", "ws_new_s", "ws_new_v"),
+            (
+                {"//Existing/S": "ws_e"},
+                "ws_ep",
+                "//Brand/New",
+                "ws_bn",
+                "ws_bnp",
+            ),
+        ],
+    )
+    def test_registry_updated_after_new_workspace_creation(
+        self,
+        initial_streams,
+        initial_view,
+        new_stream_key,
+        new_stream_val,
+        new_view_val,
+    ):
+        """
+        Property 5: Registry updated after new workspace creation.
+        Validates: Requirements 1.4, 2.3, 3.3
+        """
+        info = WorkspaceInfoFile(
+            stream_workspaces=dict(initial_streams),
+            view_workspace=initial_view,
+        )
+
+        info.register_stream(new_stream_key, new_stream_val)
+        assert info.lookup_stream(new_stream_key) == new_stream_val
+
+        info.register_view(new_view_val)
+        assert info.lookup_view() == new_view_val
+
+    @pytest.mark.parametrize(
+        "existing_views, new_views",
+        [
+            ([], []),
+            (["//A/... //ws/..."], []),
+            ([], ["//B/... //ws/..."]),
+            (
+                ["//A/... //ws/..."],
+                ["//B/... //ws/..."],
+            ),
+            (
+                ["//A/... //ws/...", "//B/... //ws/..."],
+                ["//B/... //ws/...", "//C/... //ws/..."],
+            ),
+        ],
+    )
+    def test_view_merge_appends_new_mappings(self, existing_views, new_views):
+        """
+        Property 6: View merge appends new mappings.
+        Validates: Requirements 4.2
+        """
+        result = merge_view_mappings(existing_views, new_views)
+        for entry in existing_views:
+            assert entry in result
+        for entry in new_views:
+            assert entry in result
+
+    @pytest.mark.parametrize(
+        "views",
+        [
+            [],
+            ["//A/... //ws/..."],
+            ["//A/... //ws/...", "//B/... //ws/..."],
+            ["//A/... //ws/...", "//B/... //ws/...", "//C/... //ws/..."],
+        ],
+    )
+    def test_view_merge_idempotence(self, views):
+        """
+        Property 7: View merge idempotence.
+        Validates: Requirements 4.3
+        """
+        result = merge_view_mappings(views, views)
+        assert result == views
+
+    @pytest.mark.parametrize(
+        "stream_path, expected_readable, expected_suffix_len",
+        [
+            ("//MeerkatDemo/Mainline", "MeerkatDemo_Mainline", 4),
+            ("//MeerkatDemo/Dev", "MeerkatDemo_Dev", 4),
+            ("//A/B/C", "A_B_C", 4),
+        ],
+    )
+    def test_stream_path_to_name_component(
+        self, stream_path, expected_readable, expected_suffix_len
+    ):
+        """Stream paths are converted to readable name components with a hash suffix."""
+        result = _stream_path_to_name_component(stream_path)
+        # Should start with the readable portion
+        assert result.startswith(expected_readable + "_")
+        # Should end with a short hex hash
+        suffix = result[len(expected_readable) + 1 :]
+        assert len(suffix) == expected_suffix_len
+        int(suffix, 16)  # Should be valid hex
+
+    def test_stream_path_to_name_component_different_paths_differ(self):
+        """Different stream paths produce different name components."""
+        a = _stream_path_to_name_component("//MeerkatDemo/Mainline")
+        b = _stream_path_to_name_component("//MeerkatDemo/Dev")
+        assert a != b
+
+    def test_stream_path_to_name_component_ambiguous_paths_differ(self):
+        """Paths that look the same after slash replacement are disambiguated by hash."""
+        a = _stream_path_to_name_component("//A_B/C")
+        b = _stream_path_to_name_component("//A/B_C")
+        # Both have readable portion A_B_C but different hash suffixes
+        assert a != b
+
+
+class TestCreateWorkspaceFromTemplatePersistence:
+    """Unit tests for reusable workspace behavior in create_perforce_workspace_from_template."""
+
+    # --- Task 3.2: Non-reusable behavior unchanged ---
+
+    @patch("deadline.unreal_perforce_utils.app.perforce")
+    @patch("deadline.unreal_perforce_utils.app.get_workspace_name", return_value="user_host_proj")
+    def test_no_clients_root_creates_new_workspace(self, mock_get_name, mock_perforce):
+        """When P4_CLIENTS_ROOT_DIRECTORY is not set, existing behavior is preserved."""
+        mock_client = MagicMock()
+        mock_perforce.PerforceClient.return_value = mock_client
+        mock_perforce.PerforceConnection.return_value = MagicMock()
+
+        template = {
+            "Client": "{workspace_name}",
+            "Root": "D:/workspace",
+            "Stream": "//MeerkatDemo/Mainline",
+        }
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = create_perforce_workspace_from_template(template, "MeerkatDemo")
+
+        mock_get_name.assert_called_once_with(project_name="MeerkatDemo")
+        mock_perforce.PerforceClient.assert_called_once()
+        mock_client.save.assert_called_once()
+        assert result is mock_client
+
+    @patch("deadline.unreal_perforce_utils.app.perforce")
+    @patch("deadline.unreal_perforce_utils.app.get_workspace_name", return_value="user_host_proj")
+    def test_no_clients_root_does_not_read_or_write_workspace_info(
+        self, mock_get_name, mock_perforce
+    ):
+        """When P4_CLIENTS_ROOT_DIRECTORY is not set, no workspace_info.json I/O occurs."""
+        mock_perforce.PerforceClient.return_value = MagicMock()
+        mock_perforce.PerforceConnection.return_value = MagicMock()
+
+        template = {
+            "Client": "{workspace_name}",
+            "Root": "D:/workspace",
+            "Stream": "//MeerkatDemo/Mainline",
+        }
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("builtins.open", side_effect=AssertionError("should not open files")):
+                # open() should never be called for workspace_info.json
+                create_perforce_workspace_from_template(template, "MeerkatDemo")
+
+    # --- Task 3.3: Stream workspace reuse flow ---
+
+    @patch("deadline.unreal_perforce_utils.app.perforce")
+    @patch("deadline.unreal_perforce_utils.app.get_workspace_name", return_value="new_ws_name")
+    def test_stream_reuse_existing_workspace(self, mock_get_name, mock_perforce, tmp_path):
+        """When stream path is in registry, reuse existing workspace name."""
+        mock_client = MagicMock()
+        mock_perforce.PerforceClient.return_value = mock_client
+        mock_perforce.PerforceConnection.return_value = MagicMock()
+
+        # Pre-populate registry
+        info = WorkspaceInfoFile(
+            stream_workspaces={"//MeerkatDemo/Mainline": "existing_ws"},
+        )
+        info_path = str(tmp_path / "workspace_info.json")
+        info.save(info_path)
+
+        template = {
+            "Client": "{workspace_name}",
+            "Root": "D:/workspace",
+            "Stream": "//MeerkatDemo/Mainline",
+        }
+
+        with patch.dict(os.environ, {"P4_CLIENTS_ROOT_DIRECTORY": str(tmp_path)}, clear=True):
+            create_perforce_workspace_from_template(template, "MeerkatDemo")
+
+        # Should NOT call get_workspace_name since we're reusing
+        mock_get_name.assert_not_called()
+        # PerforceClient should be created with the existing workspace name
+        call_kwargs = mock_perforce.PerforceClient.call_args
+        assert call_kwargs[1]["name"] == "existing_ws"
+        mock_client.save.assert_called_once()
+
+    @patch("deadline.unreal_perforce_utils.app.perforce")
+    @patch("deadline.unreal_perforce_utils.app.get_workspace_name", return_value="new_ws_name")
+    def test_stream_new_workspace_registered(self, mock_get_name, mock_perforce, tmp_path):
+        """When stream path is NOT in registry, create new workspace and register it."""
+        mock_client = MagicMock()
+        mock_perforce.PerforceClient.return_value = mock_client
+        mock_perforce.PerforceConnection.return_value = MagicMock()
+
+        # Empty registry
+        info = WorkspaceInfoFile()
+        info_path = str(tmp_path / "workspace_info.json")
+        info.save(info_path)
+
+        template = {
+            "Client": "{workspace_name}",
+            "Root": "D:/workspace",
+            "Stream": "//MeerkatDemo/Mainline",
+        }
+
+        with patch.dict(os.environ, {"P4_CLIENTS_ROOT_DIRECTORY": str(tmp_path)}, clear=True):
+            create_perforce_workspace_from_template(template, "MeerkatDemo")
+
+        # When reusing workspaces, stream workspaces use stream-derived name component
+        expected_component = _stream_path_to_name_component("//MeerkatDemo/Mainline")
+        mock_get_name.assert_called_once_with(project_name=expected_component)
+
+        # Verify registry was updated
+        loaded = WorkspaceInfoFile.load(info_path)
+        assert loaded.lookup_stream("//MeerkatDemo/Mainline") == "new_ws_name"
+
+    # --- Task 3.4: View workspace reuse flow ---
+
+    @patch("deadline.unreal_perforce_utils.app.perforce")
+    @patch("deadline.unreal_perforce_utils.app.get_workspace_name", return_value="new_ws_name")
+    def test_view_reuse_existing_workspace_merges_views(
+        self, mock_get_name, mock_perforce, tmp_path
+    ):
+        """When view workspace exists in registry, reuse workspace, fetch existing spec, merge views."""
+        mock_connection = MagicMock()
+        mock_perforce.PerforceConnection.return_value = mock_connection
+        # Simulate existing spec on P4 server with one view
+        mock_connection.p4.fetch_client.return_value = {
+            "Client": "existing_ws",
+            "View": ["//MeerkatDemo/Mainline/... //existing_ws/..."],
+        }
+        mock_client = MagicMock()
+        mock_perforce.PerforceClient.return_value = mock_client
+
+        # Pre-populate registry with single view workspace
+        info = WorkspaceInfoFile(
+            view_workspace="existing_ws",
+        )
+        info_path = str(tmp_path / "workspace_info.json")
+        info.save(info_path)
+
+        template = {
+            "Client": "{workspace_name}",
+            "Root": "D:/workspace",
+            "View": [
+                "//MeerkatDemo/Mainline/... //{workspace_name}/...",
+                "//Plugins/Mainline/... //{workspace_name}/Plugins/...",
+            ],
+        }
+
+        with patch.dict(os.environ, {"P4_CLIENTS_ROOT_DIRECTORY": str(tmp_path)}, clear=True):
+            create_perforce_workspace_from_template(template, "MeerkatDemo")
+
+        mock_get_name.assert_not_called()
+        # fetch_client should have been called to get existing spec
+        mock_connection.p4.fetch_client.assert_called_with("existing_ws")
+        # The merged views should contain both existing and new
+        call_kwargs = mock_perforce.PerforceClient.call_args[1]
+        spec_views = call_kwargs["specification"]["View"]
+        assert "//MeerkatDemo/Mainline/... //existing_ws/..." in spec_views
+        assert "//Plugins/Mainline/... //existing_ws/Plugins/..." in spec_views
+
+    @patch("deadline.unreal_perforce_utils.app.perforce")
+    @patch("deadline.unreal_perforce_utils.app.get_workspace_name", return_value="new_ws_name")
+    def test_view_new_workspace_registered(self, mock_get_name, mock_perforce, tmp_path):
+        """When no view workspace in registry, create new workspace and register it."""
+        mock_client = MagicMock()
+        mock_perforce.PerforceClient.return_value = mock_client
+        mock_perforce.PerforceConnection.return_value = MagicMock()
+
+        info = WorkspaceInfoFile()
+        info_path = str(tmp_path / "workspace_info.json")
+        info.save(info_path)
+
+        template = {
+            "Client": "{workspace_name}",
+            "Root": "D:/workspace",
+            "View": ["//MeerkatDemo/Mainline/... //{workspace_name}/..."],
+        }
+
+        with patch.dict(os.environ, {"P4_CLIENTS_ROOT_DIRECTORY": str(tmp_path)}, clear=True):
+            create_perforce_workspace_from_template(template, "MeerkatDemo")
+
+        mock_get_name.assert_called_once()
+        loaded = WorkspaceInfoFile.load(info_path)
+        assert loaded.lookup_view() == "new_ws_name"
+
+    # --- Task 3.5: Error handling ---
+
+    @pytest.mark.parametrize(
+        "bad_data",
+        [
+            {"stream_workspaces": "not_a_dict", "view_workspace": None},
+            {"stream_workspaces": {"ok": 123}, "view_workspace": None},
+            {"stream_workspaces": {}, "view_workspace": 42},
+        ],
+    )
+    def test_load_invalid_types_logs_warning_returns_empty(self, bad_data, tmp_path):
+        """WorkspaceInfoFile.load() with valid JSON but wrong types returns empty registry."""
+        path = str(tmp_path / "workspace_info.json")
+        with open(path, "w") as f:
+            json.dump(bad_data, f)
+
+        with patch("deadline.unreal_perforce_utils.app.logger") as mock_logger:
+            result = WorkspaceInfoFile.load(path)
+
+        assert result.stream_workspaces == {}
+        assert result.view_workspace is None
+        mock_logger.warning.assert_called_once()
+
+    def test_load_invalid_json_logs_warning_returns_empty(self, tmp_path):
+        """WorkspaceInfoFile.load() with invalid JSON logs warning and returns empty registry."""
+        bad_path = str(tmp_path / "workspace_info.json")
+        with open(bad_path, "w") as f:
+            f.write("not valid json {{{")
+
+        with patch("deadline.unreal_perforce_utils.app.logger") as mock_logger:
+            result = WorkspaceInfoFile.load(bad_path)
+
+        assert result.stream_workspaces == {}
+        assert result.view_workspace is None
+        mock_logger.warning.assert_called_once()
+
+    def test_load_fs_error_logs_warning_returns_empty(self, tmp_path):
+        """WorkspaceInfoFile.load() with FS read error logs warning and returns empty registry."""
+        with patch("builtins.open", side_effect=PermissionError("access denied")):
+            with patch("deadline.unreal_perforce_utils.app.logger") as mock_logger:
+                result = WorkspaceInfoFile.load("/some/path/workspace_info.json")
+
+        assert result.stream_workspaces == {}
+        assert result.view_workspace is None
+        mock_logger.warning.assert_called_once()
+
+    def test_save_fs_error_logs_error_does_not_raise(self, tmp_path):
+        """WorkspaceInfoFile.save() with FS write error logs error and does not raise."""
+        info = WorkspaceInfoFile(stream_workspaces={"a": "b"})
+
+        with patch("builtins.open", side_effect=PermissionError("access denied")):
+            with patch("deadline.unreal_perforce_utils.app.logger") as mock_logger:
+                # Should not raise
+                info.save("/some/readonly/path/workspace_info.json")
+
+        mock_logger.error.assert_called_once()
+
+    @patch("deadline.unreal_perforce_utils.app.perforce")
+    @patch(
+        "deadline.unreal_perforce_utils.app.get_workspace_name",
+        side_effect=lambda project_name: f"mock_ws_{project_name}",
+    )
+    def test_different_streams_get_different_workspace_names(
+        self, mock_get_name, mock_perforce, tmp_path
+    ):
+        """Two different stream paths on the same worker produce different workspace names."""
+        mock_perforce.PerforceClient.return_value = MagicMock()
+        mock_perforce.PerforceConnection.return_value = MagicMock()
+
+        info = WorkspaceInfoFile()
+        info_path = str(tmp_path / "workspace_info.json")
+        info.save(info_path)
+
+        with patch.dict(os.environ, {"P4_CLIENTS_ROOT_DIRECTORY": str(tmp_path)}, clear=True):
+            template1 = {
+                "Client": "{workspace_name}",
+                "Root": "D:/workspace",
+                "Stream": "//MeerkatDemo/Mainline",
+            }
+            create_perforce_workspace_from_template(template1, "MeerkatDemo")
+
+            template2 = {
+                "Client": "{workspace_name}",
+                "Root": "D:/workspace",
+                "Stream": "//MeerkatDemo/Dev",
+            }
+            create_perforce_workspace_from_template(template2, "MeerkatDemo")
+
+        loaded = WorkspaceInfoFile.load(info_path)
+        mainline_ws = loaded.lookup_stream("//MeerkatDemo/Mainline")
+        dev_ws = loaded.lookup_stream("//MeerkatDemo/Dev")
+        assert mainline_ws is not None
+        assert dev_ws is not None
+        assert mainline_ws != dev_ws
+
+    @patch("deadline.unreal_perforce_utils.app.perforce")
+    @patch("deadline.unreal_perforce_utils.app.get_workspace_name", return_value="new_ws")
+    def test_reusable_workspace_clears_host_field(self, mock_get_name, mock_perforce, tmp_path):
+        """When P4_CLIENTS_ROOT_DIRECTORY is set, Host field is cleared for host portability."""
+        mock_client = MagicMock()
+        mock_perforce.PerforceClient.return_value = mock_client
+        mock_perforce.PerforceConnection.return_value = MagicMock()
+
+        template = {
+            "Client": "{workspace_name}",
+            "Root": "D:/workspace",
+            "Stream": "//MeerkatDemo/Mainline",
+        }
+
+        with patch.dict(os.environ, {"P4_CLIENTS_ROOT_DIRECTORY": str(tmp_path)}, clear=True):
+            create_perforce_workspace_from_template(template, "MeerkatDemo")
+
+        call_kwargs = mock_perforce.PerforceClient.call_args[1]
+        assert call_kwargs["specification"]["Host"] == ""
+
+    @patch("deadline.unreal_perforce_utils.app.perforce")
+    @patch("deadline.unreal_perforce_utils.app.get_workspace_name", return_value="new_ws")
+    def test_no_clients_root_does_not_clear_host_field(self, mock_get_name, mock_perforce):
+        """When P4_CLIENTS_ROOT_DIRECTORY is not set, Host field is not touched."""
+        mock_client = MagicMock()
+        mock_perforce.PerforceClient.return_value = mock_client
+        mock_perforce.PerforceConnection.return_value = MagicMock()
+
+        template = {
+            "Client": "{workspace_name}",
+            "Root": "D:/workspace",
+            "Stream": "//MeerkatDemo/Mainline",
+        }
+
+        with patch.dict(os.environ, {}, clear=True):
+            create_perforce_workspace_from_template(template, "MeerkatDemo")
+
+        call_kwargs = mock_perforce.PerforceClient.call_args[1]
+        assert "Host" not in call_kwargs["specification"]


### PR DESCRIPTION
- Added WorkspaceInfoFile dataclass with load/save/lookup/register methods
- Added merge_view_mappings helper function
- Added parametrized pytest tests covering all 7 correctness properties
- Modified create_perforce_workspace_from_template to check P4_CLIENTS_ROOT_DIRECTORY
- Stream workspaces: lookup by stream path, reuse if found, register if new
- View workspaces: single shared workspace which adds new view paths as discovered/used
- Non-persistent behavior unchanged when env var is not set
- Added unit tests for all reuse flows and error handling
- Set Host='' in spec when P4_CLIENTS_ROOT_DIRECTORY is set
- Added tests for Host field behavior in both persistent and non-persistent modes

### What was the problem/requirement? (What/Why)
When creating perforce clients on workers we want to try to persist the client name(s) and views in order to minimize recreation of clients or redownloading of assets in cases where the workspace is persisted between jobs.

### What was the solution? (How)
Write out a data file after a client is created/update with records of the clients created and the views used.  When initializing a perforce workspace, check for this file first and reuse clients where possible before trying to create a new one.

### What is the impact of this change?
Better persistence and reuse of clients between jobs where possible.

### How was this change tested?
All unit tests pass

Submitted perforce jobs to new and reused workers/clients.

### Have you run a render job successfully with these changes?
Yes

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*