### PR TITLE
feat(adaptor): accept legacy render partitioning param names

### DIFF
--- a/docs/design/render-task-partitioning.md
+++ b/docs/design/render-task-partitioning.md
@@ -1,0 +1,61 @@
+# Render Task Partitioning
+
+When you submit a render to AWS Deadline Cloud, the Unreal submitter splits the work in a Movie Render Queue (MRQ) job into multiple OpenJD **tasks** so they can be distributed across worker hosts.
+
+This integration currently supports two submitter-side partitioning modes, described below. They are configured on the Render Step / Render Job parameters and are mutually exclusive — `FramesPerTask` takes precedence when set.
+
+> **Parameter rename in progress.** Two of these parameters are being renamed to avoid colliding with OpenJD's own task-chunking terminology:
+>
+> | Old name | New name |
+> |---|---|
+> | `ChunkSize` | `ShotsPerTask` |
+> | `ChunkId` | `TaskIndex` |
+>
+> Both names are referenced throughout this page as **`ChunkSize` / `ShotsPerTask`** and **`ChunkId` / `TaskIndex`**. During the transition the worker adaptor accepts either name, so jobs keep working whichever name your submitter emits. The old names are deprecated and will be removed in a future release.
+
+> **Important — `ChunkSize` / `ShotsPerTask` is NOT OpenJD's `ChunkSize`:** OpenJD has its own native [task chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) feature with a `ChunkSize` parameter and a `CHUNK[INT]` task-parameter type, where the scheduler groups tasks into chunks at dispatch time. This integration's parameter is unrelated: it is a **submitter-side** value that decides the shot-per-task breakdown at submission time, implemented in this integration rather than the OpenJD scheduler. The two share the old name but mean different things — and OpenJD's `ChunkSize` is actually closest in meaning to this integration's `FramesPerTask` (frames grouped per task), not to `ChunkSize` / `ShotsPerTask` (shots per task). The rename exists precisely to remove this confusion.
+
+## Mode 1 — Shots per task (`ChunkSize` / `ShotsPerTask`)
+
+Partitions the **enabled shots** of the Level Sequence. Each task renders up to `ChunkSize` / `ShotsPerTask` consecutive enabled shots.
+
+- Task count = ceil(number of enabled shots / `ChunkSize` / `ShotsPerTask`)
+- If the value is 0 or negative, it defaults to 1 (one shot per task).
+
+Example — a Level Sequence with 10 enabled shots and `ChunkSize` / `ShotsPerTask` = 3 produces 4 tasks:
+
+| ChunkId / TaskIndex | Shots rendered |
+|---|---|
+| 0 | 0, 1, 2 |
+| 1 | 3, 4, 5 |
+| 2 | 6, 7, 8 |
+| 3 | 9 |
+
+Use this mode when your sequence is organized into shots and you want each task to cover a whole number of shots.
+
+## Mode 2 — Frames per task (`FramesPerTask`)
+
+Partitions the **frame range** of the render. Each task renders up to `FramesPerTask` consecutive frames, regardless of shot boundaries. (`FramesPerTask` is not affected by the rename.)
+
+- Task count = ceil(total frame range / `FramesPerTask`)
+- `FramesPerTask` takes precedence: if it is set and greater than 0, `ChunkSize` / `ShotsPerTask` is ignored.
+- The frame range comes from the MRQ output settings' custom playback range if enabled, otherwise from the Level Sequence's playback range.
+
+Example — a 100-frame sequence with `FramesPerTask = 25` produces 4 tasks:
+
+| ChunkId / TaskIndex | Frames rendered |
+|---|---|
+| 0 | 0–24 |
+| 1 | 25–49 |
+| 2 | 50–74 |
+| 3 | 75–99 |
+
+Use this mode when you want even-sized tasks by frame count — for example to load-balance a long single shot across many workers.
+
+## `ChunkId` / `TaskIndex`
+
+In both modes, each generated task is assigned a 0-based `ChunkId` / `TaskIndex` identifying which partition it renders. It is filled in automatically during submission; you do not set it by hand. The adaptor uses it to select the correct shots (Mode 1) or frame window (Mode 2) for each task.
+
+### Output file naming
+
+When a render is split across multiple tasks, MRQ writes one output file per task. For image sequences (PNG/EXR/etc.) the default `FileNameFormat` includes `{frame_number}`, so each task's output is already unique. For video containers such as `.mov`, the default format is just `{sequence_name}` and every task would write to the same filename. To disambiguate, add the `{task_index}` token to the MRQ Output Setting's `FileNameFormat` (for example `{sequence_name}_{task_index}`); the submitter substitutes it at render time with a zero-padded per-task index.

