### PR TITLE
fix: guard adaptor against None LevelSequence + force custom playback range in chunked renders

### DIFF
--- a/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
+++ b/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
@@ -75,15 +75,35 @@ if unreal:
                         )
                     )
                     if level_sequence is None:
-                        logger.error(
-                            "Render Executor: Error: Level Sequence not loaded. Check if the sequence "
-                            "exists and is valid"
+                        # Defensive fallback: if the LevelSequence can't be loaded
+                        # (we have seen this happen in production for reasons that
+                        # are not always reproducible), use the MRQ output_settings
+                        # custom range if it is non-empty. This avoids crashing the
+                        # render with an `AttributeError: 'NoneType' object has no
+                        # attribute 'get_playback_end'` when something upstream
+                        # caused the loader to return None.
+                        if output_settings.custom_end_frame > output_settings.custom_start_frame:
+                            logger.warning(
+                                "Render Executor: Level Sequence not loaded; falling back to "
+                                f"output_settings custom range "
+                                f"[{output_settings.custom_start_frame}, "
+                                f"{output_settings.custom_end_frame}]"
+                            )
+                            self.totalFrameRange += (
+                                output_settings.custom_end_frame
+                                - output_settings.custom_start_frame
+                            )
+                        else:
+                            logger.error(
+                                "Render Executor: Error: Level Sequence not loaded and "
+                                "output_settings has no custom range. Check if the sequence "
+                                "exists and is valid."
+                            )
+                            return
+                    else:
+                        self.totalFrameRange += (
+                            level_sequence.get_playback_end() - level_sequence.get_playback_start()
                         )
-                        return
-
-                    self.totalFrameRange += (
-                        level_sequence.get_playback_end() - level_sequence.get_playback_start()
-                    )
 
                 if self.totalFrameRange == 0:
                     logger.error(
@@ -314,6 +334,33 @@ class UnrealRenderStepHandler(BaseStepHandler):
                 logger.info(
                     f"Cached custom frame range from {UnrealRenderStepHandler.cached_frame_range_start} to {UnrealRenderStepHandler.cached_frame_range_end}"
                 )
+            elif level_sequence is None:
+                # The caller passed a None LevelSequence (e.g. the loader returned
+                # None for reasons that are not always reproducible). Fall back to
+                # the MRQ output_settings custom range so chunked renders can still
+                # emit frames; otherwise we'd crash on
+                # `NoneType.get_playback_range()` further down. If output_settings
+                # has no non-empty range either, leave the cache unset and surface
+                # an error so misconfigured jobs aren't silently masked.
+                if output_settings.custom_end_frame > output_settings.custom_start_frame:
+                    UnrealRenderStepHandler.cached_frame_range_start = (
+                        output_settings.custom_start_frame
+                    )
+                    UnrealRenderStepHandler.cached_frame_range_end = (
+                        output_settings.custom_end_frame
+                    )
+                    logger.warning(
+                        "level_sequence is None in get_frame_range; using "
+                        f"output_settings custom range "
+                        f"[{UnrealRenderStepHandler.cached_frame_range_start}, "
+                        f"{UnrealRenderStepHandler.cached_frame_range_end}]"
+                    )
+                else:
+                    logger.error(
+                        "level_sequence is None and output_settings has no custom range; "
+                        "frame range cannot be determined"
+                    )
+                    return (None, None)
             else:
                 UnrealRenderStepHandler.cached_frame_range_start = (
                     level_sequence.get_playback_range().get_start_frame()
@@ -381,6 +428,12 @@ class UnrealRenderStepHandler(BaseStepHandler):
                 frame_range_start, frame_range_end = self.get_frame_range(
                     output_settings, level_sequence
                 )
+                if frame_range_start is None or frame_range_end is None:
+                    logger.error(
+                        "Frame range unavailable; cannot compute chunk window for "
+                        f"chunk_id={chunk_id} frames_per_task={frames_per_task}"
+                    )
+                    return False
 
                 output_settings.custom_start_frame = frame_range_start + (
                     chunk_id * frames_per_task
@@ -388,11 +441,28 @@ class UnrealRenderStepHandler(BaseStepHandler):
                 output_settings.custom_end_frame = min(
                     output_settings.custom_start_frame + frames_per_task, frame_range_end
                 )
-                level_sequence.set_playback_start(output_settings.custom_start_frame)
-                level_sequence.set_playback_end(output_settings.custom_end_frame)
-                logger.info(
-                    f"Rendering custom frame range from {output_settings.custom_start_frame} to {output_settings.custom_end_frame} with sequence playback start {level_sequence.get_playback_start()} end {level_sequence.get_playback_end()}"
-                )
+                # Force MRQ to honour the per-chunk window set above. Without this
+                # flag, MRQ falls back to the full range baked into the MRQ preset
+                # whenever `use_custom_playback_range` is false on the output
+                # settings -- which causes every chunked task to redundantly
+                # re-render the entire sequence. Observed in a 40-chunk render
+                # where each chunk re-rendered frames 0..end instead of its
+                # assigned window.
+                output_settings.use_custom_playback_range = True
+
+                if level_sequence is not None:
+                    level_sequence.set_playback_start(output_settings.custom_start_frame)
+                    level_sequence.set_playback_end(output_settings.custom_end_frame)
+                    logger.info(
+                        f"Rendering custom frame range from {output_settings.custom_start_frame} to {output_settings.custom_end_frame} with sequence playback start {level_sequence.get_playback_start()} end {level_sequence.get_playback_end()}"
+                    )
+                else:
+                    logger.warning(
+                        "Rendering chunk frame range "
+                        f"[{output_settings.custom_start_frame}, "
+                        f"{output_settings.custom_end_frame}] without a resolved "
+                        "LevelSequence; relying on output_settings.use_custom_playback_range"
+                    )
             elif "chunk_size" in args and "chunk_id" in args:
                 chunk_size: int = args["chunk_size"]
                 UnrealRenderStepHandler.enable_shots_by_chunk(

--- a/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_none_guard.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_none_guard.py
@@ -1,0 +1,100 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Tests for the None-guard in ``UnrealRenderStepHandler.get_frame_range``.
+
+The adaptor has been observed crashing in production with
+``AttributeError: 'NoneType' object has no attribute 'get_playback_range'``
+when ``EditorAssetLibrary.load_asset`` returns ``None`` for the
+``LevelSequence`` referenced by a job. The previous behaviour was to call
+``level_sequence.get_playback_range()`` unconditionally, which crashes
+when the loader returned None. These tests pin the defensive behaviour:
+fall back to the MRQ ``output_settings`` custom range when it is
+non-empty, and return ``(None, None)`` otherwise so the caller can
+surface a clear error instead of crashing.
+"""
+
+import sys
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# Ensure ``unreal`` is in ``sys.modules`` before the source module first
+# imports it -- consistent with the other test files in this directory.
+sys.modules.setdefault("unreal", MagicMock())
+
+
+from deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler import (  # noqa: E402
+    UnrealRenderStepHandler,
+)
+
+
+@pytest.fixture()
+def fresh_handler():
+    UnrealRenderStepHandler.cached_frame_range_start = None
+    UnrealRenderStepHandler.cached_frame_range_end = None
+    return UnrealRenderStepHandler()
+
+
+class TestGetFrameRangeNoneGuard:
+    """When ``level_sequence`` is ``None`` and ``use_custom_playback_range`` is
+    false, ``get_frame_range`` must NOT raise ``AttributeError``. It should
+    fall back to the MRQ ``output_settings`` custom range, or return
+    ``(None, None)`` if no usable range exists at all.
+    """
+
+    def test_none_sequence_falls_back_to_custom_range_when_non_empty(self, fresh_handler):
+        output_settings = MagicMock()
+        output_settings.use_custom_playback_range = False
+        output_settings.custom_start_frame = 100
+        output_settings.custom_end_frame = 200
+
+        with patch(
+            "deadline.unreal_adaptor.UnrealClient.step_handlers."
+            "unreal_render_step_handler.logger.warning"
+        ) as log_warning:
+            start, end = fresh_handler.get_frame_range(output_settings, level_sequence=None)
+
+        assert (start, end) == (100, 200)
+        assert log_warning.called
+
+    def test_none_sequence_returns_none_when_custom_range_empty(self, fresh_handler):
+        output_settings = MagicMock()
+        output_settings.use_custom_playback_range = False
+        # Empty range: end <= start. No usable fallback.
+        output_settings.custom_start_frame = 0
+        output_settings.custom_end_frame = 0
+
+        with patch(
+            "deadline.unreal_adaptor.UnrealClient.step_handlers."
+            "unreal_render_step_handler.logger.error"
+        ) as log_error:
+            start, end = fresh_handler.get_frame_range(output_settings, level_sequence=None)
+
+        assert (start, end) == (None, None)
+        assert log_error.called
+
+    def test_use_custom_playback_range_overrides_none_sequence(self, fresh_handler):
+        """If ``use_custom_playback_range`` is True, the level_sequence is
+        never consulted -- None must be safe here."""
+        output_settings = MagicMock()
+        output_settings.use_custom_playback_range = True
+        output_settings.custom_start_frame = 5
+        output_settings.custom_end_frame = 25
+
+        start, end = fresh_handler.get_frame_range(output_settings, level_sequence=None)
+        assert (start, end) == (5, 25)
+
+    def test_non_none_sequence_still_uses_sequence_playback_range(self, fresh_handler):
+        """Regression guard: when a sequence loads, behaviour is unchanged."""
+        output_settings = MagicMock()
+        output_settings.use_custom_playback_range = False
+
+        playback_range = MagicMock()
+        playback_range.get_start_frame.return_value = 1
+        playback_range.get_end_frame.return_value = 100
+        level_sequence = MagicMock()
+        level_sequence.get_playback_range.return_value = playback_range
+
+        start, end = fresh_handler.get_frame_range(output_settings, level_sequence)
+        assert (start, end) == (1, 100)


### PR DESCRIPTION
## Summary

> **Note on scope** — an earlier revision of this PR proposed reordering the `LevelSequence` loader chain (`unreal.load_asset` first, `EditorAssetLibrary.load_asset` as fallback) under the hypothesis that the latter silently returns `None` under UE 5.7 + `-RenderOffscreen`. An empirical sweep across UE 5.4 / 5.5 / 5.6 / 5.7 against a freshly-created `LevelSequence` did **not** reproduce that failure mode — both loaders worked on every version. Without a verifiable repro the reorder was speculative, so I've dropped it. This PR is now narrowed to two defensive changes whose evidence is unambiguous, both relevant to #296.

### Change 1 — `get_frame_range` is None-guarded

`UnrealRenderStepHandler.get_frame_range` previously called `level_sequence.get_playback_range()` unconditionally. If the upstream loader returned `None` for any reason, the adaptor would crash with `AttributeError: 'NoneType' object has no attribute 'get_playback_range'` — which is the exact trace we have observed in production.

New behaviour: when `level_sequence is None` and `use_custom_playback_range` is false:
- If `output_settings.custom_end_frame > custom_start_frame`, use that MRQ custom range as a fallback and log a warning.
- Otherwise, return `(None, None)` so the caller can surface a clear error instead of crashing on attribute access. (The chunk path in `run_script` checks for this and returns `False`.)

This change does not attempt to claim a cause for why `level_sequence` might be `None`. It just refuses to crash on the resulting attribute access.

### Change 2 — force `use_custom_playback_range = True` in the `frames_per_task` chunk path

When `frames_per_task` + `chunk_id` are set, the chunk path computes a per-chunk `custom_start_frame` and `custom_end_frame` on `output_settings`. **But it never set `use_custom_playback_range = True`.** MRQ ignores the custom frame values when that flag is false and falls back to the playback range baked into the MRQ preset.

In a 40-chunk render with `frames_per_task` set, every task therefore rendered the full sequence rather than its assigned window — wasting ~40× the render time and producing last-writer-wins output frames.

This is provable by reading MRQ source (`MoviePipelineOutputSetting.cpp`) — `use_custom_playback_range` gates the use of `custom_start_frame` / `custom_end_frame` in `GetEffectivePlaybackRange`. Setting the bounds without flipping the flag is a no-op.

The fix is a one-liner: set the flag after computing the chunk window. This PR also adds a None-guard so that if the level sequence didn't load, the chunk window is still applied via `output_settings.use_custom_playback_range` (since `level_sequence.set_playback_start/end` are no-ops on `None`).

## Test plan

- [x] **Unit tests added** (`test_unreal_render_step_handler_none_guard.py`): four cases pinning `get_frame_range` behaviour:
  - None sequence + non-empty custom range → falls back to custom range, warns
  - None sequence + empty custom range → `(None, None)`, errors
  - `use_custom_playback_range = True` + None sequence → short-circuits regardless of None
  - Non-None sequence → uses `sequence.get_playback_range()` as before (regression guard)
- [x] **Existing tests pass**: 29 step-handler unit tests green (`pytest test/deadline_adaptor_for_unreal --no-cov`).
- [x] **Lint clean**: `ruff check` + `black --check` on the changed files.
- [x] **Empirical sweep against UE 5.4 / 5.5 / 5.6 / 5.7** (Mac, headless `UnrealEditor-Cmd -unattended -nullrhi`, freshly-created `LevelSequence`): both `unreal.load_asset` and `EditorAssetLibrary.load_asset` worked on every version. This is what convinced me to drop the loader reorder.

## What this PR is and is not

- **Is**: a defensive hardening against `NoneType` attribute access (the actual production crash trace) and a fix for an MRQ `use_custom_playback_range` gating bug (independently verifiable from MRQ source). Both are scoped to the chunked-render path that the OpenJD adaptor uses.
- **Is not**: a claim about what causes `level_sequence` to be `None`, nor a fix for the speculative `EditorAssetLibrary.load_asset` UE 5.7 regression that the original #296 report alleged. If that regression exists, it's not the one this PR fixes — and I no longer have evidence that it exists at all.

Refs #296. (Earlier conversation on #296 referenced a loader-reorder fix; the comment on the issue has been updated with the narrower framing.)

Signed-off-by: Adam Krebs <931368+akre54@users.noreply.github.com>
