### PR TITLE
fix: P4 workspace root change detection and dependency sync optimization

### DIFF
--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -334,6 +334,25 @@ def build_plugin(runuat_path: str, plugin_input_folder: str, output_folder: str)
         raise Exception(f"Build failed {result.returncode}")
 
 
+def _warn_if_deadline_worker_service_running():
+    """Warn the user if the DeadlineWorker service is running and needs a restart."""
+    if sys.platform != "win32":
+        return
+    try:
+        result = subprocess.run(
+            ["sc", "query", "DeadlineWorker"],
+            capture_output=True,
+            text=True,
+        )
+        if "RUNNING" in result.stdout:
+            logger.warning(
+                "The DeadlineWorker service is currently running. "
+                "Restart it to pick up the new code: Restart-Service DeadlineWorker"
+            )
+    except Exception:
+        pass
+
+
 def install_worker_dependencies(engine_root: str):
     """
     Installs the dependencies required for the worker plugin to function
@@ -551,6 +570,7 @@ def build_and_install(
     if worker:
         install_whl_global(whl_path)
         install_worker_dependencies(engine_root)
+        _warn_if_deadline_worker_service_running()
 
     if test:
         install_test_content(get_plugin_folder(engine_root))

--- a/src/deadline/unreal_perforce_utils/app.py
+++ b/src/deadline/unreal_perforce_utils/app.py
@@ -92,6 +92,16 @@ class WorkspaceInfoFile:
         self.view_workspace = workspace_name
 
 
+def _normalize_root(root: str) -> str:
+    """
+    Normalize a workspace Root path for comparison: forward slashes, no trailing
+    separator, casefolded (P4 stores Windows paths case-insensitively).
+    """
+    if not root:
+        return ""
+    return root.replace("\\", "/").rstrip("/").casefold()
+
+
 def merge_view_mappings(existing_views: list[str], new_views: list[str]) -> list[str]:
     """
     Merge new view mappings into existing ones.
