### PR TITLE
chore: Bump min openjd-adaptor-runtime to 0.9.4 and openjd-model to 0.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 
 dependencies = [
     "deadline >= 0.55.1,< 0.56",
-    "openjd-adaptor-runtime >= 0.8.1,< 0.10",
-    "openjd-model >= 0.8.1, < 0.10",
+    "openjd-adaptor-runtime >= 0.9.4,< 0.10",
+    "openjd-model >= 0.9.0, < 0.10",
     "p4python == 2025.1.2767466",
     "psutil >= 5.9.0"
 ]


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The minimum-required versions of the OpenJobDescription dependencies in
`pyproject.toml` are several releases behind:

```
openjd-adaptor-runtime >= 0.8.1, < 0.10
openjd-model           >= 0.8.1, < 0.10
```

This means new installs *can* end up on older runtimes that lack important
fixes. In particular, `openjd-adaptor-runtime` 0.9.4 fixes
[#260](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/pull/260),
where `ConfigurationManager._ensure_config_file` created the per-adaptor
`<AdaptorName>.json` through `secure_open()`, which on Windows replaces the
file's DACL with a single non-inheriting ACE bound to the SID of whichever
account first created the file. Any other account — even one with otherwise
inherited access — then fails with `PermissionError`. This is particularly
relevant for Unreal Engine workers, which often run as a service account
distinct from the account that first launched a render.

### What was the solution? (How)

Bump the minimum required versions of `openjd-adaptor-runtime` and
`openjd-model` in `pyproject.toml` to the latest versions available on PyPI:

```diff
-    "openjd-adaptor-runtime >= 0.8.1,< 0.10",
-    "openjd-model >= 0.8.1, < 0.10",
+    "openjd-adaptor-runtime >= 0.9.4,< 0.10",
+    "openjd-model >= 0.9.0, < 0.10",
```

Note: `openjd-model` 0.9.1 has a GitHub release tag but was never published
to PyPI, so 0.9.0 is the highest installable version.

### What is the impact of this change?

- New installs and CI runs will pick up `openjd-adaptor-runtime` 0.9.4,
  resolving the Windows DACL issue described above and including incremental
  fixes from 0.9.0–0.9.3 (UTF-8 file encoding, path-mapping LRU cache leak,
  better error messages, etc.).
- `openjd-model` is forced to 0.9.0, which implements
  [FEATURE_BUNDLE_1 RFC 0004](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0004-enhanced-limits-and-capabilities.md):
  larger job-parameter limits, format strings in integer properties,
  embedded-file line-ending control, and interpreter syntax sugar.
- The previous upper bound (`< 0.10`) is preserved, so a future 1.0 release
  will still require an explicit bump.

### How was this change tested?

- `hatch run test` passes locally on Windows. Verified the hatch test env
  resolved the new floors:
  - `openjd-adaptor-runtime` → 0.9.4
  - `openjd-model` → 0.9.0
- No source code changes; only the dependency declaration was modified.

### Have you run a render job successfully with these changes?

*<fill in based on your local render test>*

### Was this change documented?

No documentation updates required — this is a dependency-version bump only.

### Is this a breaking change?

**No** for direct users of this package: the existing `< 0.10` upper bound
already permitted `openjd-model` 0.9.x and `openjd-adaptor-runtime` 0.9.x,
so anyone installing against `mainline` could already have been on these
versions. This PR only raises the floor.

That said, the underlying dependencies do contain changes worth noting for
users who were previously locked to `0.8.x`:

- `openjd-adaptor-runtime` 0.9.0 made all `open()` calls UTF-8
  (`fix!: Ensure all open uses UTF-8 instead of default encoding`, #171).
  Any code relying on platform-default encoding will see different behavior.
- `openjd-model` 0.9.0 widened some model fields from `Optional[int]` to
  `Optional[int | FormatString]`. Strict type-checked downstream code may
  need to be updated to handle the new union type.

Neither change requires modifications to the Unreal submitter today.
