### PR TITLE
fix: ship a default UnrealAdaptor.json with the package

### DIFF
--- a/src/deadline/unreal_adaptor/UnrealAdaptor/UnrealAdaptor.json
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/UnrealAdaptor.json
@@ -1,0 +1,3 @@
+{
+    "log_level": "DEBUG"
+}


### PR DESCRIPTION
Fixes: *N/A — no tracking issue*

### What was the problem/requirement? (What/Why)

`deadline-cloud-for-unreal-engine` does not ship a default `UnrealAdaptor.json` configuration file alongside the `UnrealAdaptor` module. The sister DCC adaptor `deadline-cloud-for-cinema-4d` does ship a `Cinema4DAdaptor.json` (containing `{"log_level": "DEBUG"}`) at the equivalent path in its package. The two adaptors should be consistent.

A package-bundled default config also gives the package author a clear place to set default behavior for the adaptor (such as the log level) without depending on the adaptor runtime synthesizing an empty config at runtime.

### What was the solution? (How)

Add `src/deadline/unreal_adaptor/UnrealAdaptor/UnrealAdaptor.json` containing `{"log_level": "DEBUG"}`, mirroring the layout and content of `deadline-cloud-for-cinema-4d`'s `src/deadline/cinema4d_adaptor/Cinema4DAdaptor/Cinema4DAdaptor.json`.

`hatch`'s default file inclusion under `[tool.hatch.build.targets.wheel] packages = ["src/deadline"]` already picks up non-`.py` files, so no `pyproject.toml` changes were required. The existing `schemas/*.schema.json` files in the same module ship via the same mechanism today.

### What is the impact of this change?

- The default adaptor `log_level` becomes `DEBUG` instead of the runtime's default of `INFO`. Adaptor logs become more verbose. This can be overridden via the system or user configuration files (see `openjd-adaptor-runtime`'s `ConfigurationManager` precedence) for any user who wants `INFO` or another level instead.
- No public API changes, no schema changes, no submitter or worker behavior changes beyond log verbosity.

### How was this change tested?

- `hatch run lint` — `ruff check`, `black --check`, and `mypy` all clean.
- `hatch run test` — 468 passed, 2 skipped (2 unrelated pre-existing `P4PASSWD`-env failures in `test_perforce.py::TestPerforceConnection::test_login` are independent of this change; they reproduce on `mainline` without the patch when `P4PASSWD` is set in the environment).
- `hatch build -t wheel` — verified `deadline/unreal_adaptor/UnrealAdaptor/UnrealAdaptor.json` ships in the resulting wheel alongside the existing `schemas/*.schema.json` files.

- [x] Have you run the unit tests? Yes (see above).

### Have you run a render job successfully with these changes?

Yes. Installed the patched package onto a customer-managed fleet worker and ran a successful Unreal Engine render job end-to-end.

### Was this change documented?

No documentation updates required. The file is internal to the package's runtime config layering and is not part of the public submitter or adaptor interface. No docstrings, README, DEVELOPMENT.md, or schema files reference defaults at this layer.

### Is this a breaking change?

No. No init-data or run-data changes. No interface changes. The only user-visible difference is that adaptor logs default to \`DEBUG\` instead of \`INFO\`, which can be overridden via the standard system/user configuration files.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*