### PR TITLE
fix(pipeline): Use hatch built-in build command in publish script

### DIFF
--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -7,4 +7,4 @@ pip install --upgrade hatch
 pip install --upgrade twine
 hatch -v run lint
 hatch run test
-hatch -v run build
+hatch -v build


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The publish GitHub Action fails with `build: command not found` (exit status 127)
during the BUILD phase. The `pipeline/build.sh` script runs `hatch -v run build`,
which looks for a hatch script named `build` in the default environment. This script
was previously defined in the `[envs.codebuild.scripts]` section of `hatch.toml`, but
was removed in bb6cf8d. Without it, hatch falls through and tries to execute a bare
`build` shell command, which doesn't exist.

This was broken since the merge of https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/commit/bb6cf8de50d34d96333a5e1d552d783c1547757f change, but we have not run the release process since this change so this surfaced just now

### What was the solution? (How)

Changed `hatch -v run build` to `hatch -v build` in `pipeline/build.sh`. The `hatch build`
command is hatch's built-in package build command that creates the sdist and wheel
artifacts in `dist/`, which is what `publish.sh` needs before running `twine upload dist/*`.

### What is the impact of this change?

Unblocks the publish GitHub Action so releases can be published to CodeArtifact.

### How was this change tested?

- Verified `hatch -v build` produces the expected sdist and wheel in `dist/`
- All existing unit tests continue to pass (424 passed, 2 skipped)

### Have you run a render job successfully with these changes?

N/A — this change only affects the CI/CD publish pipeline, not runtime behavior.

### Was this change documented?

No documentation changes needed.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*