### PR TITLE
fix: Ensure pip upgrades deadline and worker-agent dependencies on install

### DIFF
--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -178,10 +178,23 @@ def install_whl_to_plugin(whl_path: str, engine_root: str):
 
     plugin_libraries_path = os.path.join(plugin_folder, "Content", "Python", "libraries")
 
-    # Pip install the .whl file to the plugin libraries path
+    # Pip install the .whl file to the plugin libraries path.
+    # --force-reinstall is required because pip install -t still checks the
+    # interpreter's own site-packages for already-satisfied dependencies.
+    # Without it, an older 'deadline' in UE Python's Lib/site-packages causes
+    # pip to skip installing the required version into the target directory.
     logger.info(f"Installing {whl_path} to {plugin_libraries_path}")
     result = subprocess.run(
-        [python_path, "-m", "pip", "install", whl_path, "-t", plugin_libraries_path, "--upgrade"],
+        [
+            python_path,
+            "-m",
+            "pip",
+            "install",
+            whl_path,
+            "-t",
+            plugin_libraries_path,
+            "--force-reinstall",
+        ],
         check=True,
     )
     logger.info(f"Install result: {result.returncode}")
@@ -221,7 +234,7 @@ def install_whl_global(whl_path: str):
     # Pip install the .whl file to the global python interpreter
     logger.info(f"Installing {whl_path} to global interpreter")
     result = subprocess.run(
-        ["python", "-m", "pip", "install", whl_path, "--upgrade"],
+        ["python", "-m", "pip", "install", whl_path, "--upgrade", "--upgrade-strategy", "eager"],
         check=True,
     )
     logger.info(f"Install result: {result.returncode}")
@@ -338,7 +351,16 @@ def install_worker_dependencies(engine_root: str):
         )
 
     subprocess.run(
-        ["python", "-m", "pip", "install", "deadline-cloud-worker-agent"],
+        [
+            "python",
+            "-m",
+            "pip",
+            "install",
+            "deadline-cloud-worker-agent",
+            "--upgrade",
+            "--upgrade-strategy",
+            "eager",
+        ],
         check=True,
         stderr=subprocess.PIPE,
     )
