### PR TITLE
feat: Add deadline-cloud-v2 as default Conda channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Jobs created by the submitter use this adaptor by default. The Unreal Engine Ada
 
 ### Service Managed Fleets (SMF)
 
-On [Service Managed Fleets (SMF)](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/smf-manage.html) worker hosts, the Unreal Engine and adaptor are automatically available via the `deadline-cloud Conda` channel with the [default Queue Environment](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html#conda-queue-environment).
+On [Service Managed Fleets (SMF)](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/smf-manage.html) worker hosts, the Unreal Engine and adaptor are automatically available via the `deadline-cloud-v2` and `deadline-cloud` Conda channels with the [default Queue Environment](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html#conda-queue-environment).
 
 Perforce is supported on SMF!
 

--- a/docs/user_guide/setup-cmf-worker.md
+++ b/docs/user_guide/setup-cmf-worker.md
@@ -6,7 +6,7 @@ This guide walks you through setting up an EC2 instance as a CMF worker for AWS 
 
 **CMF vs SMF Differences:**
 - **CMF**: Manual installation of Unreal Engine and adaptor on worker hosts
-- **SMF**: Automatic availability through `deadline-cloud Conda` channel
+- **SMF**: Automatic availability through `deadline-cloud-v2` and `deadline-cloud` Conda channels
 
 ## Choose Your Branch
 

--- a/docs/user_guide/setup-submitter.md
+++ b/docs/user_guide/setup-submitter.md
@@ -154,7 +154,7 @@ If you already have a Windows fleet and don't need to set up a new fleet, you ca
 ## Create a Service Managed Fleet (SMF)
 
 1. Follow [Service-managed fleets](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/smf-manage.html) user guide to create a Service Managed Fleet (SMF) if you don't already have one.
-	On [Service Managed Fleets (SMF)](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/smf-manage.html), the Unreal Engine and adaptor are automatically available via the `deadline-cloud Conda` channel with the [default Queue Environment](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html#conda-queue-environment). You are ready to start rendering now! Continue with "Submit a Test Render" section below to submit a test render job.
+	On [Service Managed Fleets (SMF)](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/smf-manage.html), the Unreal Engine and adaptor are automatically available via the `deadline-cloud-v2` and `deadline-cloud` Conda channels with the [default Queue Environment](https://docs.aws.amazon.com/deadline-cloud/latest/userguide/create-queue-environment.html#conda-queue-environment). You are ready to start rendering now! Continue with "Submit a Test Render" section below to submit a test render job.
 
 ## Create a Customer Managed Fleet (CMF)
 

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
@@ -37,7 +37,7 @@ parameterDefinitions:
    control: LINE_EDIT
 - name: CondaChannels
   type: STRING
-  default: deadline-cloud
+  default: deadline-cloud-v2 deadline-cloud
   userInterface: 
    control: LINE_EDIT
 - name: ChunkSize

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
@@ -35,7 +35,7 @@ parameterDefinitions:
    control: LINE_EDIT
 - name: CondaChannels
   type: STRING
-  default: deadline-cloud
+  default: deadline-cloud-v2 deadline-cloud
   userInterface: 
    control: LINE_EDIT
 - name: ChunkSize


### PR DESCRIPTION
feat: Add deadline-cloud-v2 as default Conda channel

### What was the problem/requirement? (What/Why)

A new Conda channel, `deadline-cloud-v2`, is now the home for newer Unreal Engine and adaptor Conda packages. The Unreal render job templates and supporting docs need to point at `deadline-cloud-v2` by default so newly submitted jobs pick up the new packages out of the box, while still falling back to `deadline-cloud` so existing packages (and any submitter that hasn't migrated yet) keep resolving.

### What was the solution? (How)

Updated the `CondaChannels` parameter default in both render job templates to list both channels, with `deadline-cloud-v2` first so Conda prefers it during package resolution and falls back to `deadline-cloud`:

- `src/unreal_plugin/Content/Python/openjd_templates/render_job.yml` — `default: deadline-cloud` → `default: deadline-cloud-v2 deadline-cloud`
- `src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml` — same change

Updated the docs that name the channel by hand to mention both:

- `README.md` — "via the `deadline-cloud Conda` channel" → "via the `deadline-cloud-v2` and `deadline-cloud` Conda channels"
- `docs/user_guide/setup-submitter.md` — same docs phrasing
- `docs/user_guide/setup-cmf-worker.md` — same docs phrasing

The `DEADLINE_CONDA_CHANNELS` environment-variable override path in `src/unreal_plugin/Content/Python/job_library.py` and the `--conda-channel` pytest option in `test/end_to_end/conftest.py` are unchanged — they continue to let users and tests override whatever default ships in the templates.

Other occurrences of the literal string `deadline-cloud` in the repo were intentionally left alone because they are not Conda channel names: the package name (`deadline-cloud-for-unreal-engine`), GitHub URLs (`github.com/aws-deadline/...`), AWS docs URLs (`docs.aws.amazon.com/deadline-cloud/...`), and the example Perforce-credentials secret name (`deadline-cloud-p4-credentials`).

### What is the impact of this change?

New job submissions that don't override `CondaChannels` will resolve packages from `deadline-cloud-v2` first and fall back to `deadline-cloud`. On Service Managed Fleets this aligns the default with the channel where the new `unrealengine` / `unrealengine-openjd` packages live, while preserving compatibility for anything still published only to `deadline-cloud`. Users who have explicitly overridden `CondaChannels` (via Parameter Definition Overrides on the queue, the `DEADLINE_CONDA_CHANNELS` env var, or per-job parameter values) are unaffected.

### How was this change tested?

- Ran jobs successfully with new `deadline-cloud-v2` channel on all UE version we support

### Have you run a render job successfully with these changes?

Yes, i render jobs successfully on all UE version we support

### Was this change documented?

Yes — the three user-facing docs that name the channel were updated alongside the templates so the docs and the shipped defaults stay in sync. No docstring changes needed; no adaptor init-data or run-data schema impact.

### Is this a breaking change?

No. `CondaChannels` is still a user-overridable parameter and the adaptor's init-data / run-data contracts are unchanged. The change is additive for resolution: packages previously reachable via `deadline-cloud` continue to resolve because `deadline-cloud` is still in the default list. Users who want the prior single-channel behavior can override `CondaChannels` back to `deadline-cloud` at submission time or via the queue's Parameter Definition Overrides.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*