--- a/docs/plans/render-partitioning-migration-plan.md
+++ b/docs/plans/render-partitioning-migration-plan.md
@@ -1,0 +1,100 @@
+# Migration plan: rename render partitioning params, then adopt OpenJD chunking
+
+**Status:** living plan — update as phases land.
+**Audience:** maintainers of `deadline-cloud-for-unreal-engine`.
+
+## Background
+
+This integration splits a Movie Render Queue job into OpenJD tasks using two
+**submitter-side** parameters (see
+[`docs/design/render-task-partitioning.md`](../design/render-task-partitioning.md)):
+`ChunkSize` (shots per task) and `FramesPerTask` (frames per task), with
+`ChunkId` as the per-task index. The run_data keys on the wire are
+`chunk_size`/`chunk_id`.
+
+OpenJD has since added a **native, scheduler-level** [task chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md)
+feature with its own `ChunkSize` parameter — closer in meaning to our
+`FramesPerTask` than to our `ChunkSize`. The shared name is misleading and
+blocks adoption of OpenJD's native mode.
+
+The fix is to rename `ChunkSize`→`ShotsPerTask` and `ChunkId`→`TaskIndex`, then
+adopt OpenJD chunking. Because the submitter and adaptor are released
+independently (run_data keys are their contract), we use an **expand/contract
+(parallel-change)** rollout.
+
+## Compatibility model
+
+- Submitter writes run_data keys; adaptor reads them. Key names are the contract.
+- **SMF:** adaptor version pinned by `CondaPackages` in the job template
+  (`unrealengine-openjd=0.6.*`).
+- **CMF:** adaptor pip-installed manually, must be kept version-matched to the
+  submitter (per `setup-cmf-worker.md`).
+- run_data fields are optional in `run_data.schema.json` (only `handler` is
+  required). A mismatch therefore fails **silently with wrong output** (a task
+  renders the full sequence instead of its partition), not loudly. This drives
+  the per-phase ordering below.
+
+## Phases
+
+### Phase 1 — Backwards-compatible adaptor (this change)
+
+- Adaptor uses the new names internally, accepts both legacy
+  (`chunk_size`/`chunk_id`) and new (`shots_per_task`/`task_index`) run_data
+  keys via `_apply_param_aliases` (new wins). Schema permits all four keys.
+- Submitter, templates, and user-facing names are unchanged.
+- **Release:** non-breaking (`feat`).
+- **Exit criterion:** rolled out to fleet (SMF conda channel updated; CMF hosts
+  upgraded). After this, any deployed adaptor handles both old and new templates.
+
+### Phase 2 — Submitter switches to new names (user-facing breaking change)
+
+- Rename on submitter side: `OpenJobStepParameterNames`, bundled templates,
+  sample scripts, user docs (work staged on the `RenameChunkSize` branch).
+- Bump `CondaPackages` adaptor pin so SMF workers install a Phase-1+ adaptor.
+- **Release:** breaking (`feat!` + `BREAKING CHANGE:` footer), minor bump
+  (0.6 → 0.7).
+- **Precondition:** Phase 1 deployed everywhere. A new-names template must
+  never reach a pre-Phase-1 adaptor.
+- **User migration:** update saved Data Assets, custom templates, and
+  submission scripts that reference `ChunkSize`/`ChunkId`; regenerate old job
+  bundles. (Find-and-replace details in the Phase-2 PR description.)
+- **Exit criterion:** all submitters in use emit new names.
+
+### Phase 3 — Drop legacy support from the adaptor
+
+- Remove `_apply_param_aliases` and the legacy keys from
+  `run_data.schema.json`. Optionally set `additionalProperties: false` so a
+  stale legacy template fails loudly at validation.
+- **Release:** breaking (`refactor!` + `BREAKING CHANGE:` footer).
+- **Precondition:** no submitter in use emits legacy names; no old job bundles
+  in flight.
+- **Exit criterion:** rename complete.
+
+### Phase 4 — Adopt OpenJD native chunking (separate feature track)
+
+A distinct feature unblocked by the rename: replace `FramesPerTask` with
+OpenJD's scheduler-level `CHUNK[INT]` task chunking, where chunks are formed at
+dispatch time rather than at submission. `ShotsPerTask` likely remains
+submitter-side since OpenJD chunking operates on integer ranges, not shot
+lists.
+
+- **Dependencies:** requires `TASK_CHUNKING` extension support in
+  worker-agent / openjd-sessions on target fleets.
+- **Release:** feature (`feat`); potentially breaking depending on whether
+  `FramesPerTask` is kept as an alias or removed.
+
+## Sequencing summary
+
+```
+Phase 1  feat       adaptor accepts both names           (non-breaking)  <-- this PR
+   |       deploy adaptor to all SMF + CMF workers
+Phase 2  feat!      submitter emits new names            (breaking)      next minor
+   |       all submitters updated
+Phase 3  refactor!  adaptor drops legacy-name support     (breaking)
+   |
+Phase 4  feat       adopt OpenJD native chunking          (feature)      independent track
+```
+
+Don't collapse phases: skipping Phase 1's fleet rollout before Phase 2, or
+Phase 2's rollout before Phase 3, reintroduces the silent wrong-output failure
+this plan exists to avoid.

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/run_data.schema.json
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/run_data.schema.json
@@ -12,6 +12,8 @@
         "script_args": { "type": "string" },
         "chunk_size": { "type": "integer" },
         "chunk_id": { "type": "integer" },
