### PR TITLE
fix(deps): bump deadline to >=0.57,<0.59

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -219,3 +219,46 @@ Solution: Configure Movie Render Pipeline settings as described in [Submit a Tes
      - For "Default Remote Executor", select "MoviePipelineDeadlineCloudRemoteExecutor"
      - For "Default Executor Job", select "MoviePipelineDeadlineCloudExecutorJob"
      - Under "Default Job Settings Classes", click add icon, and add "DeadlineCloudRenderStepSetting"
+
+### `ModuleNotFoundError: No module named 'deadline.job_attachments'`
+
+Error: A Python import of any code path that touches `deadline.job_attachments` fails with the same one-line signature regardless of caller:
+```
+ModuleNotFoundError: No module named 'deadline.job_attachments'
+```
+
+The full traceback varies by what triggered the import — common variants are:
+
+- **Worker agent service fails to start** (host stays offline). The traceback ends in `deadline_worker_agent\log_messages.py` doing `from deadline.job_attachments import version as deadline_job_attach_version`. The agent never reaches the point of polling the fleet, so the host shows up as offline / unreachable.
+- **Worker agent starts but render tasks fail** before the Unreal adaptor runs. The traceback comes from the adaptor or the agent's session-startup path importing `deadline.client.config`, which transitively loads `deadline.job_attachments.models`. Tasks fail with a worker-side import error and are retried until the queue gives up.
+- **Contributor running `hatch run e2e -s` or `hatch run test`**. The traceback comes from `test\end_to_end\conftest.py` or any other test module importing `deadline.client.config`. Pytest fails at collection time.
+
+Root Cause: Starting with [`deadline`](https://github.com/aws-deadline/deadline-cloud) 0.57, `job_attachments` was carved out into a separately-published distribution: [`deadline-job-attachments`](https://github.com/aws-deadline/deadline-cloud-job-attachments). The import path stayed the same (`deadline.job_attachments`) via PEP 420 namespace packaging, but the files now live in a different installed distribution. The two distributions install side by side into the same `deadline/` namespace; if either is missing, imports of the missing half fail.
+
+Solution:
+
+1. On the affected host (or in the affected hatch env), confirm the missing distribution:
+```
+python -m pip list | findstr /B deadline       # cmd
+python -m pip list | Select-String "^deadline" # PowerShell
+```
+You should see entries for both `deadline` and `deadline-job-attachments`. If only `deadline` is present, this is the bug.
+
+2. Install the missing distribution and verify the import resolves:
+```
+python -m pip install deadline-job-attachments
+python -c "from deadline.job_attachments.models import FileConflictResolution; print('ok')"
+```
+
+3. On a CMF worker, restart the worker agent service so it picks up the repaired environment:
+```
+net stop  DeadlineWorker
+net start DeadlineWorker
+```
+(Service name may vary; check `services.msc`. After the restart, monitor a few task assignments to confirm imports succeed.)
+
+4. For contributor hatch envs in a generally inconsistent state (multiple stale upgrades), prune and recreate:
+```
+hatch env prune
+hatch run e2e -s
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.55.1,< 0.57",
+    "deadline >= 0.57,< 0.59",
     "openjd-adaptor-runtime >= 0.9.4,< 0.10",
     "openjd-model >= 0.9.0, < 0.10",
     "p4python == 2025.1.2767466",


### PR DESCRIPTION

fix(deps): bump deadline to >=0.57,<0.59

### What was the problem/requirement? (What/Why)

`deadline-cloud-for-unreal-engine` currently caps `deadline<0.57` in `pyproject.toml`. In `deadline` 0.57, the `job_attachments` package was carved out into a separately-published distribution: [`deadline-job-attachments`](https://github.com/aws-deadline/deadline-cloud-job-attachments). The split preserves the `deadline.job_attachments` import path via PEP 420 namespace packaging — only the distribution metadata changes — so this package's source code is unaffected.

The version-cap mismatch causes a real customer-facing bug. The CMF worker setup script's `--worker` install path runs:

```bash
python -m pip install deadline-cloud-worker-agent --upgrade --upgrade-strategy eager
```

The eager strategy pulls `deadline` past the package's `<0.57` cap. pip detects the conflict, falls back to a degraded resolver mode, and emits a warning like:

```
ERROR: pip's dependency resolver does not currently take into account all the
packages that are installed. This behaviour is the source of the following
dependency conflicts.
deadline-cloud-for-unreal-engine 0.6.x requires deadline<0.56,>=0.55.1, but you
have deadline 0.58.0 which is incompatible.
```

In that degraded mode pip can skip installing the new transitive `deadline-job-attachments` distribution. The host is left with `deadline 0.57+` (which no longer ships `job_attachments`) and no `deadline-job-attachments` distribution to fill the gap. Any code that imports `deadline.job_attachments` then fails with:

```
ModuleNotFoundError: No module named 'deadline.job_attachments'
```

In the worst variant, the worker agent's own startup path imports `deadline.job_attachments`, so the service fails to start and the CMF host stays offline for the entire fleet until repaired manually.

This is reachable any time `deadline` is upgraded across the 0.57 boundary in an environment that already has the unreal-engine package installed with the older cap — a long-lived CMF worker host getting `pip install -U deadline-cloud-worker-agent` re-run during routine patching, a worker rebuilt from an older AMI, or a developer running the `--install --worker` path on a workstation.

### What was the solution? (How)

Two changes:

1. **Bump the `deadline` floor to `>= 0.57, < 0.59`** in `pyproject.toml`. With the floor at 0.57, pip's resolver stays in normal mode and pulls `deadline-job-attachments` deterministically as a transitive of `deadline`. The half-installed-state failure mode is structurally eliminated for any host that pulls in this new wheel.

2. **Add a troubleshooting entry to `DEVELOPMENT.md`** for the `ModuleNotFoundError: No module named 'deadline.job_attachments'` symptom. The entry covers:
   - Where the symptom shows up (worker-agent service fails to start; render tasks fail before adaptor runs; contributor `hatch run e2e -s` collection error)
   - The pip warning that often precedes it
   - Root cause and links to both relevant repos ([deadline-cloud](https://github.com/aws-deadline/deadline-cloud), [deadline-cloud-job-attachments](https://github.com/aws-deadline/deadline-cloud-job-attachments))
   - Diagnostic recipe (`pip list`) and targeted repair (`pip install --force-reinstall --no-deps deadline-job-attachments`)
   - `net stop / net start DeadlineWorker` for restoring a CMF worker after repair

The entry is targeted at the most catastrophic variant — a CMF worker host whose worker-agent service can't start — and also covers the contributor hatch-env case so anyone hitting the bug during local development can self-serve a fix until the new release reaches them.

### What is the impact of this change?

**For most customers (transitive `deadline` consumers):**
A CMF host installed or upgraded after this release pulls `deadline 0.57+` and `deadline-job-attachments 0.1.0` together. The `ModuleNotFoundError` failure mode goes away.

**For customers who explicitly pin `deadline<0.57` somewhere in their environment:**
`pip install -U deadline-cloud-for-unreal-engine` will produce a clear pip resolver error at install time. They can either relax the pin, upgrade `deadline-cloud-worker-agent` in tandem, or stay on the prior unreal-engine release. The failure is visible at install time, not a silent runtime regression.

**No source-level changes:**
No public Python API changes, no behavior changes, no removed features. Existing customer code calling the submitter or the adaptor continues to work without modification. `deadline.job_attachments.*` imports continue to work via PEP 420 namespace packaging once both distributions are installed.

### How was this change tested?

- **Unit tests:** `467 passed, 2 skipped` via `pytest test/ --cov-config pyproject.toml --ignore=test/end_to_end --ignore=test/integ`.
- **Lint / format / types:** `ruff check`, `black --check`, and `mypy src test` are clean.
- **`pip` resolution behavior:** verified locally that installing the package with the new constraint pulls `deadline 0.58.0` and `deadline-job-attachments 0.1.0` together, no resolver warnings, and that `from deadline.job_attachments.models import FileConflictResolution` and `from deadline.job_attachments.progress_tracker import ProgressReportMetadata` succeed via the namespace package.
- **CMF worker reproduction:** the original `ModuleNotFoundError` was reproduced on a Windows host running the `--worker` install path against a pre-bump build (host had `deadline 0.58.0` + `deadline-cloud-worker-agent 0.30.0` but no `deadline-job-attachments`). Repairing with `pip install --force-reinstall --no-deps deadline-job-attachments` (the steps documented in the new troubleshooting entry) restored imports and let the worker agent service start.

### Have you run a render job successfully with these changes?

Yes, confirmed this change in UE5.7

### Was this change documented?

Yes — added a new entry to the Troubleshooting section of `DEVELOPMENT.md` (`### ModuleNotFoundError: No module named 'deadline.job_attachments'`) covering the symptom, root cause, repository links, and recovery procedure for both the contributor and CMF-worker scenarios. No docstring, README, or schema changes are needed for this PR.

### Is this a breaking change?

**No, in the conventional sense.**

- No public Python API changes. No removed or renamed parameters, types, or functions.
- No runtime behavior changes for existing consumer code.
- No init-data, run-data, or OpenJD-template schema changes.
- Existing customer scripts, data assets, and OpenJD templates continue to work unchanged.

The constraint tightening (`deadline>=0.55.1,<0.57` → `deadline>=0.57,<0.59`) is the only customer-visible change, and it manifests strictly at install time. The closest analog is bumping a `python_requires` floor — strictly a constraint change, not a major-version-worthy break by Python community convention. Prior similar dependency-floor changes in this repository (e.g., #297) were treated the same way: `chore(deps)` / `fix(deps)` patches, not breaking changes.

The narrow audience for whom this is install-visible — environments that pin `deadline<0.57` independently of this package — will see a clear `pip` resolver error and can either relax the pin or pin `deadline-cloud-for-unreal-engine` to the prior release while they sort out their environment. There is no plausible silent runtime regression introduced by the floor bump.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*