### PR TITLE
fix: add {task_index} token to MRQ FileNameFormat for chunked renders

### DIFF
--- a/docs/source/docs_usage/use_cases/create_render_job.rst
+++ b/docs/source/docs_usage/use_cases/create_render_job.rst
@@ -61,6 +61,16 @@ Render Job data asset
    #. FramesPerTask - Divide up the total number of frames to be rendered in the sequence by this value to
       determine the total number of Deadline Cloud tasks to create, with each task aiming to render this number
       of frames.
+
+      .. note::
+         When chunking a render across multiple tasks, MRQ writes one output file per task.
+         For image sequences (PNG/EXR/etc.) the default ``FileNameFormat`` already includes
+         ``{frame_number}``, so each task's output is unique. For video containers such as
+         ``.mov`` the default format is just ``{sequence_name}`` and every task will write to
+         the same filename, overwriting each other. To disambiguate, add the ``{task_index}``
+         token to the MRQ Output Setting's ``FileNameFormat`` (for example
+         ``{sequence_name}_{task_index}``). The submitter substitutes ``{task_index}`` at
+         render time with a zero-padded per-task index.
    #. ExtraCmdArgs - Additional CMD arguments to launch Unreal executable with
    #. ExtraCmdArgsFile - Specific file parameter where **ExtraCmdArgs** will be stored.
       Need to avoid **1024 chars limit** on **STRING** parameter. **Filled automatically during the submission**

--- a/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
+++ b/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
@@ -289,6 +289,32 @@ class UnrealRenderStepHandler(BaseStepHandler):
         pipeline_queue.copy_from(movie_pipeline_queue_asset)
 
     @staticmethod
+    def _apply_task_index_to_filename(render_job, task_index: int) -> None:
+        """
+        Substitute ``{task_index}`` in MRQ's FileNameFormat with the per-task index so
+        chunked renders that produce a single file per task (e.g. .mov containers) do
+        not collide on the same output filename. If the resolved format contains no
+        per-task token (neither ``{task_index}`` nor ``{frame_number}``), warn that
+        outputs from sibling tasks will overwrite each other.
+        """
+        output_settings = render_job.get_configuration().find_or_add_setting_by_class(
+            unreal.MoviePipelineOutputSetting
+        )
+        file_name_format = output_settings.file_name_format or ""
+        if "{task_index}" in file_name_format:
+            output_settings.file_name_format = file_name_format.replace(
+                "{task_index}", f"{task_index:04d}"
+            )
+        elif "{frame_number}" not in file_name_format:
+            logger.warning(
+                "FileNameFormat %r contains no per-task token; outputs from sibling "
+                "tasks will overwrite each other. Add {task_index} to FileNameFormat "
+                "to disambiguate per-task output (recommended for video containers "
+                "such as .mov where {frame_number} is not present by default).",
+                file_name_format,
+            )
+
+    @staticmethod
     def enable_shots_by_chunk(render_job, task_chunk_size: int, task_chunk_id: int):
 
         all_shots_to_render = [shot for shot in render_job.shot_info if shot.enabled]
@@ -400,6 +426,9 @@ class UnrealRenderStepHandler(BaseStepHandler):
                     task_chunk_size=chunk_size,
                     task_chunk_id=chunk_id,
                 )
+
+            if "chunk_id" in args and (args.get("frames_per_task") or "chunk_size" in args):
+                UnrealRenderStepHandler._apply_task_index_to_filename(job, chunk_id)
 
             if "output_path" in args:
                 if not os.path.exists(args["output_path"]):

--- a/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_frames_per_task.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_frames_per_task.py
@@ -238,6 +238,77 @@ class TestUnrealRenderStepHandlerFramesPerTask:
             assert calculated_start == 101
             assert calculated_end == 50  # Clamped to range end
 