+        "shots_per_task": { "type": "integer" },
+        "task_index": { "type": "integer" },
         "output_path": { "type":  "string" }
     },
     "required": [

--- a/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
+++ b/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
@@ -312,7 +312,7 @@ class UnrealRenderStepHandler(BaseStepHandler):
     def _apply_task_index_to_filename(render_job, task_index: int) -> None:
         """
         Substitute ``{task_index}`` in MRQ's FileNameFormat with the per-task index so
-        chunked renders that produce a single file per task (e.g. .mov containers) do
+        multi-task renders that produce a single file per task (e.g. .mov containers) do
         not collide on the same output filename. If the resolved format contains no
         per-task token (neither ``{task_index}`` nor ``{frame_number}``), warn that
         outputs from sibling tasks will overwrite each other.
@@ -335,19 +335,19 @@ class UnrealRenderStepHandler(BaseStepHandler):
             )
 
     @staticmethod
-    def enable_shots_by_chunk(render_job, task_chunk_size: int, task_chunk_id: int):
+    def enable_shots_for_task(render_job, shots_per_task: int, task_index: int):
 
         all_shots_to_render = [shot for shot in render_job.shot_info if shot.enabled]
-        shots_chunk = all_shots_to_render[
-            task_chunk_id * task_chunk_size : (task_chunk_id + 1) * task_chunk_size
+        task_shots = all_shots_to_render[
+            task_index * shots_per_task : (task_index + 1) * shots_per_task
         ]
         for shot in render_job.shot_info:
-            if shot in shots_chunk:
+            if shot in task_shots:
                 shot.enabled = True
                 logger.info(f"Shot to render: {shot.outer_name}: {shot.inner_name}")
             else:
                 shot.enabled = False
-        logger.info(f"Shots in task: {[shot.outer_name for shot in shots_chunk]}")
+        logger.info(f"Shots in task: {[shot.outer_name for shot in task_shots]}")
 
     @staticmethod
     def get_frame_range(output_settings, level_sequence):
@@ -363,7 +363,7 @@ class UnrealRenderStepHandler(BaseStepHandler):
             elif level_sequence is None:
                 # The caller passed a None LevelSequence (e.g. the loader returned
                 # None for reasons that are not always reproducible). Fall back to
-                # the MRQ output_settings custom range so chunked renders can still
+                # the MRQ output_settings custom range so multi-task renders can still
                 # emit frames; otherwise we'd crash on
                 # `NoneType.get_playback_range()` further down. If output_settings
                 # has no non-empty range either, leave the cache unset and surface
@@ -402,6 +402,35 @@ class UnrealRenderStepHandler(BaseStepHandler):
             UnrealRenderStepHandler.cached_frame_range_end,
         )
 
+    @staticmethod
+    def _apply_param_aliases(args: dict) -> dict:
+        """Accept both the legacy and new run_data keys for the render
+        partitioning parameters, for backwards compatibility during the
+        parameter rename:
+
+            chunk_size -> shots_per_task
+            chunk_id   -> task_index
+
+        The names are being changed on the submitter side to avoid colliding
+        with OpenJD's own "ChunkSize" task-chunking term. This adaptor accepts
+        both so it can run jobs from an older submitter (legacy keys) and a
+        newer submitter (new keys) alike.
+
+        The adaptor's own downstream logic uses the NEW keys; this normalizes
+        the legacy keys onto the new ones in place. The new keys take
+        precedence when both are present. Once older submitters are no longer
+        in use, this aliasing (and the legacy keys in run_data.schema.json)
+        can be removed without touching the rest of the adaptor.
+
+        :param args: run_data arguments (mutated in place)
+        :return: the same args dict, for convenience
+        """
+        if "chunk_size" in args and "shots_per_task" not in args:
+            args["shots_per_task"] = args["chunk_size"]
+        if "chunk_id" in args and "task_index" not in args:
+            args["task_index"] = args["chunk_id"]
+        return args
+
     def run_script(self, args: dict) -> bool:
         """
         Create the unreal.MoviePipelineQueue object and render it with the render executor
@@ -413,6 +442,9 @@ class UnrealRenderStepHandler(BaseStepHandler):
         logger.info(
             f"{UnrealRenderStepHandler.run_script.__name__} executing with args: {args} ..."
         )
+
+        UnrealRenderStepHandler._apply_param_aliases(args)
+
         asset_registry = unreal.AssetRegistryHelpers.get_asset_registry()
         asset_registry.wait_for_completion()
 
@@ -437,10 +469,10 @@ class UnrealRenderStepHandler(BaseStepHandler):
             )
 
         output_settings = None
