### PR TITLE
fix: Pin `typing_extensions` in `.uplugin` and use targeted sys.path insertion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,10 @@ Use conventional commits:
 
 For new features or major refactors, use the `ue-design` skill. This does NOT apply to small bug fixes.
 
+## Dependency Version Bumps
+
+When bumping versions in `pyproject.toml`, also update `PythonRequirements` in `src/unreal_plugin/UnrealDeadlineCloudService.uplugin`. UE's PipInstall caches packages in `<project>/Intermediate/PipInstall/` and won't auto-upgrade transitive dependencies, causing silent import failures if they go stale. Pin critical transitive dependencies (e.g. `typing_extensions>=4.14.1` required by `pydantic`) explicitly in the `.uplugin`.
+
 ## Architecture
 
 C++ and Python integration enabling Unreal Movie Render Queue job submission to AWS Deadline Cloud and worker-side rendering via OpenJD adaptors. Each component has its own `AGENTS.md` with detailed context.

--- a/src/unreal_plugin/Content/Python/init_unreal.py
+++ b/src/unreal_plugin/Content/Python/init_unreal.py
@@ -154,7 +154,14 @@ if remote_execution != "True":
         os.environ["DEADLINE_CLOUD"] = libraries_path
 
     if os.getenv("DEADLINE_CLOUD") and os.environ["DEADLINE_CLOUD"] not in sys.path:
-        sys.path.append(os.environ["DEADLINE_CLOUD"])
+        # Insert before UE's auto-installed PipInstall packages, which may contain
+        # older versions of shared dependencies (e.g. typing_extensions) that are
+        # incompatible with the versions bundled by this plugin.
+        _pip_install_idx = next(
+            (i for i, p in enumerate(sys.path) if "PipInstall" in p),
+            len(sys.path),
+        )
+        sys.path.insert(_pip_install_idx, os.environ["DEADLINE_CLOUD"])
 
     from deadline.unreal_logger import get_logger
 

--- a/src/unreal_plugin/UnrealDeadlineCloudService.uplugin
+++ b/src/unreal_plugin/UnrealDeadlineCloudService.uplugin
@@ -42,7 +42,8 @@
 			"Platform": "All",
 			"Requirements":
 			[
-				"deadline-cloud-for-unreal-engine>=0.5.0"
+				"deadline-cloud-for-unreal-engine>=0.5.0",
+				"typing_extensions>=4.14.1"
 			]
 		}
 	]


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/issues/291

### What was the problem/requirement? (What/Why)

Plugin initialization silently fails when UE's PipInstall directory contains an outdated `typing_extensions` (< 4.14.0) that lacks `Sentinel`, which `pydantic` requires. This causes `MoviePipelineDeadlineCloudRemoteExecutor` to disappear from the Movie Render Pipeline settings with no obvious error beyond a log message:

```
LogPython: Error: ImportError: cannot import name 'Sentinel' from 'typing_extensions'
```

The root cause is twofold:
1. The `.uplugin` `PythonRequirements` doesn't pin `typing_extensions`, so UE's PipInstall may cache a stale version from another plugin.
2. `init_unreal.py` appends the plugin's bundled `libraries/` path to `sys.path`, so PipInstall's stale version takes precedence.

PR #292 addressed this with `sys.path.insert(0, ...)`, but that hijacks the entire Python import order, potentially shadowing the standard library and other plugins' packages.

### What was the solution? (How)

Three complementary changes:

1. **Pin `typing_extensions>=4.14.1` in `.uplugin` `PythonRequirements`** — tells UE's PipInstall to install a compatible version. This is the root cause fix.
2. **Targeted `sys.path` insertion** — instead of `insert(0, ...)`, insert the plugin's `libraries/` path just before the PipInstall entry in `sys.path`. Falls back to `append` if no PipInstall path exists. This is a defensive fallback with minimal blast radius.
3. **Added dependency maintenance note to `AGENTS.md`** — documents that `.uplugin` `PythonRequirements` must be updated when bumping transitive dependencies in `pyproject.toml`.

### What is the impact of this change?

- Resolves the silent init failure caused by stale `typing_extensions` in PipInstall.
- Unlike `sys.path.insert(0, ...)`, the targeted insertion does not risk shadowing the standard library, UE core packages, or other plugins.
- The `.uplugin` pin ensures UE proactively installs a compatible `typing_extensions` rather than relying on path ordering.

### How was this change tested?

Unit test results:
```
-------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                      2838    762    754     58    70%
Coverage HTML written to dir build/coverage
Coverage XML written to file build/coverage/coverage.xml
Required test coverage of 65.0% reached. Total coverage: 69.99%
=================================================================== slowest 5 durations ===================================================================
1.00s call     test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py::TestUnrealAdaptor_on_start::test_init_data_wrong_schema
0.13s call     test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py::TestUnrealOpenJob::test__build_template
0.12s call     test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py::TestUnrealAdaptor_on_start::test_unreal_init_timeout
0.10s call     test/test_copyright_headers.py::test_copyright_headers
0.05s call     test/deadline_submitter_for_unreal/unit/test_python397_patch.py::TestPython397Patch::test_patch_skipped_on_other_python_versions
============================================================= 460 passed, 2 skipped in 11.47s =============================================================

```

### Have you run a render job successfully with these changes?

No — There is no submitter or adaptor changes

### Was this change documented?

Yes — added a "Dependency Version Bumps" section to `AGENTS.md` documenting the `.uplugin` maintenance requirement.

### Is this a breaking change?

No. This is a backwards-compatible fix. The `.uplugin` pin only upgrades `typing_extensions` if the cached version is too old. The `sys.path` change preserves the same import precedence for all paths except PipInstall.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
