### PR TITLE
refactor!: Rename ChunkSize/ChunkId render params to ShotsPerTask/Tas…

### DIFF
--- a/docs/source/docs_usage/use_cases/create_render_job.rst
+++ b/docs/source/docs_usage/use_cases/create_render_job.rst
@@ -18,15 +18,15 @@ Render Step data asset
 
    a. Handler - specify which UnrealAdaptor’s handler will process the script commands. Handler "render" used for usual pipeline of MRQ  render **Filled automatically during the submission**
    #. QueueManifestPath - path to the serialized MRQ manifest where render job is described. **Filled automatically during the submission**
-   #. TaskChunkSize - Number of shots of Level Sequence to render per OpenJob Task. Set this value according to what number of tasks you want Deadline Cloud to generate
-      For example, if Level Sequence has 10 shots and TaskChunkSize = 3 that means 4 OpenJob Tasks will be introduced:
+   #. ShotsPerTask - Number of shots of Level Sequence to render per OpenJob Task. Set this value according to what number of tasks you want Deadline Cloud to generate
+      For example, if Level Sequence has 10 shots and ShotsPerTask = 3 that means 4 OpenJob Tasks will be introduced:
 
        i. Task 0 - shots 0, 1, 2
        #. Task 1 - shots 3, 4, 5
        #. Task 2 - shots 6, 7, 8
        #. Task 3 - shot 9
 
-   #. TaskChunkId - list of chunk ids. This example will consist of 0, 1, 2, 3 (task ids). **Filled automatically during the submission**
+   #. TaskIndex - list of task indices. This example will consist of 0, 1, 2, 3 (task ids). **Filled automatically during the submission**
 
 
 Launch UE Environment data asset
@@ -63,7 +63,7 @@ Render Job data asset
       of frames.
 
       .. note::
-         When chunking a render across multiple tasks, MRQ writes one output file per task.
+         When a render is split across multiple tasks, MRQ writes one output file per task.
          For image sequences (PNG/EXR/etc.) the default ``FileNameFormat`` already includes
          ``{frame_number}``, so each task's output is unique. For video containers such as
          ``.mov`` the default format is just ``{sequence_name}`` and every task will write to

--- a/docs/user_guide/create-perforce-render-job.md
+++ b/docs/user_guide/create-perforce-render-job.md
@@ -145,7 +145,7 @@ Set up an OpenJD Render Job that orchestrates the entire rendering workflow.
 | `Executable` | Unreal executable name for render node | ❌ | **Configure** - Use default for standard setups |
 | `CondaPackages` | Conda packages needed to render the job | ❌ | **Configure** - Use default for standard setups |
 | `CondaChannels` | Conda channels where packages are stored | ❌ | **Configure** - Use default for standard setups |
-| `ChunkSize` | Number of shots grouped in a single render session | ❌ | **Configure** - Default: 1 (tune for performance) |
+| `ShotsPerTask` | Number of shots grouped in a single render session | ❌ | **Configure** - Default: 1 (tune for performance) |
 | `MarketplacePluginsDir` | Path to engine Marketplace plugins | ✅ | **Leave empty** - Auto-populated |
 
 > **📝 Legend**: ✅ = Auto-populated during submission, ❌ = No Auto-populated
@@ -153,7 +153,7 @@ Set up an OpenJD Render Job that orchestrates the entire rendering workflow.
 **Parameter Configuration Guidelines:**
 - **Auto-populated parameters**: Leave these empty - they're filled automatically during job submission
 - **Manual parameters**: Review defaults and adjust based on your specific requirements
-- **ChunkSize**: Start with 1, increase for better performance with simple shots
+- **ShotsPerTask**: Start with 1, increase for better performance with simple shots
 
 ![Perforce Job Parameter Definition](./images/p4-job-parameter-definition.png)
 
@@ -181,9 +181,9 @@ Set up an OpenJD Render Job that orchestrates the entire rendering workflow.
 
 ### Performance Optimization
 
-**Chunk Size Configuration:**
+**Shots Per Task Configuration:**
 
-| Chunk Size | Use Case | Performance Impact |
+| Shots Per Task | Use Case | Performance Impact |
 |------------|----------|-------------------|
 | 1-2 shots | Complex shots, detailed review needed | Lower throughput, higher quality control |
 | 4-8 shots | Balanced workload, typical projects | Optimal balance of speed and manageability |

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -22,6 +22,7 @@ Follow these guides to set up and use AWS Deadline Cloud with Unreal Engine:
 
 - Advanced Сonfigurations
     - **[Host Requirements](./custom-host-requirements.md)** - Describe the Worker host capability requirements that must be met for Task scheduling
+    - **[Render Task Partitioning](./render-task-partitioning.md)** - How a render is split into tasks
 
 
 **Note:** We're currently migrating our documentation to this site. In the meantime, you can find additional user guides in the [deadline-cloud-for-unreal-engine GitHub repository](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine). To view these guides locally, follow the [Building the docs](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/blob/mainline/DEVELOPMENT.md#building-the-docs) instructions in our development guide.