+    @pytest.mark.parametrize(
+        "fmt, task_index, expected",
+        [
+            ("{sequence_name}_{task_index}", 0, "{sequence_name}_0000"),
+            ("{sequence_name}_{task_index}", 7, "{sequence_name}_0007"),
+            ("{shot_name}.{task_index}.{render_pass}", 42, "{shot_name}.0042.{render_pass}"),
+        ],
+    )
+    def test_apply_task_index_substitutes_token(
+        self, unreal_render_step_handler, fmt, task_index, expected
+    ):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler as handler_mod,
+        )
+
+        output_settings = MagicMock()
+        output_settings.file_name_format = fmt
+        render_job = MagicMock()
+        render_job.get_configuration.return_value.find_or_add_setting_by_class.return_value = (
+            output_settings
+        )
+
+        with patch.object(handler_mod, "unreal", MagicMock()):
+            handler_mod.UnrealRenderStepHandler._apply_task_index_to_filename(
+                render_job, task_index
+            )
+
+        assert output_settings.file_name_format == expected
+
+    def test_apply_task_index_warns_when_no_per_task_token(self, unreal_render_step_handler):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler as handler_mod,
+        )
+
+        output_settings = MagicMock()
+        output_settings.file_name_format = "{sequence_name}"
+        render_job = MagicMock()
+        render_job.get_configuration.return_value.find_or_add_setting_by_class.return_value = (
+            output_settings
+        )
+
+        with (
+            patch.object(handler_mod, "unreal", MagicMock()),
+            patch.object(handler_mod.logger, "warning") as warn_mock,
+        ):
+            handler_mod.UnrealRenderStepHandler._apply_task_index_to_filename(render_job, 3)
+
+        assert output_settings.file_name_format == "{sequence_name}"
+        warn_mock.assert_called_once()
+
+    def test_apply_task_index_silent_when_frame_number_present(self, unreal_render_step_handler):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler as handler_mod,
+        )
+
+        output_settings = MagicMock()
+        output_settings.file_name_format = "{sequence_name}.{frame_number}"
+        render_job = MagicMock()
+        render_job.get_configuration.return_value.find_or_add_setting_by_class.return_value = (
+            output_settings
+        )
+
+        with (
+            patch.object(handler_mod, "unreal", MagicMock()),
+            patch.object(handler_mod.logger, "warning") as warn_mock,
+        ):
+            handler_mod.UnrealRenderStepHandler._apply_task_index_to_filename(render_job, 3)
+
+        assert output_settings.file_name_format == "{sequence_name}.{frame_number}"
+        warn_mock.assert_not_called()
+
     def test_static_method_behavior(self, unreal_render_step_handler):
         """Test that get_frame_range is a static method and caching works across instances"""
         # GIVEN


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When an MRQ render is split across multiple Deadline tasks (via
`FramesPerTask` or `TaskChunkSize`), each task writes to MRQ's
`FileNameFormat`. For image-sequence outputs the engine's default
`FileNameFormat` includes `{frame_number}`, so each task's per-frame
files are unique on disk. For video-container outputs such as `.mov`
(ProRes etc.) the default has no `{frame_number}` — there's only one
file per task — and every task ends up writing the same filename,
clobbering each other. Customers running 5-tasks-per-shot were getting
five `.mov` files all named `shot1.mov`, then having to stitch the
results back together themselves.

### What was the solution? (How)

- Added a `{task_index}` token to MRQ `FileNameFormat`. When chunking is
  active, the render-step adaptor substitutes `{task_index}` with a
  zero-padded per-task index (e.g. `0003`) before MRQ resolves the
  output path. Customers add `{task_index}` to `FileNameFormat`
  themselves (e.g. `{sequence_name}_{task_index}`) — we don't silently
  rewrite their format.
- When chunking is active and the resolved `FileNameFormat` contains
  no per-task token (neither `{task_index}` nor `{frame_number}`), the
  worker now logs a warning so silent overwrites are surfaced instead
  of being a quiet correctness bug.
- Documented the new token under `FramesPerTask` in
  `docs/source/docs_usage/use_cases/create_render_job.rst`.

### What is the impact of this change?

- Customers chunking video-container renders (`.mov`, `.mp4`, etc.) can
  now get unique per-task output files by adding `{task_index}` to
  `FileNameFormat`.
- Existing renders are unaffected: the substitution and warning only
  fire when chunking is in effect, and the substitution is a no-op
  unless the customer opts in by including the token. No on-disk
  filenames change for existing setups.

### How was this change tested?

- Added unit tests covering: the substitution with multiple format
  patterns and indices, the no-token warning firing when chunking is
  active without a per-task token, and the warning being suppressed
  when `{frame_number}` is already present.
- Yes — full unit test suite passes locally
- Live end-to-end: submitted a chunked ProRes `.mov` job from the
  submitter to a CMF worker with the patched adaptor and
  `FileNameFormat = {sequence_name}_{task_index}`. Confirmed each task
  produced a unique `<sequence>_0000.mov`, `<sequence>_0001.mov`, etc.,
  and that submitting the same job without the token produced the
  warning in the worker log.

### Have you run a render job successfully with these changes?

Yes — chunked ProRes `.mov` render against a CMF worker, with each
task producing a uniquely named output as expected.

### Was this change documented?

Yes — added a note under `FramesPerTask` in the user guide
(`docs/source/docs_usage/use_cases/create_render_job.rst`) explaining
when `.mov` chunked outputs collide and how to resolve it by adding
`{task_index}` to MRQ's `FileNameFormat`. The new helper carries a
docstring describing the substitution and warning behavior.

### Is this a breaking change?

No. Existing `FileNameFormat` strings without `{task_index}` continue
to render exactly as before; the substitution is opt-in. The added
warning only logs (does not raise) and only when chunking is active,
so jobs that previously succeeded continue to succeed. No changes to
init-data, run-data, or any public adaptor interface.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*