### PR TITLE
feat: Notify customers if newer submitter is available.

### DIFF
--- a/docs/user_guide/setup-submitter.md
+++ b/docs/user_guide/setup-submitter.md
@@ -210,7 +210,9 @@ This example will use the Meerkat Demo from the Unreal Marketplace:
 
 The submitter plugin automatically checks for newer releases on GitHub when Unreal Editor starts. If an update is available, a dialog will prompt you to visit the release page.
 
-To deactivate update notifications:
+To deactivate update notifications, uncheck "Show submitter update notifications" under "General Settings" in the Deadline Cloud settings panel (Edit > Project Settings > Plugins > Deadline Cloud).
+
+Alternatively, you can use the CLI:
 
 ```
 deadline config set settings.submitter_update_notification false

--- a/docs/user_guide/setup-submitter.md
+++ b/docs/user_guide/setup-submitter.md
@@ -204,3 +204,20 @@ This example will use the Meerkat Demo from the Unreal Marketplace:
 		
 	1. Ready to Go! Hit "Render (Remote)". 
 1. You can go to Deadline Cloud Monitor and watch the progress of your job. 
+
+
+# Update Notifications
+
+The submitter plugin automatically checks for newer releases on GitHub when Unreal Editor starts. If an update is available, a dialog will prompt you to visit the release page.
+
+To deactivate update notifications:
+
+```
+deadline config set settings.submitter_update_notification false
+```
+
+To re-enable:
+
+```
+deadline config set settings.submitter_update_notification true
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.51,< 0.54",
+    "deadline >= 0.55.1,< 0.56",
     "openjd-adaptor-runtime >= 0.8.1,< 0.10",
     "openjd-model >= 0.8.1, < 0.10",
     "p4python == 2025.1.2767466",

--- a/src/unreal_plugin/Content/Python/init_unreal.py
+++ b/src/unreal_plugin/Content/Python/init_unreal.py
@@ -162,6 +162,10 @@ if remote_execution != "True":
 
     logger.info("INIT DEADLINE CLOUD")
 
+    from update_check import safe_check_and_show_update_dialog
+
+    safe_check_and_show_update_dialog()
+
     logger.info(f'DEADLINE CLOUD PATH: {os.getenv("DEADLINE_CLOUD")}')
 
     # These unused imports are REQUIRED!!!

--- a/src/unreal_plugin/Content/Python/settings.py
+++ b/src/unreal_plugin/Content/Python/settings.py
@@ -337,6 +337,13 @@ class DeadlineCloudSettingsLibraryImplementation(unreal.DeadlineCloudSettingsLib
             config=config_parser,
         )
 
+        # general.show_update_notifications (settings.submitter_update_notification)
+        config.set_setting(
+            "settings.submitter_update_notification",
+            "true" if settings.general.show_update_notifications else "false",
+            config=config_parser,
+        )
+
         config_file.write_config(config_parser)
 
         if farm_queue_update:

--- a/src/unreal_plugin/Content/Python/update_check.py
+++ b/src/unreal_plugin/Content/Python/update_check.py
@@ -1,0 +1,151 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Update checker for the Deadline Cloud for Unreal Engine plugin.
+
+Checks the GitHub releases API for a newer version and shows an Unreal
+Editor dialog when an update is available.  Respects the Deadline Cloud
+``settings.submitter_update_notification`` config toggle.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import ssl
+import urllib.request
+import urllib.error
+import webbrowser
+
+import botocore
+import unreal
+
+from packaging.version import Version, InvalidVersion
+
+from deadline.client.config import config_file
+from deadline.unreal_submitter._version import version as _current_version
+
+logger = logging.getLogger(__name__)
+
+GITHUB_LATEST_RELEASE_URL = (
+    "https://api.github.com/repos/aws-deadline/deadline-cloud-for-unreal-engine/releases/latest"
+)
+RELEASES_PAGE_URL = "https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/releases"
+_REQUEST_TIMEOUT_SECONDS = 5
+
+
+def _is_update_notification_enabled() -> bool:
+    """Check whether the user has opted in to update notifications."""
+    return config_file.str2bool(config_file.get_setting("settings.submitter_update_notification"))
+
+
+def _get_current_version() -> str:
+    """Return the currently installed plugin version string."""
+    return _current_version
+
+
+def _fetch_latest_version() -> str | None:
+    """Fetch the latest release tag from GitHub.
+
+    Returns:
+        The version string (e.g. ``"0.6.5"``) or ``None`` on failure.
+    """
+    # Pin to GitHub REST API v3 JSON format so the response shape stays stable.
+    req = urllib.request.Request(
+        GITHUB_LATEST_RELEASE_URL,
+        headers={"Accept": "application/vnd.github.v3+json"},
+    )
+
+    # Build a strict TLS context: enforce TLS 1.2+ and use the botocore CA
+    # bundle so certificate verification works even in embedded Python
+    # environments (e.g. Unreal) that may lack system root certificates.
+    ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+    ctx.load_verify_locations(_get_botocore_ca_bundle())
+
+    try:
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS, context=ctx) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            tag = data.get("tag_name", "")
+            return tag.lstrip("v") if tag else None
+    except urllib.error.URLError:
+        return None
+    except (socket.timeout, TimeoutError):
+        return None
+    except json.JSONDecodeError:
+        return None
+
+
+def _get_botocore_ca_bundle() -> str:
+    """Return the path to botocore's bundled CA certificate bundle."""
+    return os.path.join(os.path.dirname(botocore.__file__), "cacert.pem")
+
+
+def _is_update_available(current: str, latest: str) -> bool:
+    """Return True if *latest* is strictly newer than *current*."""
+    try:
+        return Version(latest) > Version(current)
+    except InvalidVersion:
+        return False
+
+
+def safe_check_and_show_update_dialog() -> bool:
+    """Check GitHub for a newer release and show an Unreal dialog if found.
+
+    Returns:
+        ``True`` if the user chose to open the download page (caller may
+        want to skip opening the submitter), ``False`` otherwise.
+    """
+    try:
+        return _check_and_show_update_dialog()
+    except Exception:
+        logger.debug("Update check failed -- skipping", exc_info=True)
+        return False
+
+
+def _check_and_show_update_dialog() -> bool:
+    """Internal implementation of the update check and dialog flow."""
+    if not _is_update_notification_enabled():
+        return False
+
+    current_version = _get_current_version()
+
+    latest_version = _fetch_latest_version()
+
+    if not latest_version:
+        return False
+
+    if not _is_update_available(current_version, latest_version):
+        return False
+
+    message = (
+        f"Version {latest_version} of Deadline Cloud for Unreal Engine "
+        f"submitter is now available.\n\n"
+        f"Current: {current_version}  ->  New: {latest_version}\n\n"
+        f"View release notes:\n{RELEASES_PAGE_URL}\n\n"
+        "Click 'Yes' to be redirected to the release page, or 'No' to dismiss."
+    )
+
+    response = unreal.EditorDialog.show_message(
+        "New version available",
+        message,
+        unreal.AppMsgType.YES_NO,
+    )
+
+    if response == unreal.AppReturnType.YES:
+        try:
+            webbrowser.open(RELEASES_PAGE_URL)
+        except Exception:
+            return False
+
+        unreal.EditorDialog.show_message(
+            "Application Restart Required",
+            "Please install the new release and then restart Unreal Engine "
+            "to use the new version.",
+            unreal.AppMsgType.OK,
+        )
+        return True
+
+    return False