@@ -272,14 +282,44 @@ def create_perforce_workspace_from_template(
 
     connection = perforce.PerforceConnection()
 
-    if reusing and "View" in specification_template:
-        # Stream workspaces: no view merge needed — P4 derives the view from the stream definition.
-        # View workspaces: merge with existing spec to preserve mappings from prior jobs.
+    # Always fetch the existing server-side spec when using a persistent root.
+    # The workspace may already exist on the server even if the local registry
+    # (workspace_info.json) doesn't know about it (e.g. created by an older
+    # version of the code before the registry was introduced).
+    if persistent_root or reusing:
         existing_spec = connection.p4.fetch_client(workspace_name)
-        existing_views = existing_spec.get("View", [])
-        new_views = specification_template["View"]
-        merged_views = merge_view_mappings(existing_views, new_views)
-        specification_template["View"] = merged_views
+
+        # If Root changed since the workspace was last used, the server's have-list
+        # still describes files at the old root. A subsequent `p4 sync` would then
+        # report "file(s) up-to-date" and write nothing to the new root, leaving
+        # the renderer to fail loading assets that aren't actually on disk.
+        # Clear the have-list so the next sync transfers files to the new root.
+        existing_root = _normalize_root(existing_spec.get("Root", ""))
+        new_root = _normalize_root(specification_template.get("Root", ""))
+        if existing_root and new_root and existing_root != new_root:
+            logger.info(
+                f"Workspace '{workspace_name}' Root changed "
+                f"({existing_spec.get('Root')} -> {specification_template.get('Root')}); "
+                f"clearing have-list so subsequent sync transfers files to the new root."
+            )
+            try:
+                connection.p4.client = workspace_name
+                connection.p4.run("sync", "-k", "//...#none")
+            except Exception as e:
+                # Don't fail workspace creation — a force-sync downstream can still
+                # recover. Log loudly so operators can correlate later sync issues.
+                logger.error(
+                    f"Failed to clear have-list for workspace '{workspace_name}' "
+                    f"after Root change: {e}"
+                )
+
+        if reusing and "View" in specification_template:
+            # Stream workspaces: no view merge needed — P4 derives the view from the stream definition.
+            # View workspaces: merge with existing spec to preserve mappings from prior jobs.
+            existing_views = existing_spec.get("View", [])
+            new_views = specification_template["View"]
+            merged_views = merge_view_mappings(existing_views, new_views)
+            specification_template["View"] = merged_views
 
     perforce_client = perforce.PerforceClient(
         connection=connection,
@@ -349,26 +389,35 @@ def initial_workspace_sync(
     logger.info("Workspace initial synchronizing ...")
 
     workspace_root = workspace.spec["Root"].replace("\\", "/")
-    paths_to_sync = [f"{workspace_root}/{unreal_project_relative_path}"]
+    skeleton_paths = [f"{workspace_root}/{unreal_project_relative_path}"]
     unreal_project_directory = os.path.dirname(unreal_project_relative_path)
     for folder in ["Binaries", "Config", "Plugins"]:
         tokens = filter(
             lambda t: t not in [None, ""], [workspace_root, unreal_project_directory, folder, "..."]
         )
-        paths_to_sync.append("/".join(tokens))
+        skeleton_paths.append("/".join(tokens))
 
-    # Add job dependencies if provided
-    if job_dependencies_descriptor_path and os.path.exists(job_dependencies_descriptor_path):
-        dependency_paths = _parse_job_dependencies(workspace, job_dependencies_descriptor_path)
-        paths_to_sync.extend(dependency_paths)
-
-    logger.info(f"Paths to sync: {paths_to_sync}")
-
-    for path in paths_to_sync:
+    # Sync skeleton files with force to ensure they're always correct
+    logger.info(f"Paths to sync: {skeleton_paths}")
+    for path in skeleton_paths:
         try:
             workspace.sync(path, changelist=changelist, force=True)
         except Exception as e:
             logger.error(f"Initial workspace sync exception: {str(e)}")
+
+    # Sync job dependencies without force — P4's have-list will skip files
+    # already at the correct revision, making reuse near-instant.
+    if job_dependencies_descriptor_path and os.path.exists(job_dependencies_descriptor_path):
+        dependency_paths = _parse_job_dependencies(workspace, job_dependencies_descriptor_path)
+        logger.info(f"Dependency paths to sync: {dependency_paths}")
+        for path in dependency_paths:
+            try:
+                workspace.sync(path, changelist=changelist, force=False)
+            except Exception as e:
+                logger.error(f"Dependency sync exception: {str(e)}")
+
+    if job_dependencies_descriptor_path and os.path.exists(job_dependencies_descriptor_path):
+        logger.info("openjd_env: DEPENDENCIES_SYNCED=true")
 
 
 def configure_project_source_control_settings(

--- a/src/deadline/unreal_perforce_utils/perforce.py
+++ b/src/deadline/unreal_perforce_utils/perforce.py
@@ -164,7 +164,11 @@ class PerforceClient:
         logger.info(f"Running P4 sync with following arguments: {sync_args}")
 
         try:
-            self.p4.run(sync_args)
+            results = self.p4.run(sync_args)
+            if results:
+                logger.info(f"Sync results: {results}")
+            else:
+                logger.info("Sync: file(s) up-to-date")
         except Exception as e:
             logger.error(f"Error during p4 sync: {str(e)}")
 

--- a/src/unreal_plugin/Content/Python/init_unreal.py
+++ b/src/unreal_plugin/Content/Python/init_unreal.py
@@ -32,7 +32,10 @@ def get_ue_path(in_path: str) -> Optional[str]:
 def sync_mrq_dependencies(dependencies_descriptor_path: str) -> None:
     """
     Read given dependencies descriptor, try to sync them with unreal source control and
-    scan modified assets
+    scan modified assets.
+
+    If DEPENDENCIES_SYNCED env var is set, the P4 sync environment already synced
+    these files — skip the redundant sync and just scan the asset registry.
 
     :param dependencies_descriptor_path: Path to the dependencies JSON descriptor file
     :type dependencies_descriptor_path: str
@@ -52,13 +55,16 @@ def sync_mrq_dependencies(dependencies_descriptor_path: str) -> None:
         unreal.log_error(f"Job dependencies list is empty: {dependencies_descriptor_path}")
         return
 
-    synced = unreal.SourceControl.sync_files(job_dependencies)
-    if not synced:
-        unreal.log_error(
-            f"Failed to sync job dependencies: {dependencies_descriptor_path}. "
-            f"Sync error message: {unreal.SourceControl.last_error_msg()}"
-        )
-        return
+    if os.getenv("DEPENDENCIES_SYNCED") != "true":
+        synced = unreal.SourceControl.sync_files(job_dependencies)
+        if not synced:
+            unreal.log_error(
+                f"Failed to sync job dependencies: {dependencies_descriptor_path}. "
+                f"Sync error message: {unreal.SourceControl.last_error_msg()}"
+            )
+            return
+    else:
+        unreal.log("Skipping P4 sync — dependencies already synced by P4 sync environment.")
 
     ue_paths = []
     for job_dependency in job_dependencies:

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_sync_cmf_environment.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_sync_cmf_environment.yml
@@ -16,6 +16,8 @@ script:
       - '{{Param.PerforceWorkspaceSpecificationTemplate}}'
       - -PerforceChangelistNumber
       - '{{Param.PerforceChangelistNumber}}'
+      - -MrqJobDependenciesDescriptor
+      - '{{Param.MrqJobDependenciesDescriptor}}'
       cancelation:
         mode: NOTIFY_THEN_TERMINATE
     onExit:

--- a/test/deadline_perforce_utils_for_unreal/test_app.py
+++ b/test/deadline_perforce_utils_for_unreal/test_app.py
@@ -264,3 +264,253 @@ class TestUnrealP4UtilsApp:
 
         finally:
             os.unlink(job_deps_path)
+
+    @pytest.mark.parametrize(
+        "existing_root, new_root, expect_flush",
+        [
+            # Root changed (the customer's bug): server have-list points at the old
+            # root, files don't exist at the new root, sync would no-op.
+            ("E:/Perforce/ws", "C:/Perforce/ws", True),
+            # Root changed only by drive letter, slashes, and trailing slash —
+            # still a real move, must flush.
+            ("E:\\Perforce\\ws", "C:/Perforce/ws/", True),
+            # Same root with cosmetic differences (slashes, casing on Windows,
+            # trailing slash) — must NOT flush, or every reuse pays the full
+            # re-sync cost.
+            ("C:/Perforce/ws", "c:\\Perforce\\ws", False),
+            ("C:/Perforce/ws/", "C:/Perforce/ws", False),
+            # Existing client has no Root yet (newly fetched, fresh client) — don't
+            # flush, there's nothing to be stale.
+            ("", "C:/Perforce/ws", False),
+        ],
+    )
+    @patch("deadline.unreal_perforce_utils.app.perforce.PerforceClient")
+    @patch("deadline.unreal_perforce_utils.app.perforce.PerforceConnection")
+    @patch("deadline.unreal_perforce_utils.app._resolve_workspace_name")
+    def test_create_workspace_flushes_have_list_when_root_changes(
+        self,
+        resolve_mock: Mock,
+        connection_cls_mock: Mock,
+        client_cls_mock: Mock,
+        existing_root: str,
+        new_root: str,
+        expect_flush: bool,
+    ):
+        # GIVEN a reused workspace whose server-side Root may or may not match the new Root
+        resolve_mock.return_value = app._ResolvedWorkspace(name="ws-1", reusing=True)
+
+        connection = connection_cls_mock.return_value
+        connection.p4.fetch_client.return_value = {
+            "Root": existing_root,
+            "View": ["//depot/A/... //ws-1/A/..."],
+        }
+
+        template = {
+            "Client": "{workspace_name}",
+            "Root": new_root,
+            "View": ["//depot/A/... //{workspace_name}/A/..."],
+        }
+
+        # WHEN create_perforce_workspace_from_template runs with overridden_workspace_root
+        # so we control the new Root precisely (bypasses P4_CLIENTS_ROOT_DIRECTORY env).
+        with patch.dict(os.environ, {}, clear=True):
+            app.create_perforce_workspace_from_template(
+                specification_template=template,
+                project_name="Project",
+                overridden_workspace_root=new_root,
+            )
+
+        # THEN the have-list is flushed iff the Root actually changed
+        sync_calls = [c for c in connection.p4.run.call_args_list if c.args and c.args[0] == "sync"]
+        if expect_flush:
+            assert (
+                len(sync_calls) == 1
+            ), f"expected exactly one `p4 sync` flush call, got {sync_calls}"
+            assert sync_calls[0].args == ("sync", "-k", "//...#none")
+            assert (
+                connection.p4.client == "ws-1"
+            ), "must set p4.client before flushing so flush targets the right workspace"
+        else:
+            assert sync_calls == [], f"must not flush when Root is unchanged, got {sync_calls}"
+
+    @patch("deadline.unreal_perforce_utils.app.perforce.PerforceClient")
+    @patch("deadline.unreal_perforce_utils.app.perforce.PerforceConnection")
+    @patch("deadline.unreal_perforce_utils.app._resolve_workspace_name")
+    def test_create_workspace_continues_when_flush_fails(
+        self,
+        resolve_mock: Mock,
+        connection_cls_mock: Mock,
+        client_cls_mock: Mock,
+    ):
+        # GIVEN a reused workspace with a Root change, where the flush command errors
+        resolve_mock.return_value = app._ResolvedWorkspace(name="ws-1", reusing=True)
+
+        connection = connection_cls_mock.return_value
+        connection.p4.fetch_client.return_value = {"Root": "E:/old", "View": []}
+        connection.p4.run.side_effect = RuntimeError("p4 sync failed")
+
+        template = {
+            "Client": "{workspace_name}",
+            "Root": "C:/new",
+            "View": ["//depot/A/... //{workspace_name}/A/..."],
+        }
+
+        # WHEN
+        with patch.dict(os.environ, {}, clear=True):
+            result = app.create_perforce_workspace_from_template(
+                specification_template=template,
+                project_name="Project",
+                overridden_workspace_root="C:/new",
+            )
+
+        # THEN workspace creation still completes (don't fail the whole job over
+        # a flush hiccup — a downstream force-sync can still recover).
+        assert result is client_cls_mock.return_value
+        client_cls_mock.return_value.save.assert_called_once()  # type: ignore[attr-defined]
+
+    @patch("deadline.unreal_perforce_utils.app.perforce.PerforceClient")
+    @patch("deadline.unreal_perforce_utils.app.perforce.PerforceConnection")
+    @patch("deadline.unreal_perforce_utils.app._resolve_workspace_name")
+    def test_create_workspace_flushes_when_not_reusing_but_server_root_differs(
+        self,
+        resolve_mock: Mock,
+        connection_cls_mock: Mock,
+        client_cls_mock: Mock,
+    ):
+        # GIVEN a workspace that is NOT in the local registry (reusing=False) but
+        # already exists on the P4 server with a different Root (e.g. created by
+        # an older version before the registry was introduced).
+        resolve_mock.return_value = app._ResolvedWorkspace(name="ws-1", reusing=False)
+
+        connection = connection_cls_mock.return_value
+        connection.p4.fetch_client.return_value = {
+            "Root": "C:/Users/Administrator/Perforce/old_client",
+            "View": ["//depot/... //ws-1/..."],
+        }
+
+        template = {
+            "Client": "{workspace_name}",
+            "Root": "C:/P4projects2/ws-1",
+            "View": ["//depot/... //{workspace_name}/..."],
+        }
+
+        # WHEN P4_CLIENTS_ROOT_DIRECTORY is set (persistent workspace mode)
+        with patch.dict(os.environ, {"P4_CLIENTS_ROOT_DIRECTORY": "C:/P4projects2"}, clear=True):
+            app.create_perforce_workspace_from_template(
+                specification_template=template,
+                project_name="Project",
+                overridden_workspace_root="C:/P4projects2/ws-1",
+            )
+
+        # THEN the have-list is flushed even though reusing=False, because the
+        # server-side workspace has a different Root.
+        sync_calls = [c for c in connection.p4.run.call_args_list if c.args and c.args[0] == "sync"]
+        assert len(sync_calls) == 1
+        assert sync_calls[0].args == ("sync", "-k", "//...#none")
+
+    @patch("deadline.unreal_perforce_utils.app.perforce.PerforceClient")
+    @patch("deadline.unreal_perforce_utils.app.perforce.PerforceConnection")
+    @patch("deadline.unreal_perforce_utils.app._resolve_workspace_name")
+    def test_initial_workspace_sync_uses_force_for_skeleton_not_for_dependencies(
+        self,
+        resolve_mock: Mock,
+        connection_cls_mock: Mock,
+        client_cls_mock: Mock,
+        tmp_path,
+    ):
+        # GIVEN a workspace with a job dependencies descriptor
+        resolve_mock.return_value = app._ResolvedWorkspace(name="ws-1", reusing=False)
+
+        connection = connection_cls_mock.return_value
+        connection.p4.fetch_client.return_value = {"Root": "", "View": []}
+
+        workspace_mock = client_cls_mock.return_value
+        workspace_mock.spec = {"Root": "C:/P4root/ws-1"}
+        workspace_mock.where.side_effect = lambda dp: f"C:/P4root/ws-1/{dp.split('//depot/')[-1]}"
+
+        deps_file = tmp_path / "deps.json"
+        deps_file.write_text(
+            json.dumps(
+                {
+                    "job_dependencies": [
+                        "//depot/Project/Content/file1.uasset",
+                        "//depot/Project/Content/file2.uasset",
+                    ]
+                }
+            )
+        )
+
+        template = {
+            "Client": "{workspace_name}",
+            "Root": "C:/P4root/ws-1",
+            "View": ["//depot/... //{workspace_name}/..."],
+        }
+
+        # WHEN
+        with patch.dict(os.environ, {"P4_CLIENTS_ROOT_DIRECTORY": "C:/P4root"}, clear=True):
+            app.create_perforce_workspace_from_template(
+                specification_template=template,
+                project_name="Project",
+                overridden_workspace_root="C:/P4root/ws-1",
+            )
+
+        # Manually call initial_workspace_sync since create_perforce_workspace_from_template
+        # is tested via create_workspace which we can't easily call without full P4 setup
+        app.initial_workspace_sync(
+            workspace=workspace_mock,
+            unreal_project_relative_path="Project/Project.uproject",
+            changelist="3",
+            job_dependencies_descriptor_path=str(deps_file),
+        )
+
+        # THEN skeleton files synced with force=True, deps with force=False
+        sync_calls = workspace_mock.sync.call_args_list
+        skeleton_calls = [c for c in sync_calls if c.kwargs.get("force") is True]
+        dep_calls = [c for c in sync_calls if c.kwargs.get("force") is False]
+
+        assert len(skeleton_calls) == 4  # uproject, Binaries, Config, Plugins
+        assert len(dep_calls) == 2  # file1.uasset, file2.uasset
+
+    def test_initial_workspace_sync_emits_dependencies_synced(self, tmp_path, caplog):
+        # GIVEN a workspace and a valid dependencies descriptor
+        workspace_mock = MagicMock()
+        workspace_mock.spec = {"Root": "C:/P4root/ws-1"}
+        workspace_mock.where.side_effect = lambda dp: f"C:/P4root/ws-1/{dp.split('//depot/')[-1]}"
+
+        deps_file = tmp_path / "deps.json"
+        deps_file.write_text(
+            json.dumps(
+                {
+                    "job_dependencies": [
+                        "//depot/Project/Content/file1.uasset",
+                    ]
+                }
+            )
+        )
+
+        # WHEN
+        app.initial_workspace_sync(
+            workspace=workspace_mock,
+            unreal_project_relative_path="Project/Project.uproject",
+            changelist="3",
+            job_dependencies_descriptor_path=str(deps_file),
+        )
+
+        # THEN DEPENDENCIES_SYNCED is emitted
+        assert "openjd_env: DEPENDENCIES_SYNCED=true" in caplog.text
+
+    def test_initial_workspace_sync_no_signal_without_deps(self, tmp_path, caplog):
+        # GIVEN a workspace with no dependencies descriptor
+        workspace_mock = MagicMock()
+        workspace_mock.spec = {"Root": "C:/P4root/ws-1"}
+
+        # WHEN
+        app.initial_workspace_sync(
+            workspace=workspace_mock,
+            unreal_project_relative_path="Project/Project.uproject",
+            changelist="3",
+            job_dependencies_descriptor_path=None,
+        )
+
+        # THEN DEPENDENCIES_SYNCED is NOT emitted
+        assert "DEPENDENCIES_SYNCED" not in caplog.text

--- a/test/deadline_perforce_utils_for_unreal/test_perforce.py
+++ b/test/deadline_perforce_utils_for_unreal/test_perforce.py
@@ -147,7 +147,7 @@ class TestPerforceClient:
         client.sync(filepath, changelist, force)
 
         # THEN
-        logger_mock.info.assert_called_once_with(
+        logger_mock.info.assert_any_call(
             f"Running P4 sync with following arguments: {expected_arguments}"
         )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Two performance and correctness issues with Perforce workspace syncing on render workers:

1. **Stale have-list when workspace Root changes** — When using persistent Perforce workspaces (`P4_CLIENTS_ROOT_DIRECTORY`), if the workspace Root changes between jobs (e.g. persistent volume recycled, directory moved), the P4 server's have-list still describes files at the old root. A subsequent `p4 sync` reports "file(s) up-to-date" and writes nothing to the new root, causing UE to fail loading assets.

2. **Redundant dependency sync on every job** — UE's `init_unreal.py` calls `SourceControl.sync_files()` with every job dependency individually on every launch. Even when all files are already at the correct revision, the P4 server round-trip takes significant time (scales with project size). On CMF, the sync environment template was not syncing dependencies at all (oversight — SMF already had it), so this was the only sync path. On reused workers, this was pure waste.

### What was the solution? (How)

**Root change detection:**
- When `P4_CLIENTS_ROOT_DIRECTORY` is set, fetch the server-side workspace spec and compare Root to the new Root
- If they differ, run `p4 sync -k //...#none` to clear the stale have-list before saving the updated spec
- The subsequent sync then transfers files normally to the new root

**Dependency sync optimization:**
- Add `-MrqJobDependenciesDescriptor` to the CMF sync template (SMF already had it)
- Sync dependencies **without** `-f` (force) — P4's have-list skips files already at the correct revision, making reuse near-instant
- Emit `openjd_env: DEPENDENCIES_SYNCED=true` after successful dependency sync
- In `init_unreal.py`, skip the redundant `sync_files` call when `DEPENDENCIES_SYNCED` is set; still perform the asset registry scan so UE discovers the files

**Developer experience:**
- Log P4 sync results to clearly show which files were transferred vs skipped
- Warn when DeadlineWorker service needs restart after `--worker` install

### What is the impact of this change?

- **Reused workspace, same changelist:** Eliminates redundant per-file P4 server round-trip during UE launch. The time saved depends on P4 server latency and dependency count — in our testing with MeerkatDemo (~250 assets), this eliminated ~30s of overhead per job.
- **Reused workspace, new changelist:** Only changed files transfer; others skip instantly
- **Root change:** Files correctly arrive at the new root (was broken without the flush)
- **First run / new root:** Full sync happens once in P4SyncCmf, UE skips redundant re-check
- Applies equally to CMF and SMF

### How was this change tested?

- Unit tests for root-change detection (with/without registry), non-force dep sync, and DEPENDENCIES_SYNCED signal emission
- Manual E2E testing on Prodmon Windows CMF queue:
  - Root change with no local registry — flush fired, files synced correctly
  - Reuse with same changelist — all files "up-to-date" in ~2s, UE skipped sync
  - New changelist — only modified file (`Main_LVL.umap`) transferred, rest skipped
  - Fresh root — full sync in P4SyncCmf (~19s), UE skip confirmed
  - Backward compat — jobs using old template (without `-MrqJobDependenciesDescriptor`) fall through to UE's original sync

### Have you run a render job successfully with these changes?

Yes — multiple successful render jobs on Prodmon Windows CMF queue across all scenarios above.

### Was this change documented?

- Docstrings/comments updated for modified functions
- Log messages added for P4 sync visibility
- Template change is self-documenting (matches existing SMF template pattern)

### Is this a breaking change?

No. Existing jobs without `-MrqJobDependenciesDescriptor` in the template fall through to UE's original `sync_files` behavior. Users must recreate/reset the P4SyncCmf data asset to pick up the new CMF template.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*