--- a/docs/user_guide/render-task-partitioning.md
+++ b/docs/user_guide/render-task-partitioning.md
@@ -1,0 +1,55 @@
+# Render Task Partitioning
+
+When you submit a render to AWS Deadline Cloud, the Unreal submitter splits the work in a Movie Render Queue (MRQ) job into multiple OpenJD **tasks** so they can be distributed across worker hosts.
+
+This integration currently supports two submitter-side partitioning modes, described below. They are configured on the Render Step / Render Job parameters and are mutually exclusive — `FramesPerTask` takes precedence when set.
+
+> **Note on terminology — submitter partitioning vs. OpenJD chunking:** OpenJD has its own native [task chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) feature, where the scheduler groups tasks into chunks at dispatch time using a `ChunkSize` parameter and a `CHUNK[INT]` task-parameter type. The two modes below are different: they are **submitter-side** partitioning that decides the task breakdown at submission time, implemented in this integration rather than the OpenJD scheduler.
+>
+> Support for OpenJD's native chunking is planned as an additional mode. To avoid the name collision ahead of that work, the submitter-side parameters that were previously called `ChunkSize`/`ChunkId` are now `ShotsPerTask`/`TaskIndex`. When OpenJD chunking is added, its `ChunkSize` will be a distinct, separately-documented concept.
+
+## Mode 1 — Shots per task (`ShotsPerTask`)
+
+Partitions the **enabled shots** of the Level Sequence. Each task renders up to `ShotsPerTask` consecutive enabled shots.
+
+- Task count = ceil(number of enabled shots / `ShotsPerTask`)
+- If `ShotsPerTask` is 0 or negative, it defaults to 1 (one shot per task).
+
+Example — a Level Sequence with 10 enabled shots and `ShotsPerTask = 3` produces 4 tasks:
+
+| TaskIndex | Shots rendered |
+|---|---|
+| 0 | 0, 1, 2 |
+| 1 | 3, 4, 5 |
+| 2 | 6, 7, 8 |
+| 3 | 9 |
+
+Use this mode when your sequence is organized into shots and you want each task to cover a whole number of shots.
+
+## Mode 2 — Frames per task (`FramesPerTask`)
+
+Partitions the **frame range** of the render. Each task renders up to `FramesPerTask` consecutive frames, regardless of shot boundaries.
+
+- Task count = ceil(total frame range / `FramesPerTask`)
+- `FramesPerTask` takes precedence: if it is set and greater than 0, `ShotsPerTask` is ignored.
+- The frame range comes from the MRQ output settings' custom playback range if enabled, otherwise from the Level Sequence's playback range.
+
+Example — a 100-frame sequence with `FramesPerTask = 25` produces 4 tasks:
+
+| TaskIndex | Frames rendered |
+|---|---|
+| 0 | 0–24 |
+| 1 | 25–49 |
+| 2 | 50–74 |
+| 3 | 75–99 |
+
+Use this mode when you want even-sized tasks by frame count — for example to load-balance a long single shot across many workers.
+
+## `TaskIndex`
+
+In both modes, each generated task is assigned a 0-based `TaskIndex` identifying which partition it renders. It is filled in automatically during submission; you do not set it by hand. The adaptor uses `TaskIndex` to select the correct shots (Mode 1) or frame window (Mode 2) for each task.
+
+### Output file naming
+
+When a render is split across multiple tasks, MRQ writes one output file per task. For image sequences (PNG/EXR/etc.) the default `FileNameFormat` includes `{frame_number}`, so each task's output is already unique. For video containers such as `.mov`, the default format is just `{sequence_name}` and every task would write to the same filename. To disambiguate, add the `{task_index}` token to the MRQ Output Setting's `FileNameFormat` (for example `{sequence_name}_{task_index}`); the submitter substitutes it at render time with a zero-padded per-task index.
+

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/run_data.schema.json
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/run_data.schema.json
@@ -10,8 +10,8 @@
         "queue_path": { "type": "string" },
         "script_path": { "type": "string" },
         "script_args": { "type": "string" },
