### PR TITLE
test: add automated integration tests for bundle generation

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,45 @@
+name: Unreal Engine Integration Tests
+
+on:
+  push:
+    branches:
+      - mainline
+  workflow_dispatch:
+    inputs:
+      ref_type:
+        description: 'Reference type to test'
+        required: true
+        default: 'branch'
+        type: choice
+        options:
+          - branch
+          - tag
+      branch:
+        description: 'Branch to test (e.g., mainline, feature-branch)'
+        required: false
+        default: 'mainline'
+        type: string
+      tag:
+        description: 'Tag to test (only used when ref_type is "tag")'
+        required: false
+        type: string
+
+jobs:
+  IntegrationTests:
+    name: ${{ matrix.name }} Integration Tests
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows
+            name: Windows
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      branch: ${{ github.event.inputs.ref_type == 'branch' && github.event.inputs.branch || 'mainline' }}
+      tag: ${{ github.event.inputs.ref_type == 'tag' && github.event.inputs.tag || '' }}
+      os: ${{ matrix.os }}

--- a/hatch.toml
+++ b/hatch.toml
@@ -5,7 +5,7 @@ pre-install-commands = [
 
 [envs.default.scripts]
 sync = "pip install -r requirements-testing.txt"
-test = "pytest test/ --cov-config pyproject.toml --ignore=test/end_to_end {args}"
+test = "pytest test/ --cov-config pyproject.toml --ignore=test/end_to_end --ignore=test/integ {args}"
 e2e = "pytest test/end_to_end --no-cov {args}"
 typing = "mypy {args:src test}"
 style = [
@@ -35,6 +35,38 @@ deploy = "mkdocs gh-deploy --force"
 
 [[envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11"]
+
+[envs.integ-ci]
+pre-install-commands = [
+  "pip install -r requirements-testing.txt"
+]
+
+[[envs.integ-ci.matrix]]
+unreal = ["5.7"]
+python = ["3.11"]
+
+[envs.integ-ci.env-vars]
+UE_VERSION = "{matrix:unreal}"
+
+[envs.integ-ci.scripts]
+setup = "python ./pipeline/setup-runner.py --versions {matrix:unreal}"
+integ = "pytest --no-cov {args:test/integ} -vvv --numprocesses=1"
+
+[envs.e2e-ci]
+pre-install-commands = [
+  "pip install -r requirements-testing.txt"
+]
+
+[[envs.e2e-ci.matrix]]
+unreal = ["5.7"]
+python = ["3.11"]
+
+[envs.e2e-ci.env-vars]
+UE_VERSION = "{matrix:unreal}"
+
+[envs.e2e-ci.scripts]
+setup = "python ./pipeline/setup-runner.py --versions {matrix:unreal}"
+e2e = "pytest --no-cov {args:test/end_to_end/test_create_job.py} -vvv --numprocesses=1"
 
 [envs.release]
 detached = true

--- a/pipeline/generate_bundle.py
+++ b/pipeline/generate_bundle.py
@@ -1,0 +1,97 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Generate a Deadline Cloud job bundle inside Unreal Engine.
+
+This script is executed via UE's -ExecutePythonScript flag. It creates a minimal
+OpenJob bundle (template.yaml, parameter_values.yaml, asset_references.yaml)
+without making any Deadline Cloud API calls. The resulting bundle path is written
+to a marker file so the parent test process can locate it.
+
+Environment variable required:
+    DEADLINE_CLOUD_INTEG_MARKER_FILE - path to write the bundle directory path to.
+"""
+
+import os
+import traceback
+
+import unreal
+
+from pathlib import Path
+
+# Ensure OPENJD_TEMPLATES_DIRECTORY is set before importing deadline modules
+# (init_unreal.py normally does this, but -ExecutePythonScript may run first).
+if "OPENJD_TEMPLATES_DIRECTORY" not in os.environ:
+    plugin_content_python = Path(unreal.Paths.project_plugins_dir()).joinpath(
+        "UnrealDeadlineCloudService", "Content", "Python"
+    )
+    os.environ["OPENJD_TEMPLATES_DIRECTORY"] = str(plugin_content_python / "openjd_templates")
+
+from deadline.unreal_submitter import settings
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job import UnrealOpenJob
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job_step import (
+    UnrealOpenJobStep,
+    UnrealOpenJobStepParameterDefinition,
+)
+
+
+def main():
+    marker_file = os.environ.get("DEADLINE_CLOUD_INTEG_MARKER_FILE", "")
+    if not marker_file:
+        unreal.log_error("generate_bundle: DEADLINE_CLOUD_INTEG_MARKER_FILE env var is not set.")
+        unreal.SystemLibrary.quit_editor()
+        return
+
+    try:
+        templates_dir = settings.OPENJD_TEMPLATES_DIRECTORY
+        job_template = f"{templates_dir}/custom/custom_job.yml"
+        step_template = f"{templates_dir}/custom/custom_step.yml"
+
+        if not os.path.isfile(job_template):
+            raise FileNotFoundError(f"Job template not found: {job_template}")
+        if not os.path.isfile(step_template):
+            raise FileNotFoundError(f"Step template not found: {step_template}")
+
+        # Build a minimal OpenJob with one custom step.
+        open_job = UnrealOpenJob(
+            name="IntegTestBundle",
+            file_path=job_template,
+            steps=[
+                UnrealOpenJobStep(
+                    name="IntegTestStep",
+                    file_path=step_template,
+                    extra_parameters=[
+                        UnrealOpenJobStepParameterDefinition(
+                            "ScriptPath", "PATH", ["/tmp/placeholder.py"]
+                        )
+                    ],
+                )
+            ],
+        )
+
+        bundle_path = open_job.create_job_bundle()
+        unreal.log(f"generate_bundle: Bundle created at {bundle_path}")
+
+        # Write bundle path to marker file for the test harness to read.
+        os.makedirs(os.path.dirname(marker_file), exist_ok=True)
+        with open(marker_file, "w", encoding="utf-8") as f:
+            f.write(bundle_path)
+
+        unreal.log(f"generate_bundle: Marker written to {marker_file}")
+
+    except Exception as e:
+        unreal.log_error(f"generate_bundle: Failed - {e}")
+        unreal.log_error(traceback.format_exc())
+        # Write error to marker so test harness can report the failure.
+        try:
+            os.makedirs(os.path.dirname(marker_file), exist_ok=True)
+            with open(marker_file, "w", encoding="utf-8") as f:
+                f.write(f"ERROR: {e}")
+        except Exception as write_err:
+            unreal.log_error(f"generate_bundle: Failed to write marker file: {write_err}")
+
+    unreal.SystemLibrary.quit_editor()
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Setup runner for Unreal Engine integration tests in CodeBuild.
+
+Installs UE 5.7 full SDK on Windows from a zip in S3, along with all
+build dependencies (VS Build Tools, .NET Framework SDK, .NET SDK 8.0).
+
+Follows the same pattern as deadline-cloud-for-cinema-4d and
+deadline-cloud-for-maya setup runners.
+
+Environment variables required:
+    INSTALLER_BUCKET - S3 bucket containing the UE installer zip
+    INSTALLER_BUCKET_EXPECTED_OWNER - 12-digit AWS account ID (for verification)
+"""
+
+import argparse
+import hashlib
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import boto3
+from botocore.config import Config
+
+
+UE_INSTALLERS = {
+    "5.7": {
+        "windows": {
+            "s3_key": "unrealengine/5/UnrealEngine_5.7_FullSDK_Win.zip",
+            "sha256": "",
+            "type": "zip",
+        },
+    },
+}
+
+UE_INSTALL_PATHS = {
+    "5.7": {
+        "windows": Path("C:/Program Files/Epic Games/UE_5.7"),
+    },
+}
+
+
+def run(cmd, check=True):
+    """Run a shell command, exiting on failure if check is True."""
+    print(f"Running: {' '.join(cmd) if isinstance(cmd, list) else cmd}")
+    result = subprocess.run(cmd, shell=isinstance(cmd, str))
+    if check and result.returncode != 0:
+        sys.exit(result.returncode)
+    return result
+
+
+def download_from_s3(s3_path, local_path):
+    """Download a file from S3 with optional expected bucket owner verification."""
+    bucket = os.environ.get("INSTALLER_BUCKET")
+    if not bucket:
+        print("ERROR: INSTALLER_BUCKET not set")
+        sys.exit(1)
+
+    expected_bucket_owner = os.environ.get("INSTALLER_BUCKET_EXPECTED_OWNER")
+    if expected_bucket_owner and not (
+        expected_bucket_owner.isdigit() and len(expected_bucket_owner) == 12
+    ):
+        raise ValueError("INSTALLER_BUCKET_EXPECTED_OWNER must be a 12-digit AWS Account ID")
+
+    config = Config(read_timeout=300, connect_timeout=60, retries={"max_attempts": 2})
+    s3 = boto3.client("s3", config=config)
+
+    extra_args = {}
+    if expected_bucket_owner:
+        extra_args["ExpectedBucketOwner"] = expected_bucket_owner
+
+    print(f"Downloading s3://{bucket}/{s3_path} to {local_path}")
+    s3.download_file(bucket, s3_path, str(local_path), ExtraArgs=extra_args)
+
+
+def verify_checksum(file_path, expected_checksum):
+    """Verify SHA256 checksum of downloaded file."""
+    if not expected_checksum:
+        print(f"WARNING: No checksum configured for {file_path}, skipping verification")
+        return
+    print(f"Verifying checksum for {file_path}...")
+    sha256 = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            sha256.update(chunk)
+    actual = sha256.hexdigest()
+    if actual != expected_checksum:
+        print("ERROR: Checksum mismatch!")
+        print(f"  Expected: {expected_checksum}")
+        print(f"  Actual:   {actual}")
+        sys.exit(1)
+    print("OK Checksum verified")
+
+
+def ensure_7zip():
+    """Ensure 7-Zip is installed from the installer bucket, install if missing."""
+    seven_zip = Path("C:/Program Files/7-Zip/7z.exe")
+    if seven_zip.exists():
+        return str(seven_zip)
+
+    print("Installing 7-Zip from installer bucket...")
+    installer_path = Path("C:/Temp/7z-install.exe")
+    installer_path.parent.mkdir(parents=True, exist_ok=True)
+    download_from_s3("tools/7z2408-x64.exe", installer_path)
+    run(
+        [
+            "powershell",
+            "-Command",
+            f"Start-Process '{installer_path}' -ArgumentList '/S' -Wait",
+        ]
+    )
+
+    if not seven_zip.exists():
+        print("ERROR: 7-Zip installation failed")
+        sys.exit(1)
+
+    return str(seven_zip)
+
+
+def ensure_vs_buildtools():
+    """Ensure Visual Studio Build Tools 2022 with required components are installed.
+
+    Components installed:
+    - VCTools workload (C++ build tools)
+    - MSVC x64/x86 build tools (latest, includes v14.44+)
+    - Windows 11 SDK
+    - .NET Framework 4.6.1 Targeting Pack
+    - .NET Framework 4.8.1 SDK
+    - .NET development prerequisites
+    """
+    msvc_path = Path("C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/MSVC")
+    if msvc_path.exists() and any(msvc_path.iterdir()):
+        # Check if .NET Framework SDK is also present
+        netfx_path = Path(
+            "C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools"
+            "/MSBuild/Microsoft/Microsoft.NET.Build.Extensions"
+        )
+        if netfx_path.exists():
+            print("VS Build Tools already installed with all required components")
+            return
+
+    print("Installing Visual Studio Build Tools 2022...")
+    installer_path = Path("C:/Temp/vs_buildtools.exe")
+    installer_path.parent.mkdir(parents=True, exist_ok=True)
+
+    run(
+        [
+            "powershell",
+            "-Command",
+            "Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vs_buildtools.exe'"
+            f" -OutFile '{installer_path}' -UseBasicParsing",
+        ]
+    )
+
+    run(
+        [
+            "powershell",
+            "-Command",
+            f"Start-Process '{installer_path}' -ArgumentList "
+            "'--quiet','--wait','--norestart',"
+            "'--add','Microsoft.VisualStudio.Workload.VCTools',"
+            "'--add','Microsoft.VisualStudio.Component.VC.Tools.x86.x64',"
+            "'--add','Microsoft.VisualStudio.Component.Windows11SDK.22621',"
+            "'--add','Microsoft.Net.Component.4.6.1.TargetingPack',"
+            "'--add','Microsoft.Net.Component.4.8.1.SDK',"
+            "'--add','Microsoft.Net.ComponentGroup.DevelopmentPrerequisites'"
+            " -Wait",
+        ]
+    )
+
+    if not msvc_path.exists():
+        print("ERROR: VS Build Tools installation failed")
+        sys.exit(1)
+
+    print("VS Build Tools installed successfully")
+
+
+def extract_zip(zip_path, dest_dir):
+    """Extract a zip archive using 7-Zip (faster and lower memory than Python zipfile)."""
+    seven_zip = ensure_7zip()
+    print(f"Extracting {zip_path} to {dest_dir}...")
+    run([seven_zip, "x", str(zip_path), f"-o{dest_dir}", "-y"])
+
+
+def setup_windows(versions):
+    """Install Unreal Engine and build dependencies on Windows."""
+    # Install build tools first (needed for plugin compilation)
+    ensure_vs_buildtools()
+
+    for version in versions:
+        install_dir = UE_INSTALL_PATHS[version]["windows"]
+        marker = install_dir / ".installed"
+        editor_exe = install_dir / "Engine" / "Binaries" / "Win64" / "UnrealEditor-Cmd.exe"
+
+        if marker.exists() and editor_exe.exists():
+            print(f"UE {version} already installed at {install_dir}")
+            continue
+
+        print(f"Installing UE {version}...")
+        installer_info = UE_INSTALLERS[version]["windows"]
+        local_installer = Path(f"C:/Temp/UE_{version}_installer.zip")
+        local_installer.parent.mkdir(parents=True, exist_ok=True)
+
+        download_from_s3(installer_info["s3_key"], local_installer)
+        verify_checksum(local_installer, installer_info["sha256"])
+
+        install_dir.mkdir(parents=True, exist_ok=True)
+        print(f"Extracting to {install_dir} (this may take 10-15 minutes)...")
+        extract_zip(local_installer, install_dir)
+
+        # Clean up installer zip
+        local_installer.unlink(missing_ok=True)
+
+        # Verify
+        if not editor_exe.exists():
+            print(f"ERROR: UnrealEditor-Cmd.exe not found at {editor_exe}")
+            print("Contents of install dir:")
+            for item in sorted(install_dir.iterdir())[:10]:
+                print(f"  {item.name}")
+            sys.exit(1)
+
+        # Clear AutomationTool runtime cache (logs from previous runs)
+        for cache_dir in [
+            install_dir / "Engine" / "Programs" / "AutomationTool" / "Saved",
+        ]:
+            if cache_dir.exists():
+                print(f"  Clearing cache: {cache_dir}")
+                shutil.rmtree(cache_dir, ignore_errors=True)
+
+        local_app_data = os.environ.get("LOCALAPPDATA", "")
+        if local_app_data:
+            uat_cache = Path(local_app_data) / "UnrealEngine" / "Programs" / "AutomationTool"
+            if uat_cache.exists():
+                shutil.rmtree(uat_cache, ignore_errors=True)
+
+        marker.touch()
+        print(f"UE {version} installed successfully at {install_dir}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Setup Unreal Engine test environment")
+    parser.add_argument(
+        "--versions",
+        nargs="+",
+        required=True,
+        help="UE versions to install (e.g., 5.7)",
+    )
+    args = parser.parse_args()
+
+    system = platform.system()
+    print(f"Setting up {system} with UE {', '.join(args.versions)}")
+
+    if system != "Windows":
+        print(f"ERROR: Only Windows is supported (got {system})")
+        sys.exit(1)
+
+    for v in args.versions:
+        if v not in UE_INSTALLERS:
+            print(f"ERROR: Unsupported version {v}. Supported: {list(UE_INSTALLERS.keys())}")
+            sys.exit(1)
+
+    setup_windows(args.versions)
+    print("Setup complete!")

--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -1001,7 +1001,8 @@ def deadline_client(session: boto3.Session) -> BaseClient:
     Returns:
         A Deadline Cloud client
     """
-    client = session.client("deadline", region_name=TEST_TARGET_REGION)
+    endpoint_url = os.environ.get("DEADLINE_ENDPOINT", None)
+    client = session.client("deadline", region_name=TEST_TARGET_REGION, endpoint_url=endpoint_url)
     logger.info(f"Created deadline client for region {TEST_TARGET_REGION}")
     return client
 

--- a/test/integ/__init__.py
+++ b/test/integ/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -1,0 +1,250 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+from pathlib import Path
+from typing import Generator, List, Tuple
+
+# Add repository root to path
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../.."))
+
+from scripts.build_plugin import find_engine_root
+
+logger = logging.getLogger(__name__)
+
+
+def pytest_addoption(parser) -> None:
+    """Add custom command line options to pytest."""
+    parser.addoption(
+        "--nobuild", action="store_true", default=False, help="Skip build_plugin fixture"
+    )
+    parser.addoption(
+        "--ueversion",
+        action="store",
+        default=None,
+        help="Specify Unreal Engine version (e.g. 5.4)",
+    )
+
+
+def get_source_root() -> str:
+    """
+    Return the path of the root of the deadline-cloud-for-unreal-engine source.
+
+    Assumes it's 2 folders up from the directory this file lives in.
+    """
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    parent_dir = os.path.dirname(current_dir)
+    root_dir = os.path.dirname(parent_dir)
+    return root_dir
+
+
+def add_plugins_to_project(project_path: str, plugins: List[str], enabled: bool) -> None:
+    """
+    Add the provided list of plugins to the uproject at the given project_path.
+
+    Args:
+        project_path: Path to .uproject file to add plugins to
+        plugins: List of string names of plugins to add to the project
+        enabled: Whether to enable or disable the plugins
+    """
+    with open(project_path, "r") as f:
+        project_data = json.load(f)
+
+    if "Plugins" not in project_data:
+        project_data["Plugins"] = []
+
+    for plugin_name in plugins:
+        plugin_entry = {"Name": plugin_name, "Enabled": enabled}
+        if plugin_entry not in project_data["Plugins"]:
+            project_data["Plugins"].append(plugin_entry)
+
+    with open(project_path, "w") as f:
+        json.dump(project_data, f, indent=2)
+
+
+@pytest.fixture(scope="session")
+def build_plugin(request) -> None:
+    """
+    Fixture to run the scripts/build_plugin.py script at most once per test session.
+
+    Guarantees the latest version of the code has been built and installed.
+    Skipped if --nobuild is passed.
+    """
+    if request.config.getoption("--nobuild"):
+        logger.info("Skipping build_plugin (--nobuild)")
+    else:
+        script_path = os.path.join(get_source_root(), "scripts", "build_plugin.py")
+        if not os.path.exists(script_path):
+            pytest.fail(f"Could not find build_plugin.py at {script_path}")
+
+        build_args = ["python", script_path, "--install", "--test"]
+
+        ueversion = request.config.getoption("--ueversion")
+        if ueversion:
+            build_args.append(f"--ueversion={ueversion}")
+
+        logger.info(f"Running build_plugin: {' '.join(build_args)}")
+        result = subprocess.run(build_args, text=True)
+        assert (
+            result.returncode == 0
+        ), f"build_plugin.py failed with return code {result.returncode}"
+
+
+@pytest.fixture(scope="session")
+def create_test_project(request) -> Generator[Tuple[str, str], None, None]:
+    """
+    Create a test Unreal Engine project for integration testing.
+
+    Creates a copy of the TP_DMXBP template project and adds the required plugins.
+
+    Yields:
+        Tuple containing (project_directory_path, project_file_path)
+    """
+    project_base = os.path.expanduser("~/Documents/UnrealProjects/TestProjects")
+    os.makedirs(project_base, exist_ok=True)
+
+    # Create a directory with a unique name under the project base folder
+    temp_dir = tempfile.TemporaryDirectory(dir=project_base).name
+    logger.info(f"Created project folder: {temp_dir}")
+
+    engine_root = find_engine_root(request.config.getoption("--ueversion"))
+    source_path = os.path.join(engine_root, r"Templates\TP_DMXBP")
+    if not os.path.exists(source_path):
+        pytest.fail(f"Could not find source template at {source_path}")
+
+    dest_path = os.path.abspath(os.path.join(temp_dir, "TP_DMXBP"))
+
+    shutil.copytree(source_path, dest_path)
+    logger.info(f"Created project dir {dest_path}")
+
+    # Add required plugins to the project
+    project_path = os.path.join(dest_path, "TP_DMXBP.uproject")
+    add_plugins_to_project(
+        project_path,
+        ["UnrealDeadlineCloudService", "MovieRenderPipeline"],
+        True,
+    )
+
+    yield dest_path, project_path
+
+    # Cleanup: remove the temporary project directory
+    try:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        logger.info(f"Cleaned up project folder: {temp_dir}")
+    except Exception as e:
+        logger.warning(f"Failed to clean up project folder {temp_dir}: {e}")
+
+
+@pytest.fixture
+def run_unreal_bundle_only(request, create_test_project) -> Path:
+    """
+    Fixture that launches UnrealEditor-Cmd with -ExecutePythonScript to generate a job bundle.
+
+    Uses a marker file to communicate the bundle path back from UE's embedded Python,
+    since UE's print() does not reach parent process stdout. No Deadline Cloud API
+    calls are made -- the script generates the bundle locally with zero network access.
+
+    Returns:
+        Path to the generated job bundle directory.
+    """
+    _, uproject_file = create_test_project
+
+    # Locate the editor executable
+    engine_root = find_engine_root(request.config.getoption("--ueversion"))
+    editor_exe = os.path.join(engine_root, "Engine", "Binaries", "Win64", "UnrealEditor-Cmd.exe")
+    if not os.path.exists(editor_exe):
+        pytest.fail(f"Could not find UnrealEditor-Cmd.exe at {editor_exe}")
+
+    # Locate the generate_bundle.py script relative to the repository root
+    repo_root = get_source_root()
+    generate_bundle_script = os.path.join(repo_root, "pipeline", "generate_bundle.py")
+    if not os.path.exists(generate_bundle_script):
+        pytest.fail(f"Could not find generate_bundle.py at {generate_bundle_script}")
+
+    # Create a temporary marker file for the script to write the bundle path into
+    marker_fd, marker_file_path = tempfile.mkstemp(prefix="deadline_bundle_marker_", suffix=".txt")
+    os.close(marker_fd)
+    marker_file = Path(marker_file_path)
+    # Ensure it starts empty so we can detect if the script never wrote to it
+    marker_file.write_text("")
+
+    # Set up environment -- only the marker file env var is needed, no API credentials
+    env = os.environ.copy()
+    env["DEADLINE_CLOUD_INTEG_MARKER_FILE"] = str(marker_file)
+
+    # Build the UE command line
+    cmd = [
+        editor_exe,
+        uproject_file,
+        f"-ExecutePythonScript={generate_bundle_script}",
+        "-stdout",
+        "-unattended",
+        "-nullrhi",
+        "-nosplash",
+        "-nosound",
+        "-nopause",
+    ]
+
+    logger.info("Launching UE to generate bundle via -ExecutePythonScript")
+    logger.info(f"Editor: {editor_exe}")
+    logger.info(f"Project: {uproject_file}")
+    logger.info(f"Script: {generate_bundle_script}")
+    logger.info(f"Marker file: {marker_file}")
+    logger.info(f"Command: {' '.join(cmd)}")
+
+    # Run UE and wait for it to exit
+    process = subprocess.run(
+        cmd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+
+    ue_output = process.stdout or ""
+
+    logger.info(f"UE exited with return code {process.returncode}")
+
+    # Read the marker file to get the bundle path
+    if not marker_file.exists():
+        pytest.fail(
+            f"Marker file was not created at {marker_file}.\n"
+            f"UE exit code: {process.returncode}\n"
+            f"UE output (last 100 lines):\n"
+            f"{''.join(ue_output.splitlines(keepends=True)[-100:])}"
+        )
+
+    bundle_path = marker_file.read_text().strip()
+
+    # Clean up marker file
+    try:
+        marker_file.unlink()
+    except OSError:
+        pass  # Non-critical: temp file cleanup failure is acceptable
+
+    if not bundle_path:
+        pytest.fail(
+            f"Marker file at {marker_file_path} exists but is empty. "
+            f"The generate_bundle.py script may have failed to write the bundle path.\n"
+            f"UE exit code: {process.returncode}\n"
+            f"UE output (last 100 lines):\n"
+            f"{''.join(ue_output.splitlines(keepends=True)[-100:])}"
+        )
+
+    bundle = Path(bundle_path)
+    if not bundle.exists():
+        pytest.fail(
+            f"Bundle path reported by script does not exist: {bundle}\n"
+            f"UE exit code: {process.returncode}"
+        )
+
+    logger.info(f"Bundle generated at: {bundle}")
+    return bundle

--- a/test/integ/test_bundle_generation.py
+++ b/test/integ/test_bundle_generation.py
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import yaml
+
+
+def test_bundle_generation(build_plugin, create_test_project, run_unreal_bundle_only):
+    """Launch UE headless, generate job bundle via ExecutePythonScript, validate YAML."""
+    bundle_path = run_unreal_bundle_only
+
+    assert bundle_path.exists(), f"Bundle path does not exist: {bundle_path}"
+
+    template_file = bundle_path / "template.yaml"
+    params_file = bundle_path / "parameter_values.yaml"
+    assets_file = bundle_path / "asset_references.yaml"
+
+    assert template_file.exists(), "template.yaml not found in bundle"
+    assert params_file.exists(), "parameter_values.yaml not found in bundle"
+    assert assets_file.exists(), "asset_references.yaml not found in bundle"
+
+    # Validate template structure
+    template = yaml.safe_load(template_file.read_text())
+    assert template.get("specificationVersion") == "jobtemplate-2023-09"
+    assert "name" in template
+    assert "steps" in template
+    assert len(template["steps"]) > 0
+
+    # Validate each step has required fields
+    for step in template["steps"]:
+        assert "name" in step
+        assert "script" in step or "parameterSpace" in step or "stepEnvironments" in step
+
+    # Validate parameter values
+    params = yaml.safe_load(params_file.read_text())
+    assert "parameterValues" in params
+
+    # Validate template is a valid OpenJD job template
+    from openjd.model import decode_job_template
+    from openjd.model._errors import DecodeValidationError
+
+    try:
+        decode_job_template(template=template)
+    except DecodeValidationError as e:
+        if "Unsupported extension" not in str(e):
+            raise


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Unreal Engine Deadline Cloud plugin has no automated integration tests in CI. Currently, only pure Python unit tests (mocked, no UE required) run automatically on PRs/merges. The end-to-end tests (test/end_to_end/) require manual execution by an engineer before approving the release gate.

### What was the solution? (How)
Added local integration tests that:
- Launch UE 5.7 headless 
- Generate a job bundle 
- Validate the YAML 

### What is the impact of this change?
Every PR and mainline push will validate that UE can generate valid OpenJD job bundles (once CDK infrastructure is deployed — separate CR)

### How was this change tested?
Validated the tests on dev EC2 instance and also on CodeBuild gamma.

- Have you run the unit tests?
Yes — 467 passed, 2 skipped, 0 failures.

### Have you run a render job successfully with these changes?
yes

### Was this change documented?

NA

### Is this a breaking change?

Only adds tests.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*