### PR TITLE
docs: Hoist DCO sign-off rule and add CLAUDE.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # AGENTS.md — deadline-cloud-for-unreal-engine
 
+## ⚠️ Before You Commit
+
+**Every commit MUST be signed off.** Use `git commit -s` — the DCO check will
+block any PR that contains an unsigned commit. See
+[Commit Messages](#commit-messages) below for the full format.
+
 ## Build
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

Two small agent-facing usability gaps in the repo:

1. `AGENTS.md` already documents that every commit must be signed off
   for the DCO check, but the rule sits below the Build / Tests /
   Linting sections and is easy to miss on a quick read. Missed
   sign-offs only fail at the DCO check after a PR is opened, requiring
   an amend + force-push round trip.

2. AI coding agents disagree on the canonical filename for repo
   conventions: most use `AGENTS.md`, but Claude Code looks for
   `CLAUDE.md`. Keeping two separate files invites drift.

### What was the solution? (How)

- Add a short "⚠️ Before You Commit" callout at the top of `AGENTS.md`
  linking to the existing "Commit Messages" section.
- Add `CLAUDE.md` as a git symlink (mode `120000`) to `AGENTS.md` so
  both filenames resolve to the same content with no duplication.

```diff
+## ⚠️ Before You Commit
+
+**Every commit MUST be signed off.** Use `git commit -s` — the DCO check will
+block any PR that contains an unsigned commit. See
+[Commit Messages](#commit-messages) below for the full format.
+
```

### What is the impact of this change?

- Documentation only — no behavioral change to the codebase, build,
  tests, or runtime.
- Note for Windows users: git symlinks may render as a one-line text
  file containing `AGENTS.md` unless the clone has `core.symlinks =
  true` (typically requires Developer Mode or admin). Linux/macOS
  clones work as expected. If this is a problem for the team, the
  symlink can be replaced with a one-line stub pointing at AGENTS.md.

### How was this change tested?

- Verified the symlink is recorded with git mode `120000` (real
  symlink, not a text file).
- Reading `CLAUDE.md` resolves to the contents of `AGENTS.md`.
- No code paths affected.

### Have you run a render job successfully with these changes?

N/A — documentation-only change.

### Was this change documented?

This *is* the documentation change.

### Is this a breaking change?

No.