-        "chunk_size": { "type": "integer" },
-        "chunk_id": { "type": "integer" },
+        "shots_per_task": { "type": "integer" },
+        "task_index": { "type": "integer" },
         "output_path": { "type":  "string" }
     },
     "required": [

--- a/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
+++ b/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
@@ -312,7 +312,7 @@ class UnrealRenderStepHandler(BaseStepHandler):
     def _apply_task_index_to_filename(render_job, task_index: int) -> None:
         """
         Substitute ``{task_index}`` in MRQ's FileNameFormat with the per-task index so
-        chunked renders that produce a single file per task (e.g. .mov containers) do
+        multi-task renders that produce a single file per task (e.g. .mov containers) do
         not collide on the same output filename. If the resolved format contains no
         per-task token (neither ``{task_index}`` nor ``{frame_number}``), warn that
         outputs from sibling tasks will overwrite each other.
@@ -335,19 +335,19 @@ class UnrealRenderStepHandler(BaseStepHandler):
             )
 
     @staticmethod
-    def enable_shots_by_chunk(render_job, task_chunk_size: int, task_chunk_id: int):
+    def enable_shots_for_task(render_job, shots_per_task: int, task_index: int):
 
         all_shots_to_render = [shot for shot in render_job.shot_info if shot.enabled]
-        shots_chunk = all_shots_to_render[
-            task_chunk_id * task_chunk_size : (task_chunk_id + 1) * task_chunk_size
+        task_shots = all_shots_to_render[
+            task_index * shots_per_task : (task_index + 1) * shots_per_task
         ]
         for shot in render_job.shot_info:
-            if shot in shots_chunk:
+            if shot in task_shots:
                 shot.enabled = True
                 logger.info(f"Shot to render: {shot.outer_name}: {shot.inner_name}")
             else:
                 shot.enabled = False
-        logger.info(f"Shots in task: {[shot.outer_name for shot in shots_chunk]}")
+        logger.info(f"Shots in task: {[shot.outer_name for shot in task_shots]}")
 
     @staticmethod
     def get_frame_range(output_settings, level_sequence):
@@ -363,7 +363,7 @@ class UnrealRenderStepHandler(BaseStepHandler):
             elif level_sequence is None:
                 # The caller passed a None LevelSequence (e.g. the loader returned
                 # None for reasons that are not always reproducible). Fall back to
-                # the MRQ output_settings custom range so chunked renders can still
+                # the MRQ output_settings custom range so multi-task renders can still
                 # emit frames; otherwise we'd crash on
                 # `NoneType.get_playback_range()` further down. If output_settings
                 # has no non-empty range either, leave the cache unset and surface
@@ -437,10 +437,10 @@ class UnrealRenderStepHandler(BaseStepHandler):
             )
 
         output_settings = None
-        if "chunk_id" in args:
-            chunk_id: int = args["chunk_id"]
+        if "task_index" in args:
+            task_index: int = args["task_index"]
         for job in subsystem.get_queue().get_jobs():
-            if args.get("frames_per_task") and "chunk_id" in args:
+            if args.get("frames_per_task") and "task_index" in args:
                 frames_per_task: int = args["frames_per_task"]
                 if not output_settings:
                     output_settings = job.get_configuration().find_or_add_setting_by_class(
@@ -456,24 +456,23 @@ class UnrealRenderStepHandler(BaseStepHandler):
                 )
                 if frame_range_start is None or frame_range_end is None:
                     logger.error(
-                        "Frame range unavailable; cannot compute chunk window for "
-                        f"chunk_id={chunk_id} frames_per_task={frames_per_task}"
+                        "Frame range unavailable; cannot compute the frame window for "
+                        f"task_index={task_index} frames_per_task={frames_per_task}"
                     )
                     return False
 
                 output_settings.custom_start_frame = frame_range_start + (
-                    chunk_id * frames_per_task
+                    task_index * frames_per_task
                 )
                 output_settings.custom_end_frame = min(
                     output_settings.custom_start_frame + frames_per_task, frame_range_end
                 )
-                # Force MRQ to honour the per-chunk window set above. Without this
-                # flag, MRQ falls back to the full range baked into the MRQ preset
-                # whenever `use_custom_playback_range` is false on the output
-                # settings -- which causes every chunked task to redundantly
-                # re-render the entire sequence. Observed in a 40-chunk render
-                # where each chunk re-rendered frames 0..end instead of its
-                # assigned window.
+                # Force MRQ to honour the per-task frame window set above. Without
+                # this flag, MRQ falls back to the full range baked into the MRQ
+                # preset whenever `use_custom_playback_range` is false on the output
+                # settings -- which causes every task to redundantly re-render the
+                # entire sequence. Observed in a 40-task render where each task
+                # re-rendered frames 0..end instead of its assigned window.
                 output_settings.use_custom_playback_range = True
 
                 if level_sequence is not None:
@@ -484,21 +483,21 @@ class UnrealRenderStepHandler(BaseStepHandler):
                     )
                 else:
                     logger.warning(
-                        "Rendering chunk frame range "
+                        "Rendering task frame range "
                         f"[{output_settings.custom_start_frame}, "
                         f"{output_settings.custom_end_frame}] without a resolved "
                         "LevelSequence; relying on output_settings.use_custom_playback_range"
                     )
-            elif "chunk_size" in args and "chunk_id" in args:
-                chunk_size: int = args["chunk_size"]
-                UnrealRenderStepHandler.enable_shots_by_chunk(
+            elif "shots_per_task" in args and "task_index" in args:
+                shots_per_task: int = args["shots_per_task"]
+                UnrealRenderStepHandler.enable_shots_for_task(
                     render_job=job,
-                    task_chunk_size=chunk_size,
-                    task_chunk_id=chunk_id,
+                    shots_per_task=shots_per_task,
+                    task_index=task_index,
                 )
 
-            if "chunk_id" in args and (args.get("frames_per_task") or "chunk_size" in args):
-                UnrealRenderStepHandler._apply_task_index_to_filename(job, chunk_id)
+            if "task_index" in args and (args.get("frames_per_task") or "shots_per_task" in args):
+                UnrealRenderStepHandler._apply_task_index_to_filename(job, task_index)
 
             if "output_path" in args:
                 if not os.path.exists(args["output_path"]):

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
@@ -300,8 +300,8 @@ class OpenJobStepParameterNames:
 
     :cvar ADAPTOR_HANDLER: Handler name to run the jobs on Adaptor (render/custom)
     :cvar FRAMES_PER_TASK: If set, each task will render this number of frames
-    :cvar TASK_CHUNK_SIZE: Count of the shots per OpenJD Step's Task unless FRAMES_PER_TASK set
-    :cvar TASK_CHUNK_ID: Chunk number that should be rendered at OpenJD Step's Task
+    :cvar SHOTS_PER_TASK: Count of the shots per OpenJD Step's Task unless FRAMES_PER_TASK set
+    :cvar TASK_INDEX: Index of the task (0-based) within the OpenJD Step's parameter space
     """
 
     QUEUE_MANIFEST_PATH = "QueueManifestPath"
@@ -313,5 +313,5 @@ class OpenJobStepParameterNames:
 
     ADAPTOR_HANDLER = "Handler"
     FRAMES_PER_TASK = "FramesPerTask"
-    TASK_CHUNK_SIZE = "ChunkSize"
-    TASK_CHUNK_ID = "ChunkId"
+    SHOTS_PER_TASK = "ShotsPerTask"
+    TASK_INDEX = "TaskIndex"

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
@@ -450,21 +450,21 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
     def mrq_job(self, value: unreal.MoviePipelineExecutorJob):
         self._mrq_job = value
 
-    def _get_chunk_ids_count(self) -> int:
+    def _get_task_count(self) -> int:
         """
-        Get number of shot chunks
-        as count of total number of frames divided by FramesPerTask if set, or
-        as count of enabled shots in level sequence divided by chuck size parameter value.
-        If no chunk size parameter value is 0, return 1
+        Get the number of tasks the render Step will be split into:
+        total number of frames divided by FramesPerTask if set, or
+        the number of enabled shots in the level sequence divided by
+        ShotsPerTask. If ShotsPerTask is <= 0, defaults to 1.
 
         Example:
             - LevelSequence shots: [sh1 - enabled, sh2 - disabled, sh3 - enabled, sh4 - enabled]
-            - ChunkSize: 2
-            - ChunkIds count: 2 (sh1, sh3; sh4)
+            - ShotsPerTask: 2
+            - Task count: 2 (sh1, sh3; sh4)
 
-        :raises ValueError: When no chunk size parameter is set
+        :raises ValueError: When neither ShotsPerTask nor FramesPerTask parameter is set
 
-        :return: ChunkIds count
+        :return: Number of tasks
         :rtype: int
         """
 
@@ -476,8 +476,8 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
         if not self.open_job:
             raise exceptions.OpenJobIsMissingError("Render Job must be provided")
 
-        chunk_size_parameter = self.open_job._find_extra_parameter(
-            parameter_name=OpenJobStepParameterNames.TASK_CHUNK_SIZE, parameter_type="INT"
+        shots_per_task_parameter = self.open_job._find_extra_parameter(
+            parameter_name=OpenJobStepParameterNames.SHOTS_PER_TASK, parameter_type="INT"
         )
         frames_per_task_parameter = self.open_job._find_extra_parameter(
             parameter_name=OpenJobStepParameterNames.FRAMES_PER_TASK, parameter_type="INT"
@@ -503,22 +503,22 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
                 logger.info(
                     f"Level sequence at submission has range {level_sequence.get_playback_range()} ({total_frame_range} frames)"
                 )
-            task_chunk_ids_count = math.ceil(total_frame_range / frames_per_task_parameter.value)
-            return task_chunk_ids_count
-        if chunk_size_parameter is None:
+            task_count = math.ceil(total_frame_range / frames_per_task_parameter.value)
+            return task_count
+        if shots_per_task_parameter is None:
             raise ValueError(
-                f'Render Job\'s parameter "{OpenJobStepParameterNames.TASK_CHUNK_SIZE}"'
+                f'Render Job\'s parameter "{OpenJobStepParameterNames.SHOTS_PER_TASK}"'
                 f' or "{OpenJobStepParameterNames.FRAMES_PER_TASK}" '
                 f"must be provided in extra parameters or template"
             )
 
-        chunk_size = int(chunk_size_parameter.value)
-        if chunk_size <= 0:
-            chunk_size = 1  # by default 1 chunk consist of 1 shot
+        shots_per_task = int(shots_per_task_parameter.value)
+        if shots_per_task <= 0:
+            shots_per_task = 1  # by default each task renders 1 shot
 
-        task_chunk_ids_count = math.ceil(len(enabled_shots) / chunk_size)
+        task_count = math.ceil(len(enabled_shots) / shots_per_task)
 
-        return task_chunk_ids_count
+        return task_count
 
     def _load_level_sequence(self, mrq_job):
         """Load the level sequence asset from the MRQ job."""
@@ -585,12 +585,12 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
                 f"{OpenJobStepParameterNames.MRQ_JOB_CONFIGURATION_PATH})\n"
             )
 
-        task_chunk_id_param_definition = UnrealOpenJobStepParameterDefinition(
-            OpenJobStepParameterNames.TASK_CHUNK_ID,
+        task_index_param_definition = UnrealOpenJobStepParameterDefinition(
+            OpenJobStepParameterNames.TASK_INDEX,
             TaskParameterType.INT.value,
-            [i for i in range(self._get_chunk_ids_count())],
+            [i for i in range(self._get_task_count())],
         )
-        self._update_extra_parameter(task_chunk_id_param_definition)
+        self._update_extra_parameter(task_index_param_definition)
 
         handler_param_definition = UnrealOpenJobStepParameterDefinition(
             OpenJobStepParameterNames.ADAPTOR_HANDLER, TaskParameterType.STRING.value, ["render"]

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
@@ -40,7 +40,7 @@ parameterDefinitions:
   default: deadline-cloud
   userInterface: 
    control: LINE_EDIT
-- name: ChunkSize
+- name: ShotsPerTask
   type: INT
   default: 1
 - name: MarketplacePluginsDir

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_step.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_step.yml
@@ -1,7 +1,7 @@
 name: Render
 parameterSpace:
   taskParameterDefinitions:
-  - name: ChunkId
+  - name: TaskIndex
     type: INT
     range: []
   - name: Handler
@@ -22,8 +22,8 @@ script:
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
       frames_per_task: {{Param.FramesPerTask}}
-      chunk_size: {{Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
       output_path: {{Task.Param.OutputPath}}
   actions:
     onRun:

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
@@ -38,7 +38,7 @@ parameterDefinitions:
   default: deadline-cloud
   userInterface: 
    control: LINE_EDIT
-- name: ChunkSize
+- name: ShotsPerTask
   type: INT
   default: 1
   userInterface: 

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_step.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_step.yml
@@ -1,7 +1,7 @@
 name: Render
 parameterSpace:
   taskParameterDefinitions:
-  - name: ChunkId
+  - name: TaskIndex
     type: INT
     range: []
   - name: Handler
@@ -19,8 +19,8 @@ script:
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
       frames_per_task: {{Param.FramesPerTask}}
-      chunk_size: {{Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
   actions:
     onRun:
       command: unreal-engine-openjd

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_step_mpq.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_step_mpq.yml
@@ -1,7 +1,7 @@
 name: Render
 parameterSpace:
   taskParameterDefinitions:
-  - name: ChunkId
+  - name: TaskIndex
     type: INT
     range: []
   - name: Handler
@@ -13,7 +13,7 @@ parameterSpace:
   - name: FramesPerTask
     type: INT
     range: [0]
-  - name: ChunkSize
+  - name: ShotsPerTask
     type: INT
     range: [1]
 script:
@@ -24,8 +24,8 @@ script:
     data: |
       handler: {{Task.Param.Handler}}
       queue_path: {{Task.Param.MoviePipelineQueuePath}}
-      chunk_size: {{Task.Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Task.Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
   actions:
     onRun:
       command: unreal-engine-openjd

--- a/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_job.yml
@@ -26,7 +26,7 @@ parameterDefinitions:
 - name: FramesPerTask
   type: INT
   default: 0
-- name: ChunkSize
+- name: ShotsPerTask
   type: INT
   default: 1
 - name: MarketplacePluginsDir

--- a/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_step.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_step.yml
@@ -1,7 +1,7 @@
 name: Render
 parameterSpace:
   taskParameterDefinitions:
-  - name: ChunkId
+  - name: TaskIndex
     type: INT
     range: []
   - name: Handler
@@ -22,8 +22,8 @@ script:
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
       frames_per_task: {{Param.FramesPerTask}}
-      chunk_size: {{Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
       output_path: {{Task.Param.OutputPath}}
   actions:
     onRun:

--- a/src/unreal_plugin/Content/Python/submit_actions/p4_render_job_submission.py
+++ b/src/unreal_plugin/Content/Python/submit_actions/p4_render_job_submission.py
@@ -49,8 +49,8 @@ def main():
             steps=[
                 P4RenderUnrealOpenJobStep(
                     extra_parameters=[
-                        # Override ChunkSize parameter value
-                        UnrealOpenJobStepParameterDefinition("ChunkSize", "INT", [10])
+                        # Override ShotsPerTask parameter value
+                        UnrealOpenJobStepParameterDefinition("ShotsPerTask", "INT", [10])
                     ]
                 )
             ],

--- a/src/unreal_plugin/Content/Python/submit_actions/render_job_submission.py
+++ b/src/unreal_plugin/Content/Python/submit_actions/render_job_submission.py
@@ -48,8 +48,8 @@ def main():
             steps=[
                 RenderUnrealOpenJobStep(
                     extra_parameters=[
-                        # Override ChunkSize parameter value
-                        UnrealOpenJobStepParameterDefinition("ChunkSize", "INT", [10])
+                        # Override ShotsPerTask parameter value
+                        UnrealOpenJobStepParameterDefinition("ShotsPerTask", "INT", [10])
                     ]
                 )
             ],

--- a/src/unreal_plugin/Content/Python/submit_actions/ugs_render_job_submission.py
+++ b/src/unreal_plugin/Content/Python/submit_actions/ugs_render_job_submission.py
@@ -49,8 +49,8 @@ def main():
             steps=[
                 UgsRenderUnrealOpenJobStep(
                     extra_parameters=[
-                        # Override ChunkSize parameter value
-                        UnrealOpenJobStepParameterDefinition("ChunkSize", "INT", [10])
+                        # Override ShotsPerTask parameter value
+                        UnrealOpenJobStepParameterDefinition("ShotsPerTask", "INT", [10])
                     ]
                 )
             ],

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step.yml
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step.yml
@@ -10,10 +10,10 @@ parameterSpace:
   - name: FramesPerTask
     type: INT
     range: []
-  - name: ChunkSize
+  - name: ShotsPerTask
     type: INT
     range: []
-  - name: ChunkId
+  - name: TaskIndex
     type: INT
     range: []
 script:
@@ -25,8 +25,8 @@ script:
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
       frames_per_task: {{Task.Param.FramesPerTask}}
-      chunk_size: {{Task.Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Task.Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
   actions:
     onRun:
       command: unreal-engine-openjd

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step_UI.yml
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step_UI.yml
@@ -35,8 +35,8 @@ script:
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
       frames_per_task: {{Task.Param.FramesPerTask}}
-      chunk_size: {{Task.Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Task.Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
   actions:
     onRun:
       command: unreal-engine-openjd

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step_UI_empty.yml
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step_UI_empty.yml
@@ -15,8 +15,8 @@ script:
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
       frames_per_task: {{Task.Param.FramesPerTask}}
-      chunk_size: {{Task.Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Task.Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
   actions:
     onRun:
       command: unreal-engine-openjd

--- a/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_render_step_handler.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_render_step_handler.py
@@ -36,7 +36,7 @@ class RenderJobMock:
 class TestUnrealRenderStepHandler:
 
     @pytest.mark.parametrize(
-        "shots_count, enabled_shots_count, task_chunk_size, task_chunk_id",
+        "shots_count, enabled_shots_count, shots_per_task, task_index",
         [
             (29, 15, 5, 0),
             (29, 29, 5, 1),
@@ -45,13 +45,13 @@ class TestUnrealRenderStepHandler:
             (10, 9, 3, 2),
         ],
     )
-    def test_enable_shots_by_chunk(
+    def test_enable_shots_for_task(
         self,
         unreal_render_step_handler,
         shots_count,
         enabled_shots_count,
-        task_chunk_size,
-        task_chunk_id,
+        shots_per_task,
+        task_index,
     ):
         # GIVEN
         enabled_shots = [
@@ -65,28 +65,28 @@ class TestUnrealRenderStepHandler:
         render_job_mock = RenderJobMock(shot_info=enabled_shots + disabled_shots)
 
         enabled_job_shots = [shot for shot in render_job_mock.shot_info if shot.enabled]
-        chunked = enabled_job_shots[
-            task_chunk_id * task_chunk_size : (task_chunk_id + 1) * task_chunk_size
+        task_shots = enabled_job_shots[
+            task_index * shots_per_task : (task_index + 1) * shots_per_task
         ]
-        chunked_names = [shot.outer_name for shot in chunked]
+        task_shot_names = [shot.outer_name for shot in task_shots]
 
         # WHEN
         with patch(
             "deadline.unreal_adaptor.UnrealClient.step_handlers."
             "unreal_render_step_handler.logger.info"
         ) as log_mock:
-            unreal_render_step_handler.enable_shots_by_chunk(
-                render_job_mock, task_chunk_size, task_chunk_id
+            unreal_render_step_handler.enable_shots_for_task(
+                render_job_mock, shots_per_task, task_index
             )
 
             # THEN
             enabled_shots = [shot for shot in render_job_mock.shot_info if shot.enabled]
             assert all([shot.enabled for shot in enabled_shots])
-            assert all([shot.outer_name.startswith("Enabled") for shot in chunked])
-            assert len(enabled_shots) <= task_chunk_size and len(enabled_shots) <= shots_count
+            assert all([shot.outer_name.startswith("Enabled") for shot in task_shots])
+            assert len(enabled_shots) <= shots_per_task and len(enabled_shots) <= shots_count
 
             disabled_shots = [
-                shot for shot in render_job_mock.shot_info if shot.outer_name not in chunked_names
+                shot for shot in render_job_mock.shot_info if shot.outer_name not in task_shot_names
             ]
             for shot in disabled_shots:
                 assert not shot.enabled

--- a/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_frames_per_task.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_frames_per_task.py
@@ -120,19 +120,19 @@ class TestUnrealRenderStepHandlerFramesPerTask:
             log_mock.assert_called_with("Cached level sequence frame range from 1 to 100")
 
     @pytest.mark.parametrize(
-        "chunk_id, frames_per_task, frame_start, frame_end, expected_start, expected_end",
+        "task_index, frames_per_task, frame_start, frame_end, expected_start, expected_end",
         [
-            (0, 10, 1, 100, 1, 11),  # First chunk
-            (1, 10, 1, 100, 11, 21),  # Second chunk
-            (9, 10, 1, 100, 91, 100),  # Last chunk (clamped to end)
-            (0, 50, 10, 30, 10, 30),  # Single chunk covers entire range
-            (2, 5, 0, 20, 10, 15),  # Middle chunk
+            (0, 10, 1, 100, 1, 11),  # First task
+            (1, 10, 1, 100, 11, 21),  # Second task
+            (9, 10, 1, 100, 91, 100),  # Last task (clamped to end)
+            (0, 50, 10, 30, 10, 30),  # Single task covers entire range
+            (2, 5, 0, 20, 10, 15),  # Middle task
         ],
     )
     def test_frames_per_task_calculation_logic(
         self,
         unreal_render_step_handler,
-        chunk_id,
+        task_index,
         frames_per_task,
         frame_start,
         frame_end,
@@ -153,44 +153,47 @@ class TestUnrealRenderStepHandlerFramesPerTask:
                 output_settings, level_sequence
             )
 
-            calculated_start = frame_range_start + (chunk_id * frames_per_task)
+            calculated_start = frame_range_start + (task_index * frames_per_task)
             calculated_end = min(calculated_start + frames_per_task, frame_range_end)
 
             # THEN
             assert calculated_start == expected_start
             assert calculated_end == expected_end
 
-    def test_frames_per_task_vs_chunk_size_precedence(self, unreal_render_step_handler):
-        """Test that frames_per_task takes precedence over chunk_size in argument processing"""
+    def test_frames_per_task_vs_shots_per_task_precedence(self, unreal_render_step_handler):
+        """Test that frames_per_task takes precedence over shots_per_task in argument processing"""
         # GIVEN
         args_with_frames_per_task = {
             "frames_per_task": 10,
-            "chunk_id": 1,
-            "chunk_size": 5,  # This should be ignored
+            "task_index": 1,
+            "shots_per_task": 5,  # This should be ignored
         }
 
-        args_with_chunk_size_only = {
-            "chunk_size": 5,
-            "chunk_id": 1,
+        args_with_shots_per_task_only = {
+            "shots_per_task": 5,
+            "task_index": 1,
         }
 
-        args_no_chunking: dict[str, int] = {}
+        args_no_partitioning: dict[str, int] = {}
 
         # WHEN/THEN - Test precedence logic
         # frames_per_task should be used when present
         assert (
             args_with_frames_per_task.get("frames_per_task")
-            and "chunk_id" in args_with_frames_per_task
+            and "task_index" in args_with_frames_per_task
         )
 
-        # chunk_size should be used when frames_per_task is not present
+        # shots_per_task should be used when frames_per_task is not present
         assert (
-            not args_with_chunk_size_only.get("frames_per_task")
-            and "chunk_size" in args_with_chunk_size_only
+            not args_with_shots_per_task_only.get("frames_per_task")
+            and "shots_per_task" in args_with_shots_per_task_only
         )
 
-        # No chunking when neither is present
-        assert not args_no_chunking.get("frames_per_task") and "chunk_size" not in args_no_chunking
+        # No partitioning when neither is present
+        assert (
+            not args_no_partitioning.get("frames_per_task")
+            and "shots_per_task" not in args_no_partitioning
+        )
 
     def test_frame_range_caching_behavior(self, unreal_render_step_handler):
         """Test that frame range caching works correctly across multiple calls"""
@@ -217,7 +220,7 @@ class TestUnrealRenderStepHandlerFramesPerTask:
 
     def test_frame_range_edge_cases(self, unreal_render_step_handler):
         """Test edge cases for frame range calculations"""
-        # Test case 1: chunk_id * frames_per_task exceeds total range
+        # Test case 1: task_index * frames_per_task exceeds total range
         output_settings = MagicMock()
         level_sequence = MagicMock()
 
@@ -226,11 +229,11 @@ class TestUnrealRenderStepHandlerFramesPerTask:
                 output_settings, level_sequence
             )
 
-            # chunk_id=10, frames_per_task=10 would start at frame 101, but range only goes to 50
-            chunk_id = 10
+            # task_index=10, frames_per_task=10 would start at frame 101, but range only goes to 50
+            task_index = 10
             frames_per_task = 10
 
-            calculated_start = frame_range_start + (chunk_id * frames_per_task)  # 1 + 100 = 101
+            calculated_start = frame_range_start + (task_index * frames_per_task)  # 1 + 100 = 101
             calculated_end = min(
                 calculated_start + frames_per_task, frame_range_end
             )  # min(111, 50) = 50

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_entity_frames_per_task.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_entity_frames_per_task.py
@@ -24,8 +24,8 @@ class TestOpenJobStepParameterNamesFramesPerTask:
             OpenJobStepParameterNames.OUTPUT_PATH,
             OpenJobStepParameterNames.ADAPTOR_HANDLER,
             OpenJobStepParameterNames.FRAMES_PER_TASK,
-            OpenJobStepParameterNames.TASK_CHUNK_SIZE,
-            OpenJobStepParameterNames.TASK_CHUNK_ID,
+            OpenJobStepParameterNames.SHOTS_PER_TASK,
+            OpenJobStepParameterNames.TASK_INDEX,
         ]
 
         # WHEN/THEN
@@ -44,8 +44,8 @@ class TestOpenJobStepParameterNamesFramesPerTask:
             OpenJobStepParameterNames.OUTPUT_PATH,
             OpenJobStepParameterNames.ADAPTOR_HANDLER,
             OpenJobStepParameterNames.FRAMES_PER_TASK,
-            OpenJobStepParameterNames.TASK_CHUNK_SIZE,
-            OpenJobStepParameterNames.TASK_CHUNK_ID,
+            OpenJobStepParameterNames.SHOTS_PER_TASK,
+            OpenJobStepParameterNames.TASK_INDEX,
         ]
 
         # WHEN/THEN - All parameter values should be unique

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step.py
@@ -231,7 +231,7 @@ class TestUnrealOpenJobStep:
 class TestRenderUnrealOpenJobStep:
 
     @pytest.mark.parametrize(
-        "chunk_size, shots_count, expected_chunk_ids",
+        "shots_per_task, shots_count, expected_task_indices",
         [
             (1, 15, [i for i in range(15)]),
             (2, 15, [i for i in range(8)]),
@@ -240,7 +240,7 @@ class TestRenderUnrealOpenJobStep:
             (100000, 100, [0]),
         ],
     )
-    def test__get_chunk_ids_count(self, chunk_size, shots_count, expected_chunk_ids):
+    def test__get_task_count(self, shots_per_task, shots_count, expected_task_indices):
         # GIVEN
         shot_info = []
         for _ in range(shots_count):
@@ -251,29 +251,29 @@ class TestRenderUnrealOpenJobStep:
         mrq_job_mock = MagicMock()
         mrq_job_mock.shot_info = shot_info
 
-        chunk_size_param = UnrealOpenJobParameterDefinition(
-            OpenJobStepParameterNames.TASK_CHUNK_SIZE, "INT", chunk_size
+        shots_per_task_param = UnrealOpenJobParameterDefinition(
+            OpenJobStepParameterNames.SHOTS_PER_TASK, "INT", shots_per_task
         )
-        job = UnrealOpenJob(file_path="", name="TestJob", extra_parameters=[chunk_size_param])
+        job = UnrealOpenJob(file_path="", name="TestJob", extra_parameters=[shots_per_task_param])
 
         render_step = RenderUnrealOpenJobStep(file_path="", mrq_job=mrq_job_mock)
         render_step.open_job = job
         # WHEN
-        ids_count = render_step._get_chunk_ids_count()
+        ids_count = render_step._get_task_count()
 
         # THEN
-        assert [i for i in range(ids_count)] == expected_chunk_ids
+        assert [i for i in range(ids_count)] == expected_task_indices
 
-    def test__get_chunk_ids_count_no_mrq_job(self):
+    def test__get_task_count_no_mrq_job(self):
         # GIVEN
         render_step = RenderUnrealOpenJobStep(file_path="")
 
         with pytest.raises(exceptions.MrqJobIsMissingError) as exception_info:
-            render_step._get_chunk_ids_count()
+            render_step._get_task_count()
 
         assert str(exception_info.value) == "MRQ Job must be provided"
 
-    def test__get_chunk_ids_count_no_open_job(self):
+    def test__get_task_count_no_open_job(self):
         # GIVEN
         shot_info = []
         for _ in range(2):
@@ -287,11 +287,11 @@ class TestRenderUnrealOpenJobStep:
         render_step = RenderUnrealOpenJobStep(file_path="", mrq_job=mrq_job_mock)
 
         with pytest.raises(exceptions.OpenJobIsMissingError) as exception_info:
-            render_step._get_chunk_ids_count()
+            render_step._get_task_count()
 
         assert str(exception_info.value) == "Render Job must be provided"
 
-    def test__get_chunk_ids_count_no_chunk_size_param(self):
+    def test__get_task_count_no_shots_per_task_param(self):
         # GIVEN
         mrq_job_mock = MagicMock()
         mrq_job_mock.shot_info = []
@@ -302,11 +302,11 @@ class TestRenderUnrealOpenJobStep:
         render_step.open_job = job
         # WHEN
         with pytest.raises(ValueError) as exception_info:
-            render_step._get_chunk_ids_count()
+            render_step._get_task_count()
 
         # THEN
         assert (
-            f'Render Job\'s parameter "{OpenJobStepParameterNames.TASK_CHUNK_SIZE}" or '
+            f'Render Job\'s parameter "{OpenJobStepParameterNames.SHOTS_PER_TASK}" or '
             f'"{OpenJobStepParameterNames.FRAMES_PER_TASK}" '
             f"must be provided" in str(exception_info.value)
         )

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step_frames_per_task.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step_frames_per_task.py
@@ -33,7 +33,7 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
             (100, 50, 1),  # More frames per task than total
         ],
     )
-    def test_get_chunk_ids_count_frames_per_task_custom_range(
+    def test_get_task_count_frames_per_task_custom_range(
         self, frames_per_task, total_frames, expected_task_count
     ):
         # GIVEN
@@ -54,7 +54,7 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
 
         with patch.object(render_step, "_load_output_settings", return_value=output_settings_mock):
             # WHEN
-            task_count = render_step._get_chunk_ids_count()
+            task_count = render_step._get_task_count()
 
             # THEN
             assert task_count == expected_task_count
@@ -68,7 +68,7 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
             (50, 10, 30, 1),  # 20 frames (30-10), 50 per task = ceil(0.4) = 1
         ],
     )
-    def test_get_chunk_ids_count_frames_per_task_sequence_range(
+    def test_get_task_count_frames_per_task_sequence_range(
         self, frames_per_task, sequence_start, sequence_end, expected_task_count
     ):
         # GIVEN
@@ -97,21 +97,23 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
         ):
 
             # WHEN
-            task_count = render_step._get_chunk_ids_count()
+            task_count = render_step._get_task_count()
 
             # THEN
             assert task_count == expected_task_count
 
-    def test_get_chunk_ids_count_frames_per_task_precedence_over_chunk_size(self):
-        # GIVEN - Both FramesPerTask and ChunkSize provided, FramesPerTask should take precedence
+    def test_get_task_count_frames_per_task_precedence_over_shots_per_task(self):
+        # GIVEN - Both FramesPerTask and ShotsPerTask provided, FramesPerTask should take precedence
         frames_per_task_param = UnrealOpenJobParameterDefinition(
             OpenJobStepParameterNames.FRAMES_PER_TASK, "INT", 25
         )
-        chunk_size_param = UnrealOpenJobParameterDefinition(
-            OpenJobStepParameterNames.TASK_CHUNK_SIZE, "INT", 5
+        shots_per_task_param = UnrealOpenJobParameterDefinition(
+            OpenJobStepParameterNames.SHOTS_PER_TASK, "INT", 5
         )
         job = UnrealOpenJob(
-            file_path="", name="TestJob", extra_parameters=[frames_per_task_param, chunk_size_param]
+            file_path="",
+            name="TestJob",
+            extra_parameters=[frames_per_task_param, shots_per_task_param],
         )
 
         mrq_job_mock = MagicMock()
@@ -126,21 +128,23 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
 
         with patch.object(render_step, "_load_output_settings", return_value=output_settings_mock):
             # WHEN
-            task_count = render_step._get_chunk_ids_count()
+            task_count = render_step._get_task_count()
 
             # THEN - Should use FramesPerTask: 99 frames / 25 per task = 4 tasks (math.ceil(3.96))
             assert task_count == 4
 
-    def test_get_chunk_ids_count_frames_per_task_fallback_to_chunk_size(self):
-        # GIVEN - FramesPerTask is 0, should fall back to ChunkSize
+    def test_get_task_count_frames_per_task_fallback_to_shots_per_task(self):
+        # GIVEN - FramesPerTask is 0, should fall back to ShotsPerTask
         frames_per_task_param = UnrealOpenJobParameterDefinition(
             OpenJobStepParameterNames.FRAMES_PER_TASK, "INT", 0
         )
-        chunk_size_param = UnrealOpenJobParameterDefinition(
-            OpenJobStepParameterNames.TASK_CHUNK_SIZE, "INT", 5
+        shots_per_task_param = UnrealOpenJobParameterDefinition(
+            OpenJobStepParameterNames.SHOTS_PER_TASK, "INT", 5
         )
         job = UnrealOpenJob(
-            file_path="", name="TestJob", extra_parameters=[frames_per_task_param, chunk_size_param]
+            file_path="",
+            name="TestJob",
+            extra_parameters=[frames_per_task_param, shots_per_task_param],
         )
 
         # Mock MRQ job with shots
@@ -157,13 +161,13 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
         render_step.open_job = job
 
         # WHEN
-        task_count = render_step._get_chunk_ids_count()
+        task_count = render_step._get_task_count()
 
-        # THEN - Should use chunk size logic: 10 shots / 5 per chunk = 2 tasks
+        # THEN - Should use shots-per-task logic: 10 shots / 5 per task = 2 tasks
         assert task_count == 2
 
-    def test_get_chunk_ids_count_frames_per_task_no_fallback_error(self):
-        # GIVEN - FramesPerTask is 0 and no ChunkSize parameter
+    def test_get_task_count_frames_per_task_no_fallback_error(self):
+        # GIVEN - FramesPerTask is 0 and no ShotsPerTask parameter
         frames_per_task_param = UnrealOpenJobParameterDefinition(
             OpenJobStepParameterNames.FRAMES_PER_TASK, "INT", 0
         )
@@ -177,7 +181,7 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
 
         # WHEN/THEN - Should raise ValueError about missing parameters
         with pytest.raises(ValueError) as exception_info:
-            render_step._get_chunk_ids_count()
+            render_step._get_task_count()
 
-        assert OpenJobStepParameterNames.TASK_CHUNK_SIZE in str(exception_info.value)
+        assert OpenJobStepParameterNames.SHOTS_PER_TASK in str(exception_info.value)
         assert OpenJobStepParameterNames.FRAMES_PER_TASK in str(exception_info.value)


### PR DESCRIPTION

refactor!: Rename ChunkSize/ChunkId render params to ShotsPerTask/TaskIndex

### What was the problem/requirement? (What/Why)

OpenJD added a native [task chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) feature with its own `ChunkSize` parameter and `CHUNK[INT]` task-parameter type. This integration has used the name `ChunkSize` for over a year for an unrelated, submitter-side concept — how many Level Sequence shots are rendered per task — along with a matching `ChunkId` for the per-task index.

The shared "Chunk" vocabulary makes it ambiguous whether these parameters relate to OpenJD's chunking. They do not: the integration's `ChunkSize`/`ChunkId` are decided at submission time by the submitter, whereas OpenJD chunking is a scheduler-level feature applied at dispatch time. The collision can become a source of confusion in template authoring.

It is also actively misleading: OpenJD's `ChunkSize` (frames grouped per chunk) is closest in meaning to this integration's existing `FramesPerTask`, **not** to the old `ChunkSize` (shots per task) — so a user mapping the names across would reach exactly the wrong conclusion.

With support for OpenJD's native chunking planned as a future mode, the name collision needs to be resolved first so the two concepts can coexist unambiguously.

### What was the solution? (How)

Rename both submitter-side parameters to say what they are and drop the colliding "Chunk" term:

- `ChunkSize` → `ShotsPerTask` — the number of shots rendered per task; mirrors the existing `FramesPerTask` parameter.
- `ChunkId` → `TaskIndex` — the 0-based index of a task within the Step's parameter space.

Functional behavior is unchanged: `ShotsPerTask` still controls how enabled shots are partitioned across tasks (`FramesPerTask` still takes precedence when both are set), and `TaskIndex` still identifies which partition a task renders.

Scope of the rename:
- OpenJD job/step templates (render, p4, ugs, mpq, and test fixtures)
- `run_data.schema.json` adaptor input contract: `chunk_size` → `shots_per_task`, `chunk_id` → `task_index`
- Submitter constants: `OpenJobStepParameterNames.TASK_CHUNK_SIZE` → `SHOTS_PER_TASK`, `TASK_CHUNK_ID` → `TASK_INDEX`
- Step-handler API and internals: `enable_shots_by_chunk` → `enable_shots_for_task`, `_get_chunk_ids_count` → `_get_task_count`, and the chunk-derived local names
- Sample submission scripts (render, p4, ugs)
- Unit tests and the create-render-job use-case docs

Also adds `docs/user_guide/render-task-partitioning.md`, documenting the two submitter-side partitioning modes this integration supports today (`ShotsPerTask` and `FramesPerTask`), how `TaskIndex` and output-file naming work, and how this differs from OpenJD's native chunking — written so the planned OpenJD chunking mode slots in as an additional, separately-documented concept.

### What is the impact of this change?

**Breaking for users who reference the old parameter names** — see the "Is this a breaking change?" section below for the full migration list. Anyone using the bundled OpenJD templates with a matching submitter needs no action; the templates are updated in place.

No functional/behavioral change to how renders are partitioned or executed. The adaptor reads the renamed `run_data` fields; the submitter writes them. As long as the submitter and adaptor are upgraded together (they are versioned and released together), submission and rendering behave exactly as before.

### How was this change tested?

- **Unit tests:** `467 passed, 2 skipped` via `pytest test/ --cov-config pyproject.toml --ignore=test/end_to_end --ignore=test/integ`. The submitter and adaptor tests covering shot-based and frame-based partitioning were updated to the new names and pass.
- **Lint / format / types:** `ruff check`, `black --check`, and `mypy src test` are all clean.
- **Grep audit:** confirmed no `ChunkSize`/`chunk_size`/`ChunkId`/`chunk_id`/`TASK_CHUNK_*` identifiers remain in source, templates, schema, or tests after the rename.

### Have you run a render job successfully with these changes?

Not as part of this PR. The change is a mechanical parameter rename with no behavioral change to the render path; the existing unit tests exercise both partitioning modes' task-count and frame-window logic. Recommend a reviewer with access to a dev fleet run a render with both a `ShotsPerTask` and a `FramesPerTask` job to confirm end-to-end before merge.

### Was this change documented?

Yes:
- Updated the create-render-job use-case docs (`docs/source/docs_usage/use_cases/create_render_job.rst`) and the Perforce render-job guide to the new parameter names.
- Updated all relevant docstrings (`OpenJobStepParameterNames`, `_get_task_count`, `enable_shots_for_task`, `_apply_task_index_to_filename`).
- Updated the adaptor `run_data.schema.json` field names.
- Added `docs/user_guide/render-task-partitioning.md` (linked from the user-guide index) documenting the two partitioning modes and their relationship to OpenJD chunking.

### Is this a breaking change?

**Yes.** The OpenJD job-template parameters `ChunkSize` and `ChunkId` are renamed to `ShotsPerTask` and `TaskIndex`, and the matching adaptor `run_data` fields `chunk_size`/`chunk_id` to `shots_per_task`/`task_index`. There is no compatibility shim.

Users must update the following if they reference the old names:

1. **Saved Render Job / Render Step Data Assets** (`.uasset`) where `ChunkSize` was configured — remove the `ChunkSize` override and add `ShotsPerTask` with the same value. (`TaskIndex` is filled automatically at submission and needs no manual migration.)
2. **Custom OpenJD templates** — rename `ChunkSize` → `ShotsPerTask` and `ChunkId` → `TaskIndex` in `parameterDefinitions`/`parameterSpace`, update `{{Param.ChunkSize}}` / `{{Task.Param.ChunkId}}` references, and update the adaptor-read keys in the `data:` block (`chunk_size:` → `shots_per_task:`, `chunk_id:` → `task_index:`).
3. **Python submission scripts** — replace `UnrealOpenJobStepParameterDefinition("ChunkSize", "INT", [N])` with `... "ShotsPerTask" ...`, and the `OpenJobStepParameterNames.TASK_CHUNK_SIZE`/`TASK_CHUNK_ID` constants with `SHOTS_PER_TASK`/`TASK_INDEX`.
4. **Old job bundles / queue manifests on disk** — re-submit through the new submitter to regenerate them with the new field names; the new adaptor rejects `chunk_size`/`chunk_id` in `run_data`.

The submitter and adaptor are versioned and released together; mixing an old submitter with a new adaptor (or vice versa) across this boundary is unsupported. The commit follows the conventional-commits breaking-change format (`refactor!:` with a `BREAKING CHANGE:` footer) so the generated CHANGELOG surfaces it.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

---