-        if "chunk_id" in args:
-            chunk_id: int = args["chunk_id"]
+        if "task_index" in args:
+            task_index: int = args["task_index"]
         for job in subsystem.get_queue().get_jobs():
-            if args.get("frames_per_task") and "chunk_id" in args:
+            if args.get("frames_per_task") and "task_index" in args:
                 frames_per_task: int = args["frames_per_task"]
                 if not output_settings:
                     output_settings = job.get_configuration().find_or_add_setting_by_class(
@@ -456,24 +488,23 @@ class UnrealRenderStepHandler(BaseStepHandler):
                 )
                 if frame_range_start is None or frame_range_end is None:
                     logger.error(
-                        "Frame range unavailable; cannot compute chunk window for "
-                        f"chunk_id={chunk_id} frames_per_task={frames_per_task}"
+                        "Frame range unavailable; cannot compute the frame window for "
+                        f"task_index={task_index} frames_per_task={frames_per_task}"
                     )
                     return False
 
                 output_settings.custom_start_frame = frame_range_start + (
-                    chunk_id * frames_per_task
+                    task_index * frames_per_task
                 )
                 output_settings.custom_end_frame = min(
                     output_settings.custom_start_frame + frames_per_task, frame_range_end
                 )
-                # Force MRQ to honour the per-chunk window set above. Without this
-                # flag, MRQ falls back to the full range baked into the MRQ preset
-                # whenever `use_custom_playback_range` is false on the output
-                # settings -- which causes every chunked task to redundantly
-                # re-render the entire sequence. Observed in a 40-chunk render
-                # where each chunk re-rendered frames 0..end instead of its
-                # assigned window.
+                # Force MRQ to honour the per-task frame window set above. Without
+                # this flag, MRQ falls back to the full range baked into the MRQ
+                # preset whenever `use_custom_playback_range` is false on the output
+                # settings -- which causes every task to redundantly re-render the
+                # entire sequence. Observed in a 40-task render where each task
+                # re-rendered frames 0..end instead of its assigned window.
                 output_settings.use_custom_playback_range = True
 
                 if level_sequence is not None:
