### PR TITLE
test(e2e): fail fast on terminal job states and detect leftover processes

### DIFF
--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -12,6 +12,7 @@ import botocore
 import deadline.client.config as config
 import json
 import logging
+import psutil
 import pytest
 import re
 import shutil
@@ -244,6 +245,147 @@ def pytest_addoption(parser) -> None:
         default=None,
         help="Override the CondaChannels default in the render job template",
     )
+    parser.addoption(
+        "--no-prerun-checks",
+        action="store_true",
+        default=False,
+        help=(
+            "Skip all session-start (pre-run) validation checks. Use on hosts "
+            "where the checks produce known false positives (e.g. a host with "
+            "a legitimate production deadline-worker-agent service running)."
+        ),
+    )
+
+
+def _record_leftover(
+    proc_info: Dict[str, Any], cmdline_display: str, category: str
+) -> Dict[str, Any]:
+    return {
+        "pid": proc_info["pid"],
+        # psutil sets unreadable attrs to None (the key is present), so
+        # .get(default) doesn't fall back — use `or` instead.
+        "name": proc_info.get("name") or "unknown",
+        "cmdline_short": cmdline_display,
+        "category": category,
+    }
+
+
+def _categorize_process(
+    name_lower: str, cmdline_list: List[str], cmdline_unreadable: bool
+) -> Optional[str]:
+    """Return the leftover category for a process, or None if it doesn't match."""
+    # Worker agent: name match is reliable enough to flag without cmdline,
+    # so a worker owned by another user (LOCAL_SYSTEM, etc.) is still caught.
+    if name_lower in ("deadline-worker-agent.exe", "deadline-worker-agent"):
+        return "deadline-worker-agent"
+
+    if name_lower in ("unrealeditor-cmd.exe", "unrealeditor-cmd"):
+        # Distinguish a worker-launched UE from a developer's manual UE
+        # via the OpenJD session-temp path layout. Without cmdline we
+        # can't apply the guard, so we skip rather than risk a false flag.
+        if cmdline_unreadable:
+            return None
+        for arg in cmdline_list[1:]:
+            arg_lower = arg.lower()
+            # "openjd/" / "openjd\\" not just "openjd" — otherwise an
+            # unrelated path containing "openjdk" would false-flag.
+            if "openjd/" in arg_lower or "openjd\\" in arg_lower or "session-" in arg_lower:
+                return "UnrealEditor-Cmd (worker session)"
+        return None
+
+    # Python process: name "python" alone is too generic; require an
+    # explicit module/path match in the args.
+    if cmdline_unreadable:
+        return None
+    is_python = name_lower.startswith("python") or name_lower in ("py.exe", "py")
+    if is_python:
+        for arg in cmdline_list[1:]:
+            arg_lower = arg.lower()
+            if (
+                "deadline.unreal_adaptor" in arg_lower
+                or "/unreal_adaptor/" in arg_lower
+                or "\\unreal_adaptor\\" in arg_lower
+            ):
+                return "UnrealAdaptor"
+
+    return None
+
+
+def _find_leftover_processes() -> List[Dict[str, Any]]:
+    """Iterate running processes and return records for any matching a
+    leftover category (see _categorize_process)."""
+    leftover: List[Dict[str, Any]] = []
+
+    for proc in psutil.process_iter(["pid", "name", "cmdline"]):
+        try:
+            cmdline = proc.info.get("cmdline")
+            cmdline_unreadable = cmdline is None
+            cmdline_list = cmdline or []
+            if cmdline_unreadable:
+                cmdline_display = "<cmdline unreadable; insufficient privileges>"
+            elif not cmdline_list:
+                cmdline_display = "<no cmdline>"
+            else:
+                cmdline_display = " ".join(cmdline_list)[:160]
+            name_lower = (proc.info.get("name") or "").lower()
+
+            category = _categorize_process(name_lower, cmdline_list, cmdline_unreadable)
+            if category is not None:
+                leftover.append(_record_leftover(proc.info, cmdline_display, category))
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            pass
+
+    return leftover
+
+
+def pytest_sessionstart(session) -> None:
+    """Abort the E2E session if a UE editor, Unreal adaptor, or
+    deadline-worker-agent is already running on this host. Such processes
+    hold file locks, occupy ports, and (for the worker-agent) can pick up
+    jobs the new run is trying to submit.
+
+    Detection only — the hook never terminates anything. Killing a
+    production deadline-worker-agent on a CMF host is too costly an
+    accident to risk for the convenience of automated cleanup.
+    """
+    if session.config.getoption("--no-prerun-checks"):
+        logger.info("--no-prerun-checks passed; skipping pre-run validation")
+        return
+
+    leftover = _find_leftover_processes()
+    if not leftover:
+        logger.info("No conflicting processes found")
+        return
+
+    msg_lines = [
+        "",
+        "=" * 70,
+        "ABORTING: A UE editor, Unreal adaptor, or deadline-worker-agent is",
+        "already running on this host. The E2E suite cannot run safely while",
+        "any of these processes are active.",
+        "",
+        "Detected:",
+        "",
+    ]
+    for proc_info in leftover:
+        msg_lines.append(
+            f"  [{proc_info['category']}] PID {proc_info['pid']} - {proc_info['name']}"
+        )
+        msg_lines.append(f"    {proc_info['cmdline_short']}")
+        msg_lines.append("")
+
+    msg_lines.append("To resolve, either:")
+    msg_lines.append("  Stop these processes, then re-run the suite:")
+    msg_lines.append("    - Task Manager (Ctrl+Shift+Esc): find by PID -> End Task")
+    msg_lines.append("    - Or, in an elevated shell:  taskkill /PID <pid> /F")
+    msg_lines.append("    - For a running worker service:  net stop DeadlineWorker")
+    msg_lines.append("  Or re-run with --no-prerun-checks to bypass this check.")
+    msg_lines.append("=" * 70)
+
+    full_msg = "\n".join(msg_lines)
+    logger.error(full_msg)
+    # returncode=3 = pytest "internal error / setup failure".
+    pytest.exit(full_msg, returncode=3)
 
 
 def get_source_root() -> str:
