### PR TITLE
fix: surface hatch build stderr on failure

### DIFF
--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -89,8 +89,11 @@ def build_whl() -> str:
         )
         subprocess.run(["hatch", "--version"], check=True, stderr=subprocess.PIPE)
 
-    result = subprocess.run(["hatch", "build"], check=True, stderr=subprocess.PIPE)
-    lines = result.stderr.decode("utf-8").splitlines()
+    result = subprocess.run(["hatch", "build"], stderr=subprocess.PIPE, text=True)
+    if result.returncode != 0:
+        logger.error(f"hatch build failed with stderr:\n{result.stderr}")
+        raise Exception(f"hatch build failed: {result.stderr}")
+    lines = result.stderr.splitlines()
     whl_path = None
     # Go through lines, finding the first which ends in .whl
     for line in lines:


### PR DESCRIPTION
Fixes: *N/A*

### What was the problem/requirement? (What/Why)

When `hatch build` fails inside `build_whl()` in `scripts/build_plugin.py`, the user only saw a generic `Failed to retrieve .whl file from hatch build` exception with no diagnostic output. The actual stderr from hatch was captured (via `stderr=subprocess.PIPE`) but never surfaced, because `check=True` raised `CalledProcessError` immediately and the subsequent code only ran on success. This made post-merge build failures very hard to debug.

### What was the solution? (How)

In `build_whl()`:

- Drop `check=True` and instead inspect `result.returncode` explicitly.
- On non-zero return, log the full stderr at `ERROR` and raise an `Exception` whose message includes the stderr text.
- Switch the call to `text=True` so stderr is returned as a `str`, eliminating the now-redundant `.decode("utf-8")`.

The success path is unchanged — same stderr-line scan for the `.whl` path.

### What is the impact of this change?

- Failing plugin builds now surface the real hatch error to the operator (logged at ERROR and embedded in the raised exception message).
- No behavior change on the success path.
- Successful logs still show `Build result: 0, whl_path is ...` exactly as before.

### How was this change tested?

- Verified the diff is minimal and the success path is identical to the prior implementation (same stderr-line scan, same `whl_path` resolution).
- Have not yet reproduced a failing `hatch build` locally to observe the new error output end-to-end.
- Have not run the unit test suite on this change (the touched code is in `scripts/`, outside the `src/deadline` test coverage).

### Have you run a render job successfully with these changes?

No — this change only touches the plugin build helper script (`scripts/build_plugin.py`), which is unrelated to the render/job runtime path.

### Was this change documented?

No documentation updates required. The function's behavior on success is unchanged; no public Python interface, schema, or user-facing doc is affected.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*