### PR TITLE
chore: drop psutil dependency from build_plugin.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "openjd-adaptor-runtime >= 0.9.4,< 0.10",
     "openjd-model >= 0.9.0, < 0.10",
     "p4python == 2025.1.2767466",
-    "psutil >= 5.9.0"
 ]
 
 [project.urls]

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -7,3 +7,4 @@ mypy == 1.*
 black == 25.*
 ruff == 0.14.*
 types-pyyaml == 6.*
+psutil >= 5.9.0

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -7,4 +7,3 @@ mypy == 1.*
 black == 25.*
 ruff == 0.14.*
 types-pyyaml == 6.*
-psutil >= 5.9.0

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -7,13 +7,13 @@
 # Assumes you're running from the root of your plugin source directory
 
 import argparse
+import csv
 import logging
 import shutil
 import os
 import subprocess
 import sys
 import tempfile
-import psutil
 from typing import Tuple, Optional
 
 DEFAULT_UE_INSTALL_ROOT = "C:\\Program Files\\Epic Games"
@@ -431,16 +431,29 @@ def check_running_unreal_processes():
     Returns:
         bool: True if any Unreal processes are running, False otherwise
     """
+    if sys.platform != "win32":
+        return False
+
+    target_names = {"unrealeditor.exe", "unrealeditor-cmd.exe"}
     unreal_processes = []
-    for proc in psutil.process_iter(["pid", "name"]):
-        try:
-            if proc.info["name"] and (
-                proc.info["name"].lower() == "unrealeditor.exe"
-                or proc.info["name"].lower() == "unrealeditor-cmd.exe"
-            ):
-                unreal_processes.append(proc.info)
-        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
-            pass
+    try:
+        # tasklist /FO CSV /NH outputs: "Image Name","PID","Session Name","Session#","Mem Usage"
+        result = subprocess.run(
+            ["tasklist", "/FO", "CSV", "/NH"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError) as e:
+        logger.warning(f"Could not check for running Unreal processes: {e}")
+        return False
+
+    for row in csv.reader(result.stdout.splitlines()):
+        if len(row) < 2:
+            continue
+        name, pid = row[0], row[1]
+        if name.lower() in target_names:
+            unreal_processes.append({"name": name, "pid": pid})
 
     if unreal_processes:
         logger.warning(


### PR DESCRIPTION
Fixes: *N/A*

### What was the problem/requirement? (What/Why)

`scripts/build_plugin.py` pulled in `psutil` solely to detect running `UnrealEditor.exe` / `UnrealEditor-cmd.exe` processes before a build. That meant a third-party runtime/build dependency for what amounts to one process-listing call on a Windows-only script. Reducing the dependency surface for plugin builders is worth a few extra lines of stdlib code.

### What was the solution? (How)

- Replaced `psutil.process_iter(["pid", "name"])` with a `subprocess.run(["tasklist", "/FO", "CSV", "/NH"])` call parsed via stdlib `csv.reader`.
- Added a `sys.platform != "win32"` early-return to match the platform-guard pattern already used in `unreal_python_has_deadline_installed` and `long_paths_enabled`.
- Wrapped the `tasklist` call in a try/except for `FileNotFoundError` / `CalledProcessError` so an unexpected failure logs a warning instead of crashing the build.
- Removed `psutil >= 5.9.0` from `pyproject.toml` and `requirements-testing.txt`.

### What is the impact of this change?

- One fewer transitive dependency installed when building or testing this package.
- No user-facing behavior change: same warning text, same return contract (`True` if any matching process found, `False` otherwise), same case-insensitive name match.
- PID values in the warning log are now strings rather than ints (cosmetically identical in the f-string output).

### How was this change tested?

- Confirmed `tasklist /FO CSV /NH` output format matches the parser (`"Image Name","PID","Session Name","Session#","Mem Usage"`).
- Smoke-tested the new `check_running_unreal_processes()` from a Python REPL with no Unreal running: returned `False` as expected.
- Have run with `UnrealEditor.exe` actively running, saw expected error
- Have not run the unit tests on this change (the touched code is in `scripts/`, outside the `src/deadline` test coverage).

### Have you run a render job successfully with these changes?

No — this change only touches the plugin build helper script (`scripts/build_plugin.py`), which is unrelated to the render/job runtime path.

### Was this change documented?

No documentation updates required. The function's docstring is unchanged; no public Python interface, schema, or user-facing doc is affected.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*