@@ -484,21 +515,21 @@ class UnrealRenderStepHandler(BaseStepHandler):
                     )
                 else:
                     logger.warning(
-                        "Rendering chunk frame range "
+                        "Rendering task frame range "
                         f"[{output_settings.custom_start_frame}, "
                         f"{output_settings.custom_end_frame}] without a resolved "
                         "LevelSequence; relying on output_settings.use_custom_playback_range"
                     )
-            elif "chunk_size" in args and "chunk_id" in args:
-                chunk_size: int = args["chunk_size"]
-                UnrealRenderStepHandler.enable_shots_by_chunk(
+            elif "shots_per_task" in args and "task_index" in args:
+                shots_per_task: int = args["shots_per_task"]
+                UnrealRenderStepHandler.enable_shots_for_task(
                     render_job=job,
-                    task_chunk_size=chunk_size,
-                    task_chunk_id=chunk_id,
+                    shots_per_task=shots_per_task,
+                    task_index=task_index,
                 )
 
-            if "chunk_id" in args and (args.get("frames_per_task") or "chunk_size" in args):
-                UnrealRenderStepHandler._apply_task_index_to_filename(job, chunk_id)
+            if "task_index" in args and (args.get("frames_per_task") or "shots_per_task" in args):
+                UnrealRenderStepHandler._apply_task_index_to_filename(job, task_index)
 
             if "output_path" in args:
                 if not os.path.exists(args["output_path"]):

--- a/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_render_step_handler.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_render_step_handler.py
@@ -36,7 +36,7 @@ class RenderJobMock:
 class TestUnrealRenderStepHandler:
 
     @pytest.mark.parametrize(
-        "shots_count, enabled_shots_count, task_chunk_size, task_chunk_id",
+        "shots_count, enabled_shots_count, shots_per_task, task_index",
         [
             (29, 15, 5, 0),
             (29, 29, 5, 1),
@@ -45,13 +45,13 @@ class TestUnrealRenderStepHandler:
             (10, 9, 3, 2),
         ],
     )
-    def test_enable_shots_by_chunk(
+    def test_enable_shots_for_task(
         self,
         unreal_render_step_handler,
         shots_count,
         enabled_shots_count,
-        task_chunk_size,
-        task_chunk_id,
+        shots_per_task,
+        task_index,
     ):
         # GIVEN
         enabled_shots = [
@@ -65,28 +65,28 @@ class TestUnrealRenderStepHandler:
         render_job_mock = RenderJobMock(shot_info=enabled_shots + disabled_shots)
 
         enabled_job_shots = [shot for shot in render_job_mock.shot_info if shot.enabled]
-        chunked = enabled_job_shots[
-            task_chunk_id * task_chunk_size : (task_chunk_id + 1) * task_chunk_size
+        task_shots = enabled_job_shots[
+            task_index * shots_per_task : (task_index + 1) * shots_per_task
         ]
-        chunked_names = [shot.outer_name for shot in chunked]
+        task_shot_names = [shot.outer_name for shot in task_shots]
 
         # WHEN
         with patch(
             "deadline.unreal_adaptor.UnrealClient.step_handlers."
             "unreal_render_step_handler.logger.info"
         ) as log_mock:
-            unreal_render_step_handler.enable_shots_by_chunk(
-                render_job_mock, task_chunk_size, task_chunk_id
+            unreal_render_step_handler.enable_shots_for_task(
+                render_job_mock, shots_per_task, task_index
             )
 
             # THEN
             enabled_shots = [shot for shot in render_job_mock.shot_info if shot.enabled]
             assert all([shot.enabled for shot in enabled_shots])
-            assert all([shot.outer_name.startswith("Enabled") for shot in chunked])
-            assert len(enabled_shots) <= task_chunk_size and len(enabled_shots) <= shots_count
+            assert all([shot.outer_name.startswith("Enabled") for shot in task_shots])
+            assert len(enabled_shots) <= shots_per_task and len(enabled_shots) <= shots_count
 
             disabled_shots = [
-                shot for shot in render_job_mock.shot_info if shot.outer_name not in chunked_names
+                shot for shot in render_job_mock.shot_info if shot.outer_name not in task_shot_names
             ]
             for shot in disabled_shots:
                 assert not shot.enabled
@@ -94,3 +94,57 @@ class TestUnrealRenderStepHandler:
             log_mock.assert_called_with(
                 f"Shots in task: {[shot.outer_name for shot in enabled_shots]}"
             )
+
+
+class TestApplyParamAliases:
+    """Backwards-compatible run_data key aliasing.
+
+    The adaptor's downstream logic uses the new keys (shots_per_task/task_index).
+    For backwards compatibility during the parameter rename it also accepts the
+    legacy keys (chunk_size/chunk_id), normalizing them onto the new keys. The
+    new keys take precedence when both are present.
+    """
+
+    def test_legacy_keys_aliased_to_new(self, unreal_render_step_handler):
+        args = {"handler": "render", "chunk_size": 5, "chunk_id": 2}
+        unreal_render_step_handler._apply_param_aliases(args)
+        assert args["shots_per_task"] == 5
+        assert args["task_index"] == 2
+
+    def test_new_keys_untouched_when_no_legacy_keys(self, unreal_render_step_handler):
+        args = {"handler": "render", "shots_per_task": 7, "task_index": 3}
+        unreal_render_step_handler._apply_param_aliases(args)
+        assert args["shots_per_task"] == 7
+        assert args["task_index"] == 3
+        assert "chunk_size" not in args
+        assert "chunk_id" not in args
+
+    def test_new_keys_take_precedence_over_legacy(self, unreal_render_step_handler):
+        # If both are present (e.g. a hand-edited template), the new keys win.
+        args = {
+            "handler": "render",
+            "shots_per_task": 5,
+            "task_index": 2,
+            "chunk_size": 99,
+            "chunk_id": 88,
+        }
+        unreal_render_step_handler._apply_param_aliases(args)
+        assert args["shots_per_task"] == 5
+        assert args["task_index"] == 2
+
+    def test_partial_legacy_keys_each_aliased_independently(self, unreal_render_step_handler):
+        # Only one legacy key present — it should be aliased, the new key that
+        # is already present left as-is.
+        args = {"handler": "render", "chunk_size": 4, "task_index": 1}
+        unreal_render_step_handler._apply_param_aliases(args)
+        assert args["shots_per_task"] == 4
+        assert args["task_index"] == 1
+
+    def test_no_partitioning_keys_is_noop(self, unreal_render_step_handler):
+        args = {"handler": "render"}
+        unreal_render_step_handler._apply_param_aliases(args)
+        assert args == {"handler": "render"}
+
+    def test_returns_same_dict(self, unreal_render_step_handler):
+        args = {"handler": "render", "chunk_size": 1}
+        assert unreal_render_step_handler._apply_param_aliases(args) is args

--- a/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_frames_per_task.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_frames_per_task.py
@@ -120,19 +120,19 @@ class TestUnrealRenderStepHandlerFramesPerTask:
             log_mock.assert_called_with("Cached level sequence frame range from 1 to 100")
 
     @pytest.mark.parametrize(
-        "chunk_id, frames_per_task, frame_start, frame_end, expected_start, expected_end",
+        "task_index, frames_per_task, frame_start, frame_end, expected_start, expected_end",
         [
-            (0, 10, 1, 100, 1, 11),  # First chunk
-            (1, 10, 1, 100, 11, 21),  # Second chunk
-            (9, 10, 1, 100, 91, 100),  # Last chunk (clamped to end)
-            (0, 50, 10, 30, 10, 30),  # Single chunk covers entire range
-            (2, 5, 0, 20, 10, 15),  # Middle chunk
+            (0, 10, 1, 100, 1, 11),  # First task
+            (1, 10, 1, 100, 11, 21),  # Second task
+            (9, 10, 1, 100, 91, 100),  # Last task (clamped to end)
+            (0, 50, 10, 30, 10, 30),  # Single task covers entire range
+            (2, 5, 0, 20, 10, 15),  # Middle task
         ],
     )
     def test_frames_per_task_calculation_logic(
         self,
         unreal_render_step_handler,
-        chunk_id,
+        task_index,
         frames_per_task,
         frame_start,
         frame_end,
@@ -153,44 +153,47 @@ class TestUnrealRenderStepHandlerFramesPerTask:
                 output_settings, level_sequence
             )
 
-            calculated_start = frame_range_start + (chunk_id * frames_per_task)
+            calculated_start = frame_range_start + (task_index * frames_per_task)
             calculated_end = min(calculated_start + frames_per_task, frame_range_end)
 
             # THEN
             assert calculated_start == expected_start
             assert calculated_end == expected_end
 
-    def test_frames_per_task_vs_chunk_size_precedence(self, unreal_render_step_handler):
-        """Test that frames_per_task takes precedence over chunk_size in argument processing"""
+    def test_frames_per_task_vs_shots_per_task_precedence(self, unreal_render_step_handler):
+        """Test that frames_per_task takes precedence over shots_per_task in argument processing"""
         # GIVEN
         args_with_frames_per_task = {
             "frames_per_task": 10,
-            "chunk_id": 1,
-            "chunk_size": 5,  # This should be ignored
+            "task_index": 1,
+            "shots_per_task": 5,  # This should be ignored
         }
 
-        args_with_chunk_size_only = {
-            "chunk_size": 5,
-            "chunk_id": 1,
+        args_with_shots_per_task_only = {
+            "shots_per_task": 5,
+            "task_index": 1,
         }
 
-        args_no_chunking: dict[str, int] = {}
+        args_no_partitioning: dict[str, int] = {}
 
         # WHEN/THEN - Test precedence logic
         # frames_per_task should be used when present
         assert (
             args_with_frames_per_task.get("frames_per_task")
-            and "chunk_id" in args_with_frames_per_task
+            and "task_index" in args_with_frames_per_task
         )
 
-        # chunk_size should be used when frames_per_task is not present
+        # shots_per_task should be used when frames_per_task is not present
         assert (
-            not args_with_chunk_size_only.get("frames_per_task")
-            and "chunk_size" in args_with_chunk_size_only
+            not args_with_shots_per_task_only.get("frames_per_task")
+            and "shots_per_task" in args_with_shots_per_task_only
         )
 
-        # No chunking when neither is present
-        assert not args_no_chunking.get("frames_per_task") and "chunk_size" not in args_no_chunking
+        # No partitioning when neither is present
+        assert (
+            not args_no_partitioning.get("frames_per_task")
+            and "shots_per_task" not in args_no_partitioning
+        )
 
     def test_frame_range_caching_behavior(self, unreal_render_step_handler):
         """Test that frame range caching works correctly across multiple calls"""
@@ -217,7 +220,7 @@ class TestUnrealRenderStepHandlerFramesPerTask:
 
     def test_frame_range_edge_cases(self, unreal_render_step_handler):
         """Test edge cases for frame range calculations"""
-        # Test case 1: chunk_id * frames_per_task exceeds total range
+        # Test case 1: task_index * frames_per_task exceeds total range
         output_settings = MagicMock()
         level_sequence = MagicMock()
 
@@ -226,11 +229,11 @@ class TestUnrealRenderStepHandlerFramesPerTask:
                 output_settings, level_sequence
             )
 
-            # chunk_id=10, frames_per_task=10 would start at frame 101, but range only goes to 50
-            chunk_id = 10
+            # task_index=10, frames_per_task=10 would start at frame 101, but range only goes to 50
+            task_index = 10
             frames_per_task = 10
 
-            calculated_start = frame_range_start + (chunk_id * frames_per_task)  # 1 + 100 = 101
+            calculated_start = frame_range_start + (task_index * frames_per_task)  # 1 + 100 = 101
             calculated_end = min(
                 calculated_start + frames_per_task, frame_range_end
             )  # min(111, 50) = 50


### PR DESCRIPTION
feat(adaptor): accept legacy render partitioning param names

### What was the problem/requirement? (What/Why)

The submitter-side render-partitioning parameters in this integration —
`ChunkSize` (shots per task) and `ChunkId` (per-task index) — collide
with OpenJD's own scheduler-level [task chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md)
feature, which has its own `ChunkSize` parameter and `CHUNK[INT]` task-parameter type.

The shared name is actively misleading: OpenJD's `ChunkSize` is closer
in meaning to this integration's `FramesPerTask` (frames grouped per
task), not to our `ChunkSize` (shots grouped per task). The collision
also blocks adoption of OpenJD's native chunking as a future
partitioning mode.

The fix is to rename `ChunkSize`→`ShotsPerTask` and `ChunkId`→`TaskIndex`,
but a naive rename is a flag-day breaking change because the submitter
and adaptor are released and deployed somewhat independently — the
run_data key names (`chunk_size`/`chunk_id`) are the contract between
them, and a job template generated by one version would fail on the
other. We use an **expand/contract (parallel-change)** rollout instead.
This PR is **Phase 1 of 4**; full plan lives in
[`docs/plans/render-partitioning-migration-plan.md`](../docs/plans/render-partitioning-migration-plan.md).

### What was the solution? (How)

Adaptor-only, backwards-compatible aliasing. The submitter, bundled
templates, and user-facing parameter names are intentionally **unchanged**
in this PR.

- Adaptor uses the **new** names (`shots_per_task`, `task_index`)
  throughout its own logic.
- New `_apply_param_aliases()` helper called at the top of
  `run_script()` normalizes the legacy run_data keys onto the new ones:
  `chunk_size` → `shots_per_task`, `chunk_id` → `task_index`. New keys
  take precedence when both are present.
- `run_data.schema.json` permits all four keys
  (`chunk_size`, `chunk_id`, `shots_per_task`, `task_index`); only
  `handler` remains required.
- Static helper `enable_shots_by_chunk` renamed to
  `enable_shots_for_task` with internals updated to
  `shots_per_task`/`task_index`.
- Two new docs:
  - `docs/design/render-task-partitioning.md` — reference for the two
    submitter-side partitioning modes this integration supports today,
    the in-progress rename, and an explicit clarification that this
    integration's `ChunkSize` is **not** OpenJD's `ChunkSize`.
  - `docs/plans/render-partitioning-migration-plan.md` — maintainer-facing
    4-phase rollout plan with per-phase release types, preconditions,
    and exit criteria.

### What is the impact of this change?

- **No user-facing impact in this PR.** Existing job templates,
  submitter UI, and saved Render Job/Step Data Assets continue to work
  unchanged.
- Once this adaptor version is rolled out to the fleet (SMF conda
  channel updated; CMF hosts upgraded), any deployed adaptor can run
  both old and new templates — this is the gating condition for Phase 2
  (submitter rename, breaking, 0.7.0).
- **Internal API:** the static helper `enable_shots_by_chunk` is
  renamed to `enable_shots_for_task`. Direct callers of the static
  method outside the adaptor would need updating, but this is internal.

### How was this change tested?

- New unit tests for `_apply_param_aliases` cover: legacy keys aliased
  onto new keys, new keys untouched when no legacy keys are present,
  new keys take precedence when both are present, partial-legacy keys
  aliased independently, no-op on a payload without partitioning keys,
  and returning the same dict in place.
- Existing parametrized `test_enable_shots_by_chunk` updated and renamed
  to `test_enable_shots_for_task` with the new parameter names.
- Existing `test_unreal_render_step_handler_frames_per_task.py` tests
  updated to use `task_index`/`shots_per_task` and reflect the renamed
  internal vocabulary.

### Have you run a render job successfully with these changes?

Yes, adaptor change tested in CMF 

### Was this change documented?

Yes:
- Docstring on `_apply_param_aliases` explaining the aliasing contract
  and that the new keys win when both are present.
- Inline comment retitled "chunked" → "multi-task" / "per-task frame
  window" in the step handler where the language was tied to the old
  parameter name.
- New user-facing reference doc at
  `docs/design/render-task-partitioning.md`.
- New maintainer-facing rollout plan at
  `docs/plans/render-partitioning-migration-plan.md`.
- `run_data.schema.json` updated to declare the new keys.

### Is this a breaking change?

**No.** This PR is purely additive on the run_data contract — the new
keys are accepted alongside the legacy ones, and legacy templates
continue to work unchanged.

The breaking changes are in the next phases of the rollout plan:
- **Phase 2** (`feat!`, 0.7.0): submitter renames `ChunkSize`/`ChunkId` →
  `ShotsPerTask`/`TaskIndex` in OpenJobStepParameterNames, bundled
  templates, sample scripts, and user docs. Users update saved Data
  Assets, custom OpenJD templates, and submission scripts.
- **Phase 3** (`refactor!`): adaptor drops `_apply_param_aliases` and
  the legacy keys from the schema, only after Phase 2 is fully rolled
  out and no old job bundles remain in flight.