--- a/src/unreal_plugin/Content/Python/update_check.py
+++ b/src/unreal_plugin/Content/Python/update_check.py
@@ -33,6 +33,7 @@ GITHUB_LATEST_RELEASE_URL = (
     "https://api.github.com/repos/aws-deadline/deadline-cloud-for-unreal-engine/releases/latest"
 )
 RELEASES_PAGE_URL = "https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/releases"
+SETUP_GUIDE_URL = "https://aws-deadline.github.io/unreal-engine/setup-submitter/"
 _REQUEST_TIMEOUT_SECONDS = 5
 
 
@@ -125,7 +126,10 @@ def _check_and_show_update_dialog() -> bool:
         f"submitter is now available.\n\n"
         f"Current: {current_version}  ->  New: {latest_version}\n\n"
         f"View release notes:\n{RELEASES_PAGE_URL}\n\n"
-        "Click 'Yes' to be redirected to the release page, or 'No' to dismiss."
+        "To disable these notifications, go to Edit > Project Settings > "
+        'search for "Deadline" and uncheck "Show Submitter Update '
+        'Notifications" under General Settings.\n\n'
+        "Click 'Yes' to open the release page, or 'No' to dismiss."
     )
 
     response = unreal.EditorDialog.show_message(
@@ -140,12 +144,24 @@ def _check_and_show_update_dialog() -> bool:
         except Exception:
             return False
 
-        unreal.EditorDialog.show_message(
-            "Application Restart Required",
-            "Please install the new release and then restart Unreal Engine "
-            "to use the new version.",
-            unreal.AppMsgType.OK,
+        guide_message = (
+            "Please follow the setup guide to install the new release and "
+            "then restart Unreal Engine to use the new version.\n\n"
+            f"Setup guide:\n{SETUP_GUIDE_URL}\n\n"
+            "Click 'Yes' to open the setup guide, or 'No' to dismiss."
         )
+
+        guide_response = unreal.EditorDialog.show_message(
+            "Installation Guide",
+            guide_message,
+            unreal.AppMsgType.YES_NO,
+        )
+
+        if guide_response == unreal.AppReturnType.YES:
+            try:
+                webbrowser.open(SETUP_GUIDE_URL)
+            except Exception:
+                logger.debug("Failed to open setup guide URL", exc_info=True)
         return True
 
     return False

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.cpp
@@ -17,6 +17,7 @@ namespace DeadlineSettingsKeys
     const FString AutoAccept = TEXT("settings.auto_accept");
     const FString ConflictResolution = TEXT("settings.conflict_resolution");
     const FString LogLevel = TEXT("settings.log_level");
+    const FString SubmitterUpdateNotification = TEXT("settings.submitter_update_notification");
 }
 
 UDeadlineCloudDeveloperSettings::UDeadlineCloudDeveloperSettings()
@@ -329,6 +330,9 @@ void UDeadlineCloudDeveloperSettings::RefreshFromDefaultProfileInternal()
 
 		FString CurrentLoggingLevel = Library->GetAWSStringConfigSetting(DeadlineSettingsKeys::LogLevel);
 		WorkStationConfiguration.General.CurrentLoggingLevel = CurrentLoggingLevel;
+
+		FString SubmitterUpdateNotification = Library->GetAWSStringConfigSetting(DeadlineSettingsKeys::SubmitterUpdateNotification);
+		WorkStationConfiguration.General.ShowUpdateNotifications = SubmitterUpdateNotification != TEXT("false");
     }
 }
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UpdateDialog.spec.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UpdateDialog.spec.cpp
@@ -12,19 +12,20 @@
 // Spec tests for the update dialog flow.
 //
 // The update-notification dialog itself is driven by Python
