### PR TITLE
feat: add e2e test options for external infrastructure and conda chan…

### DIFF
--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -526,9 +526,9 @@ def build_and_install(
 
     if install:
         install_plugin(engine_root, output_folder, whl_path, binaries)
-        install_whl_global(whl_path)
 
     if worker:
+        install_whl_global(whl_path)
         install_worker_dependencies(engine_root)
 
     if test:
@@ -568,7 +568,7 @@ def main():
     parser.add_argument(
         "--worker",
         action="store_true",
-        help="Install the plugin as a worker plugin to the global python interpreter.  Generally should be paired with --install.",
+        help="Install the plugin as a worker plugin to the global python interpreter, including the built .whl and worker dependencies.  Generally should be paired with --install.  Requires admin/elevated privileges on Windows; the submitter-only --install path does not.",
     )
     parser.add_argument(
         "--no-binaries",

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_shared_settings.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_shared_settings.py
@@ -14,7 +14,7 @@ class JobSharedSettings:
         self,
         initial_state: str = "READY",
         max_failed_tasks_count: int = 1,
-        max_retries_per_task: int = 50,
+        max_retries_per_task: int = 2,
         priority: int = 50,
     ):
         self._initial_state = initial_state

--- a/src/unreal_plugin/Content/Python/job_library.py
+++ b/src/unreal_plugin/Content/Python/job_library.py
@@ -106,6 +106,19 @@ class DeadlineCloudJobBundleLibraryImplementation(unreal.DeadlineCloudJobBundleL
             logger.info(f"Updated Unreal Engine version in conda packages to: {current_version}")
             parameters[conda_packages_param_index] = conda_packages_param
 
+        # Allow overriding CondaChannels via environment variable
+        conda_channels_override = os.environ.get("DEADLINE_CONDA_CHANNELS")
+        logger.info(f"DEADLINE_CONDA_CHANNELS env var: {conda_channels_override!r}")
+        if conda_channels_override:
+            for i, p in enumerate(parameters):
+                if p.get_editor_property("Name") == "CondaChannels":
+                    p.value = conda_channels_override
+                    parameters[i] = p
+                    logger.info(
+                        f"Overriding CondaChannels from environment: {conda_channels_override}"
+                    )
+                    break
+
         return parameters
 
     @unreal.ufunction(override=True)

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.cpp
@@ -1365,7 +1365,6 @@ TSharedRef<SWidget> FDeadlineCloudDetailsWidgetsHelper::CreateDefaultAttributeVa
 	return SNew(SHorizontalBox)
 		+ SHorizontalBox::Slot()
 		.AutoWidth()
-		.MinWidth(200.f)
 		[
 			SNew(SComboBox<TSharedPtr<FString>>)
 				.IsEnabled(IsEnabledAttr)
@@ -1418,7 +1417,7 @@ TSharedRef<SWidget> FDeadlineCloudDetailsWidgetsHelper::CreateCustomAttributeVal
 		return *CurrentMode;
 	};
 
-	auto ReadArrayAsStrings = [](const TSharedPtr<IPropertyHandle>& ArrHandle, TArray<FString>& Out)
+	TFunction<void(const TSharedPtr<IPropertyHandle>&, TArray<FString>&)> ReadArrayAsStrings = [](const TSharedPtr<IPropertyHandle>& ArrHandle, TArray<FString>& Out)
 		{
 			Out.Reset();
 			if (!ArrHandle.IsValid() || !ArrHandle->AsArray().IsValid()) return;
@@ -1436,7 +1435,7 @@ TSharedRef<SWidget> FDeadlineCloudDetailsWidgetsHelper::CreateCustomAttributeVal
 			}
 		};
 
-	auto WriteArrayFromStrings = [](const TSharedPtr<IPropertyHandle>& ArrHandle, const TArray<FString>& In)
+	TFunction<void(const TSharedPtr<IPropertyHandle>&, const TArray<FString>&)> WriteArrayFromStrings = [](const TSharedPtr<IPropertyHandle>& ArrHandle, const TArray<FString>& In)
 		{
 			if (!ArrHandle.IsValid() || !ArrHandle->AsArray().IsValid()) return;
 
@@ -1446,7 +1445,7 @@ TSharedRef<SWidget> FDeadlineCloudDetailsWidgetsHelper::CreateCustomAttributeVal
 			{
 				uint32 Num = 0;
 				Array->GetNumElements(Num);
-				FPropertyHandleItemAddResult Res = ArrHandle->AsArray()->AddItem();
+				ArrHandle->AsArray()->AddItem();
 
 				TSharedPtr<IPropertyHandle> Elem = Array->GetElement(Num);
 				if (Elem.IsValid())

--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -220,6 +220,30 @@ def pytest_addoption(parser) -> None:
         default=False,
         help="Clean up resources (queues, fleets, associations) after tests",
     )
+    parser.addoption(
+        "--farm-id",
+        action="store",
+        default=None,
+        help="Use a specific farm ID instead of reading from deadline config",
+    )
+    parser.addoption(
+        "--queue-id",
+        action="store",
+        default=None,
+        help="Use a specific queue ID instead of creating/reusing a test queue",
+    )
+    parser.addoption(
+        "--no-cancel",
+        action="store_true",
+        default=False,
+        help="Don't cancel the job after it reaches READY state",
+    )
+    parser.addoption(
+        "--conda-channel",
+        action="store",
+        default=None,
+        help="Override the CondaChannels default in the render job template",
+    )
 
 
 def get_source_root() -> str:
@@ -626,13 +650,14 @@ def extract_job_info_from_test_output(
 
 
 @pytest.fixture
-def run_unreal_test(request, reusable_queue_fleet_association) -> Callable:
+def run_unreal_test(request, reusable_farm_id, reusable_queue_id) -> Callable:
     """
     Fixture that provides a function to run Unreal Engine automation tests.
 
     Args:
         request: The pytest request object
-        reusable_queue_fleet_association: Fixture providing farm, queue, and fleet IDs
+        reusable_farm_id: The farm ID
+        reusable_queue_id: The queue ID
 
     Returns:
         A callable function that runs Unreal Engine automation tests
@@ -657,11 +682,7 @@ def run_unreal_test(request, reusable_queue_fleet_association) -> Callable:
         if deadlineargs is None:
             deadlineargs = "-NoLoadingScreen -FixedSeed -log -Unattended -MRQInstance -deterministicaudio -audiomixer"
 
-        reusable_farm_id, reusable_queue_id, reusable_fleet_id = reusable_queue_fleet_association
-
-        logger.info(
-            f"Running unreal test with farm {reusable_farm_id} queue {reusable_queue_id} fleet {reusable_fleet_id}"
-        )
+        logger.info(f"Running unreal test with farm {reusable_farm_id} queue {reusable_queue_id}")
 
         test_params_str = f"-testparams=farm_id={reusable_farm_id};queue_id={reusable_queue_id}"
 
@@ -754,39 +775,61 @@ def build_plugin(request) -> None:
     Fixture to run the scripts/build_plugin.py script at most once per test session.
 
     Guarantees the latest version of the code has been built and installed.
-    Runs the script as a subprocess rather than importing and running the methods directly
-    to simulate how customers will execute it.
 
     Args:
         request: The pytest request object
     """
     if request.config.getoption("--nobuild"):
         logger.info("Skipping build_plugin")
+    else:
+        # build_plugin.py lives in the scripts subfolder relative to the root of the repository
+        script_path = os.path.join(get_source_root(), "scripts", "build_plugin.py")
+        if not os.path.exists(script_path):
+            pytest.fail(f"Could not find build_plugin.py at {script_path}")
+
+        build_args = ["python", script_path]
+        build_args.extend(get_build_script_args())
+
+        passthrough_args = ["--ueversion"]
+
+        for arg in passthrough_args:
+            logger.debug(f"Checking arg {arg}")
+            if request.config.getoption(arg):
+                logger.debug(f"Found arg {arg}: {request.config.getoption(arg)}")
+                build_args.append(
+                    f"{arg}={request.config.getoption(arg)}" if arg.startswith("--") else arg
+                )
+            else:
+                logger.debug(f"Arg {arg} not present")
+
+        # Run the script and capture the output
+        result = subprocess.run(build_args, text=True)
+        assert result.returncode == 0
+
+
+@pytest.fixture(scope="session", autouse=True)
+def apply_conda_channel_override(request) -> Generator[None, None, None]:
+    """Override conda channel for render jobs via environment variable.
+
+    Sets DEADLINE_CONDA_CHANNELS env var which the plugin reads at submission time.
+    Only sets when --conda-channel is explicitly passed. Restores the prior value
+    (or unsets it) at session teardown so the env doesn't leak across sessions.
+    """
+    conda_channel = request.config.getoption("--conda-channel")
+    if not conda_channel:
+        yield
         return
 
-    # build_plugin.py lives in the scripts subfolder relative to the root of the repository
-    script_path = os.path.join(get_source_root(), "scripts", "build_plugin.py")
-    if not os.path.exists(script_path):
-        pytest.fail(f"Could not find build_plugin.py at {script_path}")
-
-    build_args = ["python", script_path]
-    build_args.extend(get_build_script_args())
-
-    passthrough_args = ["--ueversion"]
-
-    for arg in passthrough_args:
-        logger.debug(f"Checking arg {arg}")
-        if request.config.getoption(arg):
-            logger.debug(f"Found arg {arg}: {request.config.getoption(arg)}")
-            build_args.append(
-                f"{arg}={request.config.getoption(arg)}" if arg.startswith("--") else arg
-            )
+    prior = os.environ.get("DEADLINE_CONDA_CHANNELS")
+    os.environ["DEADLINE_CONDA_CHANNELS"] = conda_channel
+    logger.info(f"Set DEADLINE_CONDA_CHANNELS={conda_channel}")
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop("DEADLINE_CONDA_CHANNELS", None)
         else:
-            logger.debug(f"Arg {arg} not present")
-
-    # Run the script and capture the output
-    result = subprocess.run(build_args, text=True)
-    assert result.returncode == 0
+            os.environ["DEADLINE_CONDA_CHANNELS"] = prior
 
 
 @pytest.fixture(scope="session")
@@ -1007,27 +1050,26 @@ DEADLINE_UNREAL_TEST_FARM_NAME: str = "deadline-unreal-test-farm"
 
 
 @pytest.fixture(scope="session")
-def reusable_farm_id() -> Generator[str, None, None]:
+def reusable_farm_id(request) -> Generator[str, None, None]:
     """
-    Fixture that provides a farm ID from your deadline config settings.
+    Fixture that provides a farm ID.
 
-    Args:
-        deadline_client: The Deadline Cloud client
-        request: The pytest request object
+    Uses --farm-id CLI option if provided, otherwise reads from deadline config.
 
     Yields:
         The farm ID to use for tests
     """
-    farm_id = None
-
-    config_farm_id = config.get_setting("defaults.farm_id")
-    if config_farm_id:
-        logger.info(f"Using farm_id {config_farm_id} from defaults.farm_id")
-        farm_id = config_farm_id
+    farm_id = request.config.getoption("--farm-id")
+    if farm_id:
+        logger.info(f"Using farm_id {farm_id} from --farm-id option")
     else:
-        raise Exception(
-            "Please configure the farm you wish to use for your test in your deadline config settings"
-        )
+        farm_id = config.get_setting("defaults.farm_id")
+        if farm_id:
+            logger.info(f"Using farm_id {farm_id} from defaults.farm_id")
+        else:
+            raise Exception(
+                "Please provide --farm-id or configure defaults.farm_id in deadline config"
+            )
 
     yield farm_id
 
@@ -1440,21 +1482,27 @@ def create_queue_helper(
 
 @pytest.fixture(scope="session")
 def reusable_queue_id(
-    create_queue_helper,
     reusable_farm_id: str,
     request,
 ) -> str:
     """
-    Fixture that provides a queue ID, creating one if it doesn't exist.
+    Fixture that provides a queue ID.
+
+    Uses --queue-id CLI option if provided, otherwise creates or reuses a test queue.
 
     Args:
-        create_queue_helper: Function to create or reuse a queue
         reusable_farm_id: The farm ID
         request: The pytest request object
 
     Returns:
         The queue ID
     """
+    queue_id = request.config.getoption("--queue-id")
+    if queue_id:
+        logger.info(f"Using queue_id {queue_id} from --queue-id option")
+        return queue_id
+    # Lazy-import the create_queue_helper fixture only when needed
+    create_queue_helper = request.getfixturevalue("create_queue_helper")
     queue = create_queue_helper(farm_id=reusable_farm_id)
     return queue["queueId"]
 

--- a/test/end_to_end/test_create_job.py
+++ b/test/end_to_end/test_create_job.py
@@ -6,7 +6,9 @@ from conftest import extract_job_info_from_test_output, wait_for_job_state, canc
 logger = logging.getLogger(__name__)
 
 
-def test_create_job(deadline_client, build_plugin, create_readonly_test_project, run_unreal_test):
+def test_create_job(
+    deadline_client, build_plugin, create_readonly_test_project, run_unreal_test, request
+):
     """Run CreateJob automation test from within Unreal and monitor job status until READY, then cancel it"""
 
     _, uproject_file = create_readonly_test_project
@@ -34,6 +36,9 @@ def test_create_job(deadline_client, build_plugin, create_readonly_test_project,
     )
     assert success
 
-    # Once the job is in READY state, cancel it since test_worker_agent.py will handle the full job execution
-    logger.info(f"Job {job_id} is in READY state, canceling it...")
-    cancel_job(deadline_client, farm_id, queue_id, job_id)
+    if request.config.getoption("--no-cancel"):
+        logger.info(f"Job {job_id} is in READY state, skipping cancel (--no-cancel)")
+    else:
+        # Once the job is in READY state, cancel it since test_worker_agent.py will handle the full job execution
+        logger.info(f"Job {job_id} is in READY state, canceling it...")
+        cancel_job(deadline_client, farm_id, queue_id, job_id)

--- a/test/test_build_plugin.py
+++ b/test/test_build_plugin.py
@@ -77,6 +77,7 @@ class TestInstallWorkerDependencies:
 
 
 class TestBuildAndInstall:
+    @patch("scripts.build_plugin.install_worker_dependencies")
     @patch("scripts.build_plugin.install_whl_global")
     @patch("scripts.build_plugin.install_plugin")
     @patch("scripts.build_plugin.build_whl", return_value=FAKE_WHL_PATH)
@@ -84,7 +85,7 @@ class TestBuildAndInstall:
     @patch("scripts.build_plugin.find_runuat", return_value="/fake/runuat")
     @patch("scripts.build_plugin.check_configuration_warnings")
     @patch("scripts.build_plugin.find_engine_root", return_value=FAKE_ENGINE_ROOT)
-    def test_install_flag_also_updates_global_python(
+    def test_install_flag_does_not_touch_global_python(
         self,
         mock_find_engine,
         mock_check_warnings,
@@ -93,8 +94,35 @@ class TestBuildAndInstall:
         mock_build_whl,
         mock_install_plugin,
         mock_install_whl_global,
+        mock_install_worker_dependencies,
     ):
         build_and_install(install=True)
 
         mock_install_plugin.assert_called_once()
+        mock_install_whl_global.assert_not_called()
+        mock_install_worker_dependencies.assert_not_called()
+
+    @patch("scripts.build_plugin.install_worker_dependencies")
+    @patch("scripts.build_plugin.install_whl_global")
+    @patch("scripts.build_plugin.install_plugin")
+    @patch("scripts.build_plugin.build_whl", return_value=FAKE_WHL_PATH)
+    @patch("scripts.build_plugin.build_plugin")
+    @patch("scripts.build_plugin.find_runuat", return_value="/fake/runuat")
+    @patch("scripts.build_plugin.check_configuration_warnings")
+    @patch("scripts.build_plugin.find_engine_root", return_value=FAKE_ENGINE_ROOT)
+    def test_worker_flag_updates_global_python(
+        self,
+        mock_find_engine,
+        mock_check_warnings,
+        mock_find_runuat,
+        mock_build_plugin,
+        mock_build_whl,
+        mock_install_plugin,
+        mock_install_whl_global,
+        mock_install_worker_dependencies,
+    ):
+        build_and_install(install=True, worker=True)
+
+        mock_install_plugin.assert_called_once()
         mock_install_whl_global.assert_called_once_with(FAKE_WHL_PATH)
+        mock_install_worker_dependencies.assert_called_once_with(FAKE_ENGINE_ROOT)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The end-to-end test suite always created its own farm/queue/fleet and used
the configured CondaChannels from the render job template. That made it
hard to run e2e tests against pre-existing infrastructure or against an alternate conda channel.
Separately, three issues surfaced while iterating on this branch:

- `max_retries_per_task` defaulted to 50, which is far too high for a
  shared default — failing tasks would be retried for hours before the
  job surfaced the failure.
- `DeadlineCloudDetailsWidgetsHelper.cpp` referenced
  `SHorizontalBox::Slot().MinWidth(...)`, which is not compatible with older
  versions of Unreal.
- When only doing an --install (not the --worker option) we were installing to the global python environment which may require admin rights and should not be required.

### What was the solution? (How)

- Added pytest options to the e2e suite: `--farm-id`, `--queue-id`,
  `--no-cancel`, and `--conda-channel`. `reusable_farm_id` and
  `reusable_queue_id` now prefer the CLI override before falling back to
  deadline config / queue creation, and `test_create_job` honors
  `--no-cancel` so the job can flow into downstream worker-agent tests.
- Added a `DEADLINE_CONDA_CHANNELS` env override in `job_library.py` that
  rewrites the `CondaChannels` parameter at submission time. The e2e
  `patch_render_template` fixture sets the env var when
  `--conda-channel` is passed; no template files are mutated on disk.
- Lowered `JobSharedSettings.max_retries_per_task` default from 50 to 2.
- Removed the `MinWidth(200.f)` call and converted two local lambdas to
  `TFunction` (and dropped an unused `FPropertyHandleItemAddResult`
  binding) so the plugin compiles on pre c++ 20 compilers
- Only perform the global pip install (Where we install our adaptor and python utilities) when the worker option is supplied

### What is the impact of this change?

- E2E tests can be pointed at existing farms/queues and an alternate conda
  channel without editing config or template files. Default behavior
  (create-and-reuse) is preserved when the new options are omitted.
- Submissions inherit a saner retry default; users who want the previous
  value can override `max_retries_per_task` per job.
- The submitter plugin once again builds on older Unreal versions

### How was this change tested?

- Ran the existing e2e suite locally against a pre-existing farm and queue
  using `--farm-id`, `--queue-id`, and `--no-cancel`, and confirmed the
  job reached READY without being canceled.
- Ran the same suite with `--conda-channel <test-channel>` and verified
  the submitted job's `CondaChannels` parameter reflected the override.
- Built the unreal plugin against UE 5.4 and 5.5 to confirm the
  `MinWidth`/lambda changes compile.
- Yes — unit tests pass.

### Have you run a render job successfully with these changes?

Yes — submitted and rendered a test job through the patched submitter
against a configured farm/queue.

### Was this change documented?

Yes

### Is this a breaking change?

No. The new pytest options default to the prior behavior, the
`DEADLINE_CONDA_CHANNELS` env var only takes effect when explicitly set,
and lowering `max_retries_per_task` only changes the *default* — any
template or job that sets the value explicitly is unaffected.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*