@@ -504,9 +526,9 @@ def build_and_install(
 
     if install:
         install_plugin(engine_root, output_folder, whl_path, binaries)
+        install_whl_global(whl_path)
 
     if worker:
-        install_whl_global(whl_path)
         install_worker_dependencies(engine_root)
 
     if test:

--- a/test/test_build_plugin.py
+++ b/test/test_build_plugin.py
@@ -1,0 +1,100 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from unittest.mock import patch, MagicMock
+
+from scripts.build_plugin import (
+    build_and_install,
+    install_whl_to_plugin,
+    install_whl_global,
+    install_worker_dependencies,
+)
+
+import os
+
+FAKE_ENGINE_ROOT = "/fake/engine"
+FAKE_PYTHON_PATH = os.path.join(
+    FAKE_ENGINE_ROOT, "Engine", "Binaries", "ThirdParty", "Python3", "Win64", "python.exe"
+)
+FAKE_WHL_PATH = "/fake/path/package.whl"
+FAKE_PLUGIN_LIBRARIES = os.path.join(
+    FAKE_ENGINE_ROOT,
+    "Engine",
+    "Plugins",
+    "UnrealDeadlineCloudService",
+    "Content",
+    "Python",
+    "libraries",
+)
+
+
+class TestInstallWhlToPlugin:
+    @patch("scripts.build_plugin.subprocess.run")
+    @patch("scripts.build_plugin.os.path.exists", return_value=True)
+    def test_pip_install_uses_force_reinstall(self, mock_exists, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+
+        install_whl_to_plugin(FAKE_WHL_PATH, FAKE_ENGINE_ROOT)
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == FAKE_PYTHON_PATH
+        assert "--force-reinstall" in cmd
+        assert "-t" in cmd
+        assert cmd[cmd.index("-t") + 1] == FAKE_PLUGIN_LIBRARIES
+
+
+class TestInstallWhlGlobal:
+    @patch("scripts.build_plugin.subprocess.run")
+    @patch("scripts.build_plugin.os.path.exists", return_value=True)
+    def test_pip_install_uses_eager_upgrade_strategy(self, mock_exists, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+
+        install_whl_global(FAKE_WHL_PATH)
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert FAKE_WHL_PATH in cmd
+        assert "--upgrade" in cmd
+        assert "--upgrade-strategy" in cmd
+        assert cmd[cmd.index("--upgrade-strategy") + 1] == "eager"
+
+
+class TestInstallWorkerDependencies:
+    @patch("scripts.build_plugin.subprocess.run")
+    @patch("scripts.build_plugin.os.path.exists", return_value=True)
+    def test_worker_agent_install_uses_eager_upgrade_strategy(self, mock_exists, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+
+        install_worker_dependencies(FAKE_ENGINE_ROOT)
+
+        # Last call should be the deadline-cloud-worker-agent install
+        worker_agent_call = mock_run.call_args_list[-1]
+        cmd = worker_agent_call[0][0]
+        assert "deadline-cloud-worker-agent" in cmd
+        assert "--upgrade" in cmd
+        assert "--upgrade-strategy" in cmd
+        assert cmd[cmd.index("--upgrade-strategy") + 1] == "eager"
+
+
+class TestBuildAndInstall:
+    @patch("scripts.build_plugin.install_whl_global")
+    @patch("scripts.build_plugin.install_plugin")
+    @patch("scripts.build_plugin.build_whl", return_value=FAKE_WHL_PATH)
+    @patch("scripts.build_plugin.build_plugin")
+    @patch("scripts.build_plugin.find_runuat", return_value="/fake/runuat")
+    @patch("scripts.build_plugin.check_configuration_warnings")
+    @patch("scripts.build_plugin.find_engine_root", return_value=FAKE_ENGINE_ROOT)
+    def test_install_flag_also_updates_global_python(
+        self,
+        mock_find_engine,
+        mock_check_warnings,
+        mock_find_runuat,
+        mock_build_plugin,
+        mock_build_whl,
+        mock_install_plugin,
+        mock_install_whl_global,
+    ):
+        build_and_install(install=True)
+
+        mock_install_plugin.assert_called_once()
+        mock_install_whl_global.assert_called_once_with(FAKE_WHL_PATH)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

After #274 bumped the minimum `deadline` dependency from `>= 0.51, < 0.54` to `>= 0.55.1, < 0.56`, existing customers running `python scripts/build_plugin.py --install` were not getting their `deadline` package upgraded. The same issue affected `deadline-cloud-worker-agent` when using `--worker` as mentioned in #243. This caused job creation failures with very little log to debug with.

Three separate issues in `build_plugin.py`:

1. `install_whl_to_plugin` used `pip install -t <target> --upgrade`, but pip still checks the interpreter's own site-packages for already-satisfied dependencies. An older `deadline` in UE Python's `Lib/site-packages` caused pip to skip installing the required version into the target directory.
2. `install_whl_global` used `--upgrade` with the default `only-if-needed` strategy, which doesn't force-upgrade transitive dependencies like `deadline`.
3. `install_worker_dependencies` installed `deadline-cloud-worker-agent` without `--upgrade` at all, so pip skipped it entirely if any version was already installed.
4. `build_and_install` only called `install_whl_global` under the `--worker` flag, so `--install` never updated `deadline` in the system Python — which is needed for job submission.

### What was the solution? (How)

- `install_whl_to_plugin`: Replaced `--upgrade` with `--force-reinstall` to ensure all dependencies are installed into the `-t` target regardless of what exists in the interpreter's site-packages.
- `install_whl_global`: Added `--upgrade-strategy eager` so `deadline` gets upgraded even when pip considers the existing version sufficient.
- `install_worker_dependencies`: Added `--upgrade --upgrade-strategy eager` to the `deadline-cloud-worker-agent` install.
- `build_and_install`: Moved `install_whl_global` call into the `--install` path so the system Python's `deadline` is also updated for job submission.

### What is the impact of this change?

Running `python scripts/build_plugin.py --install` will now correctly upgrade `deadline` in both the UE plugin libraries path and the system Python. Running with `--worker` will correctly upgrade `deadline-cloud-worker-agent` and its transitive dependencies.

### How was this change tested?

- All 457 unit tests pass (4 new tests added for the modified functions)
- Format (`black`) and lint (`ruff`) clean
- Manual verification on Windows 
     - Ran `python scripts/build_plugin.py --install`, confirmed `pip show deadline` shows the updated version
     - Ran ` python scripts/build_plugin.py --install --worker`, confirmed `deadline-cloud-worker-agent` shows the updated version

### Have you run a render job successfully with these changes?

No — this change only affects the pip install commands in `build_plugin.py` and does not modify any rendering or adaptor logic.

### Was this change documented?

- Updated inline comments in `install_whl_to_plugin` explaining why `--force-reinstall` is needed
- No changes to README.md, DEVELOPMENT.md, or schema files required

### Is this a breaking change?

No. This change only fixes dependency upgrade behavior in the install script. The plugin interface, adaptor init-data, run-data, and job submission workflow are unchanged. Existing users will see their dependencies correctly upgraded on next install, which is the expected behavior.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*