@@ -491,18 +633,26 @@ def queue_role_arn(iam_client: BaseClient, sts_client: BaseClient) -> str:
         return current_role_arn
 
 
+# Terminal non-success states for a Deadline Cloud job (per the GetJob API).
+# Default failure_states for wait_for_job_state(). Update if the API gains new
+# terminal failure states.
+TERMINAL_FAILURE_STATES: Tuple[str, ...] = ("FAILED", "CANCELED", "NOT_COMPATIBLE")
+
+
 def wait_for_job_state(
     deadline_client: BaseClient,
     farm_id: str,
     job_id: str,
     queue_id: str,
     expected_states: Optional[List[str]] = None,
+    failure_states: Optional[List[str]] = None,
     max_wait_time: int = 600,
     wait_interval: int = 10,
     status_interval: int = 5,
 ) -> Tuple[bool, Optional[str], str]:
     """
-    Monitor a Deadline Cloud job until it reaches an expected state or times out.
+    Monitor a Deadline Cloud job until it reaches an expected state, hits a
+    failure state, or times out.
 
     Args:
         deadline_client: Boto3 Deadline client
@@ -511,6 +661,8 @@ def wait_for_job_state(
         queue_id: The queue ID containing the job
         expected_states: List of states to consider as successful (e.g. ["READY", "SUCCEEDED"])
                         If None, defaults to ["SUCCEEDED"]
+        failure_states: Terminal states that fail the wait immediately. None
+                        defaults to TERMINAL_FAILURE_STATES; [] disables fail-fast.
         max_wait_time: Maximum time to wait in seconds (default: 600)
         wait_interval: Time between status checks in seconds (default: 10)
         status_interval: Time between status output messages in seconds (default: 5)
@@ -524,6 +676,18 @@ def wait_for_job_state(
     # Default expected states if not provided
     if expected_states is None:
         expected_states = ["SUCCEEDED"]
+
+    if failure_states is None:
+        effective_failure_states: List[str] = list(TERMINAL_FAILURE_STATES)
+    else:
+        effective_failure_states = list(failure_states)
+
+    # Drop states the caller is explicitly waiting for (e.g. a test that
+    # cancels its own job and waits for CANCELED).
+    excluded = [s for s in effective_failure_states if s in expected_states]
+    if excluded:
+        logger.debug(f"Excluded {excluded} from failure_states because they are in expected_states")
+    effective_failure_states = [s for s in effective_failure_states if s not in expected_states]
 
     logger.info(
         f"Monitoring job {job_id} in farm {farm_id}, queue {queue_id} for state(s) {expected_states}"
@@ -581,7 +745,13 @@ def wait_for_job_state(
                 logger.info(f"Job {job_id} status changed: {status}")
                 last_logged_status = status
 
-            # Check if job reached expected state
+            # Fail-fast on a terminal failure before checking expected, so we
+            # don't wait out max_wait_time on a job that's already failed.
+            if status in effective_failure_states:
+                error_msg = f"Job {job_id} reached failure state: {status}"
+                logger.error(error_msg)
+                return False, status, error_msg
+
             if status in expected_states:
                 logger.info(f"Job {job_id} reached expected state: {status}")
                 return True, status, f"Job {job_id} reached expected state: {status}"

--- a/test/end_to_end/test_create_job.py
+++ b/test/end_to_end/test_create_job.py
@@ -1,7 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import logging
-from conftest import extract_job_info_from_test_output, wait_for_job_state, cancel_job
+from conftest import (
+    extract_job_info_from_test_output,
+    wait_for_job_state,
+    cancel_job,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +38,7 @@ def test_create_job(
         max_wait_time=30,
         wait_interval=5,
     )
-    assert success
+    assert success, message
 
     if request.config.getoption("--no-cancel"):
         logger.info(f"Job {job_id} is in READY state, skipping cancel (--no-cancel)")

--- a/test/end_to_end/test_worker_agent.py
+++ b/test/end_to_end/test_worker_agent.py
@@ -37,8 +37,6 @@ def test_create_job_with_worker_agent(
     job_id, farm_id, queue_id = extract_job_info_from_test_output(output_lines)
 
     if job_id and farm_id and queue_id:
-
-        # Wait for job completion
         success, status, message = wait_for_job_state(
             deadline_client=deadline_client,
             farm_id=farm_id,
@@ -49,7 +47,7 @@ def test_create_job_with_worker_agent(
             wait_interval=10,
         )
 
-        assert success
+        assert success, message
 
         logger.info(f"Job {job_id} SUCCEEDED")
     else:
@@ -89,9 +87,7 @@ def test_worker_agent_project_plugins(
     job_id, farm_id, queue_id = extract_job_info_from_test_output(output_lines)
 
     if job_id and farm_id and queue_id:
-
-        # Wait for job completion
-        wait_for_job_state(
+        success, status, message = wait_for_job_state(
             deadline_client=deadline_client,
             farm_id=farm_id,
             job_id=job_id,
@@ -100,6 +96,9 @@ def test_worker_agent_project_plugins(
             max_wait_time=600,
             wait_interval=10,
         )
+        # The plugin assertions below need a completed session; if the job
+        # didn't reach SUCCEEDED, the loaded-plugin log lines are unreliable.
+        assert success, message
 
         # Verify which project plugins were loaded by the worker
         worker_project_plugins = get_last_session_project_plugins(


### PR DESCRIPTION

Fixes: *N/A — no GitHub issue tracked*

### What was the problem/requirement? (What/Why)

Two operational ergonomics issues in the E2E suite both lengthen the debug cycle and obscure root causes when something goes wrong.

**1. The wait loop polls until timeout even when the job has already failed.**

`wait_for_job_state()` polls for the expected state (`SUCCEEDED`, `READY`, etc.) until `max_wait_time` (10 minutes by default for worker runs). If a task fails midway and the job lands in `FAILED` or `CANCELED`, the loop keeps polling until the timeout expires before the test fails. The eventual failure message is a generic timeout — *"Timeout waiting for job <id> to reach state(s) ['SUCCEEDED']"* — which hides the real cause.

The `test_worker_agent_project_plugins` test had an additional latent bug: it called `wait_for_job_state(...)` without inspecting the return value. If the wait timed out (or any other terminal state), the test still proceeded to inspect plugin logs from a job that may not have completed, producing flaky or misleading assertions.

**2. The suite assumes the host is isolated, but never checks.**

If a UE editor, Unreal adaptor (Python daemon), or `deadline-worker-agent` is already running on the host when a new run starts, the new run fails confusingly. They hold file locks, occupy ports, and — for the worker-agent — pick up jobs the new run is trying to submit, acting as a "ghost worker" producing results from the wrong process. Common ways the host ends up in this state:

- A previous E2E run was interrupted (Ctrl-C, crash, system reboot)
- A developer left UE or the adaptor running from local dev work
- A production `deadline-worker-agent` service is running on the host

The cause doesn't matter for the new run; the suite will fail confusingly while any of these are active. Triage requires a developer to know to look for stale processes — which is institutional knowledge, not anywhere in the test suite.

### What was the solution? (How)

**1. Fail fast when a job reaches a terminal failure state.**

`wait_for_job_state()` takes a new `failure_states` parameter (default: `TERMINAL_FAILURE_STATES = ("FAILED", "CANCELED", "NOT_COMPATIBLE")`). When the polled job's status hits one of those states, the loop returns `(False, status, "Job <id> reached failure state: <status>")` immediately rather than polling until `max_wait_time`. Pass an empty list to disable.

States the caller is explicitly waiting for are removed from `failure_states` automatically (with a debug log), so a test that legitimately expects `CANCELED` is not affected. The `TERMINAL_FAILURE_STATES` constant lives next to `wait_for_job_state` and references the GetJob API as the source of truth — it should be updated if the API gains new terminal failure states.

E2E tests now `assert success, message` instead of bare `assert success`, so the failure output identifies the underlying job state and reason. As a side effect, this fixes the latent bug in `test_worker_agent_project_plugins` where the wait result was being discarded entirely.

**2. Detect already-running UE / adaptor / worker-agent processes before the suite runs.**

A new `pytest_sessionstart` hook scans for any of those processes at session start. If found, it lists each detected PID with its command line and aborts the run via `pytest.exit(returncode=3)` so the message is shown once at the bottom of the report. Manual remediation guidance (Task Manager, `taskkill`, `net stop DeadlineWorker`) is included in the abort message, plus a pointer to the bypass flag.

Per-process classification logic (`_categorize_process`) operates on the cmdline as a list of args rather than as a joined string. This avoids two classes of false positive that a naive `substring in " ".join(cmdline)` would produce: a path argument that happens to contain the substring, and another shell's grep query searching for it. `deadline-worker-agent` is matched by executable name and is still flagged when its cmdline is unreadable (e.g. owned by another user). UE worker sessions and python adaptor processes require a readable cmdline so the worker-vs-developer guard can be applied.

**Detection only — the hook never terminates anything.** Killing a production `deadline-worker-agent` on a CMF host is too costly an accident to risk for the convenience of automated cleanup, and the matching is heuristic, so a kill path could not be made safe.

**`--no-prerun-checks`** bypasses all session-start (pre-run) validation, including this check. The flag is named generically so future pre-run checks can be governed by the same opt-out without API churn. Use on hosts where the heuristic is known to produce false positives — e.g. a host that legitimately runs a production `deadline-worker-agent` service.

### What is the impact of this change?

**For the E2E suite:**
- Job-level test failures surface in seconds instead of timing out after 10 minutes. Investigation cycle is dramatically shorter.
- A test failure now includes the actual job state and reason in the pytest output, not a bare `AssertionError`.
- A latent bug in `test_worker_agent_project_plugins` (the wait result was being discarded) is fixed.

**For developers running the suite:**
- The suite refuses to start when the host has interfering processes, with a clear actionable message instead of cascading mysterious failures. New users no longer need institutional knowledge about "check for stale UE processes" to triage a confusing failure.
- `--no-prerun-checks` provides an escape valve for shared/CMF hosts.

**For customers / CI:**
- No source-level changes. No customer-facing API or behavior changes.
- Test infrastructure only — `test/end_to_end/` directory.

### How was this change tested?

- **Unit tests:** `467 passed, 2 skipped` via the standard `pytest test/ --cov-config pyproject.toml --ignore=test/end_to_end --ignore=test/integ` invocation. No regressions in the existing unit-test suite.
- **Lint / format / types:** `ruff check`, `black --check`, and `mypy test/end_to_end` are all clean.
- **Manual `pytest_sessionstart` exercise:** with a synthetic process that matches the heuristic, the hook produces the expected abort output and exits with code 3. With `--no-prerun-checks`, the same starting state passes through to test collection.
- **Flag wiring:** verified `--no-prerun-checks` registered correctly via `pytest_addoption`, and `session.config.getoption(...)` short-circuits the hook body when set.
- **End-to-end render:** *not run as part of this change.* The change is to test infrastructure only; the suite's rendering path is unchanged. Recommend a reviewer with access to a CMF dev fleet validate that an actual E2E run still produces a working render and that the new fail-fast behaviour surfaces correctly when a render task fails.

### Have you run a render job successfully with these changes?

Not as part of this PR. The change is to test infrastructure, not the submitter or adaptor; the rendering path is unchanged.

### Was this change documented?

The behaviours are documented in code via:
- The `--no-prerun-checks` help string (visible via `pytest --help`)
- The `pytest_sessionstart` and `wait_for_job_state` docstrings
- The abort message itself (visible to anyone hitting the gate)

No standalone documentation change is needed — this is internal test infrastructure. The abort message is self-explanatory and includes remediation steps, and the `--no-prerun-checks` flag surfaces in `pytest --help`.

### Is this a breaking change?

**No.**

- No public Python API changes. The new `failure_states` parameter on `wait_for_job_state` has a backwards-compatible default.
- No behavioural changes to the rendering path.
- No init-data, run-data, or OpenJD-template schema changes.
- Test-infrastructure-only — `test/end_to_end/` directory.

The only externally-visible change is the new `--no-prerun-checks` pytest flag, which is purely additive — existing invocations keep working unchanged.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

---