-// (update_check.py → unreal.EditorDialog.show_message) and is covered by
+// (update_check.py -> unreal.EditorDialog.show_message) and is covered by
 // the Python unit tests in test_update_check.py.
 //
 // These C++ automation tests verify the settings-layer contract that the
 // Python code depends on:
-//   • The ShowUpdateNotifications property exists and defaults to true.
-//   • The property can be toggled and the value persists on the object.
-//   • The underlying config key ("settings.submitter_update_notification")
-//     is read correctly from the settings library when available.
+//   - The ShowUpdateNotifications property defaults to true.
+//   - The config key "settings.submitter_update_notification" is readable
+//     and returns a valid value via the settings library.
+//   - Toggling the setting via the UI persists through SaveToFile and
+//     is correctly restored by RefreshFromDefaultProfileInternal.
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// 1. Default value
+// 1. Default value: a fresh struct should have notifications enabled
 // ---------------------------------------------------------------------------
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 	FUpdateDialog_SettingDefaultIsTrue,
@@ -33,7 +34,6 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(
 
 bool FUpdateDialog_SettingDefaultIsTrue::RunTest(const FString& Parameters)
 {
-	// A freshly-constructed settings struct should have notifications enabled.
 	FDeadlineCloudGeneralPluginSettings DefaultGeneral;
 	TestTrue(
 		TEXT("ShowUpdateNotifications should default to true on a fresh struct"),
@@ -43,135 +43,64 @@ bool FUpdateDialog_SettingDefaultIsTrue::RunTest(const FString& Parameters)
 }
 
 // ---------------------------------------------------------------------------
-// 2. Toggle round-trip on the live settings singleton
+// 2. Save-and-reload round-trip through the config file
+//    Toggles the setting off, saves to the Deadline Cloud config file via
+//    SaveToFile(), reloads via RefreshFromDefaultProfileInternal(), and
+//    verifies the bool was correctly persisted as the string "false" and
+//    mapped back to false. Then does the same for true. Restores original.
 // ---------------------------------------------------------------------------
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
-	FUpdateDialog_SettingToggleRoundTrip,
-	"DeadlineCloud.UpdateDialog.Setting.ToggleRoundTrip",
+	FUpdateDialog_SettingSaveAndReloadRoundTrip,
+	"DeadlineCloud.UpdateDialog.Setting.SaveAndReloadRoundTrip",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
 
-bool FUpdateDialog_SettingToggleRoundTrip::RunTest(const FString& Parameters)
+bool FUpdateDialog_SettingSaveAndReloadRoundTrip::RunTest(const FString& Parameters)
 {
 	UDeadlineCloudDeveloperSettings* Settings = UDeadlineCloudDeveloperSettings::GetMutable();
 	TestNotNull(TEXT("DeveloperSettings singleton must exist"), Settings);
 	if (!Settings) return false;
 
-	const bool bOriginal = Settings->WorkStationConfiguration.General.ShowUpdateNotifications;
-
-	// Toggle off
-	Settings->WorkStationConfiguration.General.ShowUpdateNotifications = false;
-	TestFalse(
-		TEXT("ShowUpdateNotifications should be false after setting to false"),
-		Settings->WorkStationConfiguration.General.ShowUpdateNotifications);
-
-	// Toggle on
-	Settings->WorkStationConfiguration.General.ShowUpdateNotifications = true;
-	TestTrue(
-		TEXT("ShowUpdateNotifications should be true after setting to true"),
-		Settings->WorkStationConfiguration.General.ShowUpdateNotifications);
-
-	// Restore
-	Settings->WorkStationConfiguration.General.ShowUpdateNotifications = bOriginal;
-
-	return true;
-}
-
-// ---------------------------------------------------------------------------
-// 3. Verify the setting is accessible on the live singleton
-// ---------------------------------------------------------------------------
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(
-	FUpdateDialog_SettingAccessibleOnSingleton,
-	"DeadlineCloud.UpdateDialog.Setting.AccessibleOnSingleton",
-	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
-
-bool FUpdateDialog_SettingAccessibleOnSingleton::RunTest(const FString& Parameters)
-{
-	const UDeadlineCloudDeveloperSettings* Settings = UDeadlineCloudDeveloperSettings::Get();
-	TestNotNull(TEXT("DeveloperSettings const singleton must exist"), Settings);
-	if (!Settings) return false;
-
-	// Just reading the value should not crash — the property must be well-formed.
-	const bool bValue = Settings->WorkStationConfiguration.General.ShowUpdateNotifications;
-	// We don't assert a specific value here because a previous test run may have
-	// changed it; we only verify the read succeeds without error.
-	TestTrue(TEXT("Reading ShowUpdateNotifications should succeed (value is bool)"), bValue || !bValue);
-
-	return true;
-}
-
-// ---------------------------------------------------------------------------
-// 4. Verify the config key constant matches what Python expects
-// ---------------------------------------------------------------------------
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(
-	FUpdateDialog_ConfigKeyMatchesPython,
-	"DeadlineCloud.UpdateDialog.Setting.ConfigKeyMatchesPython",
-	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
-
-bool FUpdateDialog_ConfigKeyMatchesPython::RunTest(const FString& Parameters)
-{
-	// The Python update_check.py reads:
-	//   config_file.get_setting("settings.submitter_update_notification")
-	//
-	// The C++ side defines the same key in DeadlineCloudDeveloperSettings.cpp
-	// (DeadlineSettingsKeys::SubmitterUpdateNotification). We verify the
-	// settings library can be queried for this key without crashing.
 	UDeadlineCloudSettingsLibrary* Library = UDeadlineCloudSettingsLibrary::Get();
 	if (!Library)
 	{
-		// The Python side may not be initialized in a headless test run.
-		// This is acceptable — we just verify the library pointer is handled.
-		AddWarning(TEXT("DeadlineCloudSettingsLibrary not available (Python not initialized). Skipping config key read."));
+		AddWarning(TEXT("DeadlineCloudSettingsLibrary not available (Python not initialized). Skipping round-trip test."));
 		return true;
 	}
 
-	const FString ConfigKey = TEXT("settings.submitter_update_notification");
-	const FString Value = Library->GetAWSStringConfigSetting(ConfigKey);
-
-	// The value should be either "true", "false", or empty (unset).
-	const bool bValidValue = Value.IsEmpty()
-		|| Value.Equals(TEXT("true"), ESearchCase::IgnoreCase)
-		|| Value.Equals(TEXT("false"), ESearchCase::IgnoreCase);
-
-	TestTrue(
-		TEXT("submitter_update_notification config value should be empty, 'true', or 'false'"),
-		bValidValue);
-
-	return true;
-}
-
-// ---------------------------------------------------------------------------
-// 5. Verify setting maps correctly from config string to bool
-// ---------------------------------------------------------------------------
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(
-	FUpdateDialog_ConfigStringToBoolMapping,
-	"DeadlineCloud.UpdateDialog.Setting.ConfigStringToBoolMapping",
-	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
-
-bool FUpdateDialog_ConfigStringToBoolMapping::RunTest(const FString& Parameters)
-{
-	UDeadlineCloudDeveloperSettings* Settings = UDeadlineCloudDeveloperSettings::GetMutable();
-	TestNotNull(TEXT("DeveloperSettings singleton must exist"), Settings);
-	if (!Settings) return false;
-
 	const bool bOriginal = Settings->WorkStationConfiguration.General.ShowUpdateNotifications;
+	const FString ConfigKey = TEXT("settings.submitter_update_notification");
 
-	// The C++ code in DeadlineCloudDeveloperSettings.cpp does:
-	//   ShowUpdateNotifications = SubmitterUpdateNotification != TEXT("false");
-	// This means any value other than "false" (including empty) maps to true.
-	// Verify the bool property reflects this contract.
-
-	Settings->WorkStationConfiguration.General.ShowUpdateNotifications = true;
-	TestTrue(
-		TEXT("Setting true should yield true"),
-		Settings->WorkStationConfiguration.General.ShowUpdateNotifications);
-
+	// --- Toggle OFF, save, reload, verify ---
 	Settings->WorkStationConfiguration.General.ShowUpdateNotifications = false;
+	Settings->SaveToFile();
+
+	FString SavedValue = Library->GetAWSStringConfigSetting(ConfigKey);
+	TestTrue(
+		TEXT("Config should contain 'false' after saving with notifications off"),
+		SavedValue.Equals(TEXT("false"), ESearchCase::IgnoreCase));
+
+	Settings->RefreshFromDefaultProfileInternal();
 	TestFalse(
-		TEXT("Setting false should yield false"),
+		TEXT("ShowUpdateNotifications should be false after reload"),
 		Settings->WorkStationConfiguration.General.ShowUpdateNotifications);
 
-	// Restore
+	// --- Toggle ON, save, reload, verify ---
+	Settings->WorkStationConfiguration.General.ShowUpdateNotifications = true;
+	Settings->SaveToFile();
+
+	SavedValue = Library->GetAWSStringConfigSetting(ConfigKey);
+	TestTrue(
+		TEXT("Config should contain 'true' after saving with notifications on"),
+		SavedValue.Equals(TEXT("true"), ESearchCase::IgnoreCase));
+
+	Settings->RefreshFromDefaultProfileInternal();
+	TestTrue(
+		TEXT("ShowUpdateNotifications should be true after reload"),
+		Settings->WorkStationConfiguration.General.ShowUpdateNotifications);
+
+	// --- Restore original ---
 	Settings->WorkStationConfiguration.General.ShowUpdateNotifications = bOriginal;
+	Settings->SaveToFile();
 
 	return true;
 }

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UpdateDialog.spec.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UpdateDialog.spec.cpp
@@ -1,0 +1,177 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#pragma once
+#include "Misc/AutomationTest.h"
+#include "CoreMinimal.h"
+#include "Engine/Engine.h"
+#include "UObject/UObjectGlobals.h"
+#include "DeadlineCloudJobSettings/DeadlineCloudDeveloperSettings.h"
+#include "PythonAPILibraries/DeadlineCloudSettingsLibrary.h"
+
+// ---------------------------------------------------------------------------
+// Spec tests for the update dialog flow.
+//
+// The update-notification dialog itself is driven by Python
+// (update_check.py → unreal.EditorDialog.show_message) and is covered by
+// the Python unit tests in test_update_check.py.
+//
+// These C++ automation tests verify the settings-layer contract that the
+// Python code depends on:
+//   • The ShowUpdateNotifications property exists and defaults to true.
+//   • The property can be toggled and the value persists on the object.
+//   • The underlying config key ("settings.submitter_update_notification")
+//     is read correctly from the settings library when available.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// 1. Default value
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUpdateDialog_SettingDefaultIsTrue,
+	"DeadlineCloud.UpdateDialog.Setting.DefaultIsTrue",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUpdateDialog_SettingDefaultIsTrue::RunTest(const FString& Parameters)
+{
+	// A freshly-constructed settings struct should have notifications enabled.
+	FDeadlineCloudGeneralPluginSettings DefaultGeneral;
+	TestTrue(
+		TEXT("ShowUpdateNotifications should default to true on a fresh struct"),
+		DefaultGeneral.ShowUpdateNotifications);
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// 2. Toggle round-trip on the live settings singleton
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUpdateDialog_SettingToggleRoundTrip,
+	"DeadlineCloud.UpdateDialog.Setting.ToggleRoundTrip",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUpdateDialog_SettingToggleRoundTrip::RunTest(const FString& Parameters)
+{
+	UDeadlineCloudDeveloperSettings* Settings = UDeadlineCloudDeveloperSettings::GetMutable();
+	TestNotNull(TEXT("DeveloperSettings singleton must exist"), Settings);
+	if (!Settings) return false;
+
+	const bool bOriginal = Settings->WorkStationConfiguration.General.ShowUpdateNotifications;
+
+	// Toggle off
+	Settings->WorkStationConfiguration.General.ShowUpdateNotifications = false;
+	TestFalse(
+		TEXT("ShowUpdateNotifications should be false after setting to false"),
+		Settings->WorkStationConfiguration.General.ShowUpdateNotifications);
+
+	// Toggle on
+	Settings->WorkStationConfiguration.General.ShowUpdateNotifications = true;
+	TestTrue(
+		TEXT("ShowUpdateNotifications should be true after setting to true"),
+		Settings->WorkStationConfiguration.General.ShowUpdateNotifications);
+
+	// Restore
+	Settings->WorkStationConfiguration.General.ShowUpdateNotifications = bOriginal;
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// 3. Verify the setting is accessible on the live singleton
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUpdateDialog_SettingAccessibleOnSingleton,
+	"DeadlineCloud.UpdateDialog.Setting.AccessibleOnSingleton",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUpdateDialog_SettingAccessibleOnSingleton::RunTest(const FString& Parameters)
+{
+	const UDeadlineCloudDeveloperSettings* Settings = UDeadlineCloudDeveloperSettings::Get();
+	TestNotNull(TEXT("DeveloperSettings const singleton must exist"), Settings);
+	if (!Settings) return false;
+
+	// Just reading the value should not crash — the property must be well-formed.
+	const bool bValue = Settings->WorkStationConfiguration.General.ShowUpdateNotifications;
+	// We don't assert a specific value here because a previous test run may have
+	// changed it; we only verify the read succeeds without error.
+	TestTrue(TEXT("Reading ShowUpdateNotifications should succeed (value is bool)"), bValue || !bValue);
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// 4. Verify the config key constant matches what Python expects
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUpdateDialog_ConfigKeyMatchesPython,
+	"DeadlineCloud.UpdateDialog.Setting.ConfigKeyMatchesPython",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUpdateDialog_ConfigKeyMatchesPython::RunTest(const FString& Parameters)
+{
+	// The Python update_check.py reads:
+	//   config_file.get_setting("settings.submitter_update_notification")
+	//
+	// The C++ side defines the same key in DeadlineCloudDeveloperSettings.cpp
+	// (DeadlineSettingsKeys::SubmitterUpdateNotification). We verify the
+	// settings library can be queried for this key without crashing.
+	UDeadlineCloudSettingsLibrary* Library = UDeadlineCloudSettingsLibrary::Get();
+	if (!Library)
+	{
+		// The Python side may not be initialized in a headless test run.
+		// This is acceptable — we just verify the library pointer is handled.
+		AddWarning(TEXT("DeadlineCloudSettingsLibrary not available (Python not initialized). Skipping config key read."));
+		return true;
+	}
+
+	const FString ConfigKey = TEXT("settings.submitter_update_notification");
+	const FString Value = Library->GetAWSStringConfigSetting(ConfigKey);
+
+	// The value should be either "true", "false", or empty (unset).
+	const bool bValidValue = Value.IsEmpty()
+		|| Value.Equals(TEXT("true"), ESearchCase::IgnoreCase)
+		|| Value.Equals(TEXT("false"), ESearchCase::IgnoreCase);
+
+	TestTrue(
+		TEXT("submitter_update_notification config value should be empty, 'true', or 'false'"),
+		bValidValue);
+
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// 5. Verify setting maps correctly from config string to bool
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FUpdateDialog_ConfigStringToBoolMapping,
+	"DeadlineCloud.UpdateDialog.Setting.ConfigStringToBoolMapping",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FUpdateDialog_ConfigStringToBoolMapping::RunTest(const FString& Parameters)
+{
+	UDeadlineCloudDeveloperSettings* Settings = UDeadlineCloudDeveloperSettings::GetMutable();
+	TestNotNull(TEXT("DeveloperSettings singleton must exist"), Settings);
+	if (!Settings) return false;
+
+	const bool bOriginal = Settings->WorkStationConfiguration.General.ShowUpdateNotifications;
+
+	// The C++ code in DeadlineCloudDeveloperSettings.cpp does:
+	//   ShowUpdateNotifications = SubmitterUpdateNotification != TEXT("false");
+	// This means any value other than "false" (including empty) maps to true.
+	// Verify the bool property reflects this contract.
+
+	Settings->WorkStationConfiguration.General.ShowUpdateNotifications = true;
+	TestTrue(
+		TEXT("Setting true should yield true"),
+		Settings->WorkStationConfiguration.General.ShowUpdateNotifications);
+
+	Settings->WorkStationConfiguration.General.ShowUpdateNotifications = false;
+	TestFalse(
+		TEXT("Setting false should yield false"),
+		Settings->WorkStationConfiguration.General.ShowUpdateNotifications);
+
+	// Restore
+	Settings->WorkStationConfiguration.General.ShowUpdateNotifications = bOriginal;
+
+	return true;
+}

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudSettingsLibrary.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudSettingsLibrary.h
@@ -129,6 +129,12 @@ struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudGeneralPluginSettings
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(GetOptions="GetLoggingLevels", DisplayPriority=8, Category="General Settings"))
 	FString CurrentLoggingLevel;
 
+	/**
+	 * Whether to show update notifications when a newer version of the plugin is available on GitHub.
+	 */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(DisplayName="Show submitter update notifications", DisplayPriority=9, Category="General Settings"))
+	bool ShowUpdateNotifications = true;
+
 };
 
 /**

--- a/test/deadline_submitter_for_unreal/unit/test_submitter.py
+++ b/test/deadline_submitter_for_unreal/unit/test_submitter.py
@@ -29,6 +29,7 @@ def create_job_from_bundle_mock(
             progress=100.0,
             transferRate=1000.0,
             progressMessage="Done",
+            processedFiles=0,
         )
     )
     upload_progress_callback(
@@ -37,6 +38,7 @@ def create_job_from_bundle_mock(
             progress=100.0,
             transferRate=1000.0,
             progressMessage="Done",
+            processedFiles=0,
         )
     )
     create_job_result_callback()

--- a/test/deadline_submitter_for_unreal/unit/test_update_check.py
+++ b/test/deadline_submitter_for_unreal/unit/test_update_check.py
@@ -7,6 +7,8 @@ import sys
 import urllib.error
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 # Mock the 'unreal' module before importing update_check, since it's only
 # available inside the Unreal Engine Python environment.
 _mock_unreal = MagicMock()
@@ -85,29 +87,40 @@ class TestFetchLatestVersion:
 class TestIsUpdateAvailable:
     """Tests for _is_update_available()."""
 
-    def test_newer_version_available(self):
-        assert _is_update_available("0.5.0", "0.6.5") is True
-
-    def test_same_version(self):
-        assert _is_update_available("0.6.5", "0.6.5") is False
-
-    def test_older_version(self):
-        assert _is_update_available("1.0.0", "0.6.5") is False
-
-    def test_invalid_current_version(self):
-        assert _is_update_available("not-a-version", "0.6.5") is False
-
-    def test_invalid_latest_version(self):
-        assert _is_update_available("0.6.5", "not-a-version") is False
-
-    def test_dev_build_is_older_than_release(self):
-        assert _is_update_available("0.6.5.post144", "0.7.0") is True
-
-    def test_release_is_newer_than_dev_build(self):
-        assert _is_update_available("0.7.0", "0.6.5.post144") is False
-
-    def test_post_release_does_not_trigger_update_for_same_base(self):
-        assert _is_update_available("0.6.5.post144", "0.6.5") is False
+    @pytest.mark.parametrize(
+        "current, latest, expected",
+        [
+            # Newer version available
+            ("0.5.0", "0.6.5", True),
+            ("0.6.5", "0.10.0", True),
+            # Same version
+            ("0.6.5", "0.6.5", False),
+            # Current is newer (no update)
+            ("1.0.0", "0.6.5", False),
+            ("0.10.0", "0.6.5", False),
+            # Invalid versions
+            ("not-a-version", "0.6.5", False),
+            ("0.6.5", "not-a-version", False),
+            # Dev/post builds
+            ("0.6.5.post144", "0.7.0", True),
+            ("0.7.0", "0.6.5.post144", False),
+            ("0.6.5.post144", "0.6.5", False),
+        ],
+        ids=[
+            "newer_available",
+            "newer_available_double_digit_minor",
+            "same_version",
+            "current_is_newer",
+            "current_is_newer_double_digit_minor",
+            "invalid_current",
+            "invalid_latest",
+            "dev_build_older_than_release",
+            "release_newer_than_dev_build",
+            "post_release_same_base",
+        ],
+    )
+    def test_is_update_available(self, current, latest, expected):
+        assert _is_update_available(current, latest) is expected
 
 
 class TestCheckAndShowUpdateDialog:

--- a/test/deadline_submitter_for_unreal/unit/test_update_check.py
+++ b/test/deadline_submitter_for_unreal/unit/test_update_check.py
@@ -21,6 +21,7 @@ from update_check import (  # noqa: E402
     _is_update_available,
     safe_check_and_show_update_dialog,
     RELEASES_PAGE_URL,
+    SETUP_GUIDE_URL,
 )
 
 
@@ -126,6 +127,10 @@ class TestIsUpdateAvailable:
 class TestCheckAndShowUpdateDialog:
     """Tests for safe_check_and_show_update_dialog()."""
 
+    @pytest.fixture(autouse=True)
+    def reset_unreal_mock(self):
+        _mock_unreal.reset_mock()
+
     @patch("update_check._is_update_notification_enabled", return_value=False)
     def test_returns_false_when_notifications_disabled(self, mock_enabled):
         assert safe_check_and_show_update_dialog() is False
@@ -159,9 +164,20 @@ class TestCheckAndShowUpdateDialog:
         result = safe_check_and_show_update_dialog()
 
         assert result is True
-        mock_webbrowser.assert_called_once_with(RELEASES_PAGE_URL)
-        # Should show two dialogs: the update dialog and the restart reminder
+        # Should open releases page first, then setup guide
+        assert mock_webbrowser.call_count == 2
+        mock_webbrowser.assert_any_call(RELEASES_PAGE_URL)
+        mock_webbrowser.assert_any_call(SETUP_GUIDE_URL)
+        # Should show two dialogs: the update dialog and the setup guide
         assert _mock_unreal.EditorDialog.show_message.call_count == 2
+
+        # First dialog should mention release notes
+        first_call_args = _mock_unreal.EditorDialog.show_message.call_args_list[0]
+        assert RELEASES_PAGE_URL in first_call_args[0][1]
+
+        # Second dialog should mention the setup guide
+        second_call_args = _mock_unreal.EditorDialog.show_message.call_args_list[1]
+        assert SETUP_GUIDE_URL in second_call_args[0][1]
 
     @patch("update_check._is_update_available", return_value=True)
     @patch("update_check._fetch_latest_version", return_value="0.6.5")
@@ -176,6 +192,24 @@ class TestCheckAndShowUpdateDialog:
         result = safe_check_and_show_update_dialog()
 
         assert result is False
+
+    @patch("update_check.webbrowser.open")
+    @patch("update_check._is_update_available", return_value=True)
+    @patch("update_check._fetch_latest_version", return_value="0.6.5")
+    @patch("update_check._get_current_version", return_value="0.5.0")
+    @patch("update_check._is_update_notification_enabled", return_value=True)
+    def test_skips_setup_guide_when_user_dismisses_second_dialog(
+        self, mock_enabled, mock_current, mock_fetch, mock_available, mock_webbrowser
+    ):
+        _mock_unreal.AppReturnType.YES = "YES"
+        # First dialog: Yes, second dialog: No
+        _mock_unreal.EditorDialog.show_message.side_effect = ["YES", "NO"]
+
+        result = safe_check_and_show_update_dialog()
+
+        assert result is True
+        # Only the releases page should be opened, not the setup guide
+        mock_webbrowser.assert_called_once_with(RELEASES_PAGE_URL)
 
     @patch("update_check.webbrowser.open", side_effect=Exception("browser error"))
     @patch("update_check._is_update_available", return_value=True)

--- a/test/deadline_submitter_for_unreal/unit/test_update_check.py
+++ b/test/deadline_submitter_for_unreal/unit/test_update_check.py
@@ -1,0 +1,180 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+from unittest.mock import patch, MagicMock
+
+# Mock the 'unreal' module before importing update_check, since it's only
+# available inside the Unreal Engine Python environment.
+_mock_unreal = MagicMock()
+sys.modules["unreal"] = _mock_unreal
+
+
+# Now safe to import — unreal is already in sys.modules.
+from update_check import (  # noqa: E402
+    _fetch_latest_version,
+    _is_update_available,
+    safe_check_and_show_update_dialog,
+    RELEASES_PAGE_URL,
+)
+
+
+class TestFetchLatestVersion:
+    """Tests for _fetch_latest_version()."""
+
+    @patch("update_check.ssl.create_default_context")
+    @patch("update_check.urllib.request.urlopen")
+    @patch("update_check._get_botocore_ca_bundle", return_value="/fake/cacert.pem")
+    def test_returns_version_from_github(self, mock_ca, mock_urlopen, mock_ssl):
+        response_data = json.dumps({"tag_name": "v0.6.5"}).encode("utf-8")
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = response_data
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        assert _fetch_latest_version() == "0.6.5"
+
+    @patch("update_check.ssl.create_default_context")
+    @patch("update_check.urllib.request.urlopen")
+    @patch("update_check._get_botocore_ca_bundle", return_value="/fake/cacert.pem")
+    def test_returns_none_on_network_error(self, mock_ca, mock_urlopen, mock_ssl):
+        mock_urlopen.side_effect = urllib.error.URLError("connection refused")
+
+        assert _fetch_latest_version() is None
+
+    @patch("update_check.ssl.create_default_context")
+    @patch("update_check.urllib.request.urlopen")
+    @patch("update_check._get_botocore_ca_bundle", return_value="/fake/cacert.pem")
+    def test_returns_none_on_timeout(self, mock_ca, mock_urlopen, mock_ssl):
+        import socket
+
+        mock_urlopen.side_effect = socket.timeout("timed out")
+
+        assert _fetch_latest_version() is None
+
+    @patch("update_check.ssl.create_default_context")
+    @patch("update_check.urllib.request.urlopen")
+    @patch("update_check._get_botocore_ca_bundle", return_value="/fake/cacert.pem")
+    def test_returns_none_on_invalid_json(self, mock_ca, mock_urlopen, mock_ssl):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"not json"
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        assert _fetch_latest_version() is None
+
+    @patch("update_check.ssl.create_default_context")
+    @patch("update_check.urllib.request.urlopen")
+    @patch("update_check._get_botocore_ca_bundle", return_value="/fake/cacert.pem")
+    def test_returns_none_on_empty_tag(self, mock_ca, mock_urlopen, mock_ssl):
+        response_data = json.dumps({"tag_name": ""}).encode("utf-8")
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = response_data
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        assert _fetch_latest_version() is None
+
+
+class TestIsUpdateAvailable:
+    """Tests for _is_update_available()."""
+
+    def test_newer_version_available(self):
+        assert _is_update_available("0.5.0", "0.6.5") is True
+
+    def test_same_version(self):
+        assert _is_update_available("0.6.5", "0.6.5") is False
+
+    def test_older_version(self):
+        assert _is_update_available("1.0.0", "0.6.5") is False
+
+    def test_invalid_current_version(self):
+        assert _is_update_available("not-a-version", "0.6.5") is False
+
+    def test_invalid_latest_version(self):
+        assert _is_update_available("0.6.5", "not-a-version") is False
+
+    def test_dev_build_is_older_than_release(self):
+        assert _is_update_available("0.6.5.post144", "0.7.0") is True
+
+    def test_release_is_newer_than_dev_build(self):
+        assert _is_update_available("0.7.0", "0.6.5.post144") is False
+
+    def test_post_release_does_not_trigger_update_for_same_base(self):
+        assert _is_update_available("0.6.5.post144", "0.6.5") is False
+
+
+class TestCheckAndShowUpdateDialog:
+    """Tests for safe_check_and_show_update_dialog()."""
+
+    @patch("update_check._is_update_notification_enabled", return_value=False)
+    def test_returns_false_when_notifications_disabled(self, mock_enabled):
+        assert safe_check_and_show_update_dialog() is False
+
+    @patch("update_check._fetch_latest_version", return_value=None)
+    @patch("update_check._get_current_version", return_value="0.5.0")
+    @patch("update_check._is_update_notification_enabled", return_value=True)
+    def test_returns_false_when_fetch_fails(self, mock_enabled, mock_current, mock_fetch):
+        assert safe_check_and_show_update_dialog() is False
+
+    @patch("update_check._is_update_available", return_value=False)
+    @patch("update_check._fetch_latest_version", return_value="0.5.0")
+    @patch("update_check._get_current_version", return_value="0.5.0")
+    @patch("update_check._is_update_notification_enabled", return_value=True)
+    def test_returns_false_when_already_up_to_date(
+        self, mock_enabled, mock_current, mock_fetch, mock_available
+    ):
+        assert safe_check_and_show_update_dialog() is False
+
+    @patch("update_check.webbrowser.open")
+    @patch("update_check._is_update_available", return_value=True)
+    @patch("update_check._fetch_latest_version", return_value="0.6.5")
+    @patch("update_check._get_current_version", return_value="0.5.0")
+    @patch("update_check._is_update_notification_enabled", return_value=True)
+    def test_returns_true_when_user_clicks_yes(
+        self, mock_enabled, mock_current, mock_fetch, mock_available, mock_webbrowser
+    ):
+        _mock_unreal.AppReturnType.YES = "YES"
+        _mock_unreal.EditorDialog.show_message.return_value = "YES"
+
+        result = safe_check_and_show_update_dialog()
+
+        assert result is True
+        mock_webbrowser.assert_called_once_with(RELEASES_PAGE_URL)
+        # Should show two dialogs: the update dialog and the restart reminder
+        assert _mock_unreal.EditorDialog.show_message.call_count == 2
+
+    @patch("update_check._is_update_available", return_value=True)
+    @patch("update_check._fetch_latest_version", return_value="0.6.5")
+    @patch("update_check._get_current_version", return_value="0.5.0")
+    @patch("update_check._is_update_notification_enabled", return_value=True)
+    def test_returns_false_when_user_clicks_no(
+        self, mock_enabled, mock_current, mock_fetch, mock_available
+    ):
+        _mock_unreal.AppReturnType.YES = "YES"
+        _mock_unreal.EditorDialog.show_message.return_value = "NO"
+
+        result = safe_check_and_show_update_dialog()
+
+        assert result is False
+
+    @patch("update_check.webbrowser.open", side_effect=Exception("browser error"))
+    @patch("update_check._is_update_available", return_value=True)
+    @patch("update_check._fetch_latest_version", return_value="0.6.5")
+    @patch("update_check._get_current_version", return_value="0.5.0")
+    @patch("update_check._is_update_notification_enabled", return_value=True)
+    def test_returns_false_when_webbrowser_fails(
+        self, mock_enabled, mock_current, mock_fetch, mock_available, mock_webbrowser
+    ):
+        _mock_unreal.AppReturnType.YES = "YES"
+        _mock_unreal.EditorDialog.show_message.return_value = "YES"
+
+        result = safe_check_and_show_update_dialog()
+
+        assert result is False


### PR DESCRIPTION
**DO NOT MERGE UNTIL https://github.com/aws-deadline/deadline-cloud/pull/1070 is released in Deadline Cloud**

### What was the problem/requirement? (What/Why)

Customers are not aware if they are working on the latest submitter or not. 

### What was the solution? (How)

Created a new dialog to suggest customers to update their submitter. 

### What is the impact of this change?

Customers hopefully have the latest submitter always or at least are notified of this. 

### How was this change tested?


<img width="583" height="309" alt="image" src="https://github.com/user-attachments/assets/5f6ede91-6d45-4a07-96f0-a45fa443379d" />

<img width="593" height="242" alt="image" src="https://github.com/user-attachments/assets/992f2b14-6308-4bde-83c6-2808509ecf9d" />

If customers want to deactivate the feature, they can do it in the settings. 

<img width="1354" height="458" alt="image" src="https://github.com/user-attachments/assets/7d7e9f71-a834-4435-9c84-0cf18ce93892" />


- Have you run the unit tests?
Yes

Also added a spec test. 

<img width="1220" height="184" alt="image" src="https://github.com/user-attachments/assets/28ed9806-506a-4cb8-804c-306927725297" />


### Have you run a render job successfully with these changes?

No as this dialog opens even before job submission. 

### Was this change documented?

Yes added it into setup-submitter if customers want to deactivate the feature. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*