### PR TITLE
fix: run hatch build outside parent hatch env

### DIFF
--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -94,9 +94,7 @@ def build_whl() -> str:
     # marker so `hatch build` runs in the default builder context.
     build_env = os.environ.copy()
     build_env.pop("HATCH_ENV_ACTIVE", None)
-    result = subprocess.run(
-        ["hatch", "build"], stderr=subprocess.PIPE, text=True, env=build_env
-    )
+    result = subprocess.run(["hatch", "build"], stderr=subprocess.PIPE, text=True, env=build_env)
     if result.returncode != 0:
         logger.error(f"hatch build failed with stderr:\n{result.stderr}")
         raise Exception(f"hatch build failed: {result.stderr}")

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -89,7 +89,14 @@ def build_whl() -> str:
         )
         subprocess.run(["hatch", "--version"], check=True, stderr=subprocess.PIPE)
 
-    result = subprocess.run(["hatch", "build"], stderr=subprocess.PIPE, text=True)
+    # When invoked from inside a hatch-managed env (e.g. the integ-ci env in CI),
+    # hatch refuses to build because the active env isn't a builder env. Strip the
+    # marker so `hatch build` runs in the default builder context.
+    build_env = os.environ.copy()
+    build_env.pop("HATCH_ENV_ACTIVE", None)
+    result = subprocess.run(
+        ["hatch", "build"], stderr=subprocess.PIPE, text=True, env=build_env
+    )
     if result.returncode != 0:
         logger.error(f"hatch build failed with stderr:\n{result.stderr}")
         raise Exception(f"hatch build failed: {result.stderr}")


### PR DESCRIPTION
Fixes: *N/A*

### What was the problem/requirement? (What/Why)

When `build_plugin.py` is invoked from inside a hatch-managed environment — for example, the `integ-ci` env used by CI — the inner `hatch build` call fails with `Environment 'integ-ci.py3.11-5.7' is not a builder environment`. Hatch refuses to build because the active env (`integ-ci`) is configured for testing, not for building artifacts. This blocked the integ-ci pipeline after recent changes started exercising this path.

### What was the solution? (How)

In `build_whl()`, copy the current process environment and pop `HATCH_ENV_ACTIVE` before passing it to the `hatch build` subprocess. That marker is what hatch uses to detect "we're already inside a managed env"; removing it lets `hatch build` run in the default builder context, which is the only context in which it is allowed to produce a wheel.

Added a brief comment explaining the workaround so a future reader doesn't delete it during cleanup.

### What is the impact of this change?

- `python scripts/build_plugin.py` now works whether invoked from a plain shell or from inside another hatch env (such as `integ-ci`).
- No change to the success path of the build itself: the `hatch build` invocation, stderr capture, error logging, and `.whl` path resolution are unchanged.
- No change to local-developer workflows that invoke the script outside any hatch env (`HATCH_ENV_ACTIVE` is unset there, so the `pop` is a no-op).

### How was this change tested?

- Confirmed the diff is minimal and the success path is byte-for-byte identical apart from the explicit `env=` parameter.
- Have not yet re-run the integ-ci pipeline end-to-end to observe the fix in CI.
- Have not run the unit test suite on this change (the touched code is in `scripts/`, outside the `src/deadline` test coverage).

### Have you run a render job successfully with these changes?

No — this change only touches the plugin build helper script (`scripts/build_plugin.py`), which is unrelated to the render/job runtime path.

### Was this change documented?

The workaround is documented as a comment at the call site explaining why `HATCH_ENV_ACTIVE` must be stripped. No other documentation changes are required: no public Python interface, schema, or user-facing doc is affected.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*