### PR TITLE
chore(deps): Update deps (black,pytest,ruff,psutil) for unreal engine.

### DIFF
--- a/.github/scripts/get_latest_changelog.py
+++ b/.github/scripts/get_latest_changelog.py
@@ -29,6 +29,7 @@ Running this script on the above CHANGELOG.md should return the following conten
 
 ```
 """
+
 import re
 
 h2 = r"^##\s.*$"

--- a/.github/workflows/manual_pypi_release.yml
+++ b/.github/workflows/manual_pypi_release.yml
@@ -34,7 +34,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -80,7 +80,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.TagRelease.outputs.tag }}
           fetch-depth: 0

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -25,7 +25,6 @@ from pathlib import Path
 import boto3
 from botocore.config import Config
 
-
 UE_INSTALLERS = {
     "5.7": {
         "windows": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,9 +93,13 @@ namespace_packages = true
 explicit_package_bases = true
 mypy_path = "src"
 
+# unreal.* is a UE4 stub that doesn't exist outside the engine.
+# _pytest/pytest: pytest 9+ uses Python 3.10 syntax (match statements) which
+# mypy cannot parse when python_version is set to 3.9.
 [[tool.mypy.overrides]]
-module = ["unreal.*"]
+module = ["unreal.*", "_pytest.*", "pytest.*"]
 ignore_missing_imports = true
+follow_imports = "skip"
 
 [tool.ruff]
 line-length = 100
@@ -108,6 +112,7 @@ known-first-party = ["deadline", "openjd"]
 
 [tool.black]
 line-length = 100
+target-version = ["py39", "py310", "py311", "py312"]
 
 [tool.pytest.ini_options]
 xfail_strict = true

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,10 +1,12 @@
 coverage[toml] == 7.*
-pytest == 8.*
+pytest == 9.*; python_version >= "3.10"
+pytest == 8.*; python_version < "3.10"
 pytest-cov == 7.*
 pytest-xdist == 3.*
 twine == 6.*
 mypy == 1.*
-black == 25.*
-ruff == 0.14.*
+black == 26.*; python_version >= "3.10"
+black == 25.*; python_version < "3.10"
+ruff == 0.15.*
 types-pyyaml == 6.*
-psutil >= 5.9.0
+psutil >= 7.2.2

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/__init__.py
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/__init__.py
@@ -3,5 +3,4 @@
 from .__main__ import main
 from .adaptor import UnrealAdaptor
 
-
 __all__ = ["UnrealAdaptor", "main"]

--- a/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_custom_step_handler.py
+++ b/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_custom_step_handler.py
@@ -12,7 +12,6 @@ from types import ModuleType
 from .base_step_handler import BaseStepHandler
 from deadline.unreal_logger import get_logger
 
-
 logger = get_logger()
 
 

--- a/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
+++ b/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
@@ -18,7 +18,6 @@ from typing import Optional
 from .base_step_handler import BaseStepHandler
 from deadline.unreal_logger import get_logger
 
-
 logger = get_logger()
 
 

--- a/src/deadline/unreal_adaptor/UnrealClient/unreal_client.py
+++ b/src/deadline/unreal_adaptor/UnrealClient/unreal_client.py
@@ -50,7 +50,6 @@ from deadline.unreal_adaptor.UnrealClient.step_handlers.base_step_handler import
 )
 from deadline.unreal_adaptor.UnrealClient.step_handlers import get_step_handler_class  # noqa: E402
 
-
 logger = get_logger()
 
 # Global variables for keeping UnrealClient running and preventing deletion by the Unreal garbage collector

--- a/src/deadline/unreal_perforce_utils/perforce.py
+++ b/src/deadline/unreal_perforce_utils/perforce.py
@@ -8,7 +8,6 @@ from typing import Optional, Any
 from deadline.unreal_logger import get_logger
 from deadline.unreal_perforce_utils import exceptions, secret_manager
 
-
 logger = get_logger()
 
 

--- a/src/deadline/unreal_perforce_utils/secret_manager.py
+++ b/src/deadline/unreal_perforce_utils/secret_manager.py
@@ -12,7 +12,6 @@ from botocore.utils import InstanceMetadataRegionFetcher
 from deadline.unreal_logger import get_logger
 from deadline.unreal_perforce_utils import exceptions
 
-
 logger = get_logger()
 
 

--- a/src/deadline/unreal_perforce_utils/unreal_source_control.py
+++ b/src/deadline/unreal_perforce_utils/unreal_source_control.py
@@ -7,7 +7,6 @@ import configparser
 from deadline.unreal_logger import get_logger
 from deadline.unreal_perforce_utils import exceptions
 
-
 logger = get_logger()
 
 

--- a/src/deadline/unreal_submitter/common.py
+++ b/src/deadline/unreal_submitter/common.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from deadline.unreal_logger import get_logger
 from deadline.unreal_submitter import exceptions
 
-
 logger = get_logger()
 
 
@@ -253,7 +252,7 @@ def get_mrq_job_cmd_args(mrq_job: unreal.MoviePipelineExecutorJob) -> list[str]:
     job_device_profile_cvars: list[str] = []
     job_exec_cmds: list[str] = []
     for setting in mrq_job.get_configuration().get_all_settings():
-        (job_url_params, job_cmd_args, job_device_profile_cvars, job_exec_cmds) = (
+        job_url_params, job_cmd_args, job_device_profile_cvars, job_exec_cmds = (
             setting.build_new_process_command_line_args(
                 out_unreal_url_params=job_url_params,
                 out_command_line_args=job_cmd_args,

--- a/src/deadline/unreal_submitter/settings.py
+++ b/src/deadline/unreal_submitter/settings.py
@@ -2,7 +2,6 @@
 
 import os
 
-
 JOB_TEMPLATE_VERSION = os.getenv("OPEN_JOB_TEMPLATE_VERSION", "jobtemplate-2023-09")
 ENVIRONMENT_VERSION = os.getenv("OPEN_JOB_ENVIRONMENT_TEMPLATE_VERSION", "environment-2023-09")
 

--- a/src/deadline/unreal_submitter/submitter.py
+++ b/src/deadline/unreal_submitter/submitter.py
@@ -24,7 +24,6 @@ from deadline.unreal_submitter.exceptions import UserException
 
 from ._version import version
 
-
 # Initialize telemetry client, opt-out is respected
 telemetry_client = get_deadline_cloud_library_telemetry_client()
 telemetry_client.update_common_details(

--- a/src/deadline/unreal_submitter/unreal_dependency_collector.py
+++ b/src/deadline/unreal_submitter/unreal_dependency_collector.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass, asdict
 from deadline.unreal_submitter import common
 from deadline.unreal_logger import get_logger
 
-
 logger = get_logger()
 
 asset_registry = unreal.AssetRegistryHelpers.get_asset_registry()

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
@@ -29,7 +29,6 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job_parameters_consis
 from deadline.unreal_submitter import exceptions, settings
 from deadline.unreal_logger import get_logger
 
-
 logger = get_logger()
 
 

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_environment.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_environment.py
@@ -15,7 +15,6 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job_parameters_consis
 )
 from deadline.unreal_logger import get_logger
 
-
 logger = get_logger()
 
 

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_parameters_consistency.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_parameters_consistency.py
@@ -5,7 +5,6 @@ from typing import Any
 from dataclasses import dataclass
 from deadline.unreal_logger import get_logger
 
-
 logger = get_logger()
 
 

--- a/src/unreal_plugin/Content/Python/remote_executor.py
+++ b/src/unreal_plugin/Content/Python/remote_executor.py
@@ -5,7 +5,6 @@ import unreal
 from deadline.unreal_logger import get_logger
 from deadline.unreal_submitter.submitter import UnrealMrqJobSubmitter
 
-
 logger = get_logger()
 
 

--- a/src/unreal_plugin/Content/Python/settings.py
+++ b/src/unreal_plugin/Content/Python/settings.py
@@ -15,7 +15,6 @@ from deadline.job_attachments.models import FileConflictResolution
 
 from deadline.unreal_logger import get_logger
 
-
 logger = get_logger()
 
 

--- a/src/unreal_plugin/Content/Python/submit_actions/custom_job_submission.py
+++ b/src/unreal_plugin/Content/Python/submit_actions/custom_job_submission.py
@@ -22,7 +22,6 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job_environment impor
 )
 from deadline.unreal_logger import get_logger
 
-
 logger = get_logger()
 
 

--- a/src/unreal_plugin/Content/Python/submit_actions/p4_render_job_submission.py
+++ b/src/unreal_plugin/Content/Python/submit_actions/p4_render_job_submission.py
@@ -22,7 +22,6 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job_environment impor
 )
 from deadline.unreal_logger import get_logger
 
-
 logger = get_logger()
 
 

--- a/src/unreal_plugin/Content/Python/submit_actions/render_job_submission.py
+++ b/src/unreal_plugin/Content/Python/submit_actions/render_job_submission.py
@@ -21,7 +21,6 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job_environment impor
 )
 from deadline.unreal_logger import get_logger
 
-
 logger = get_logger()
 
 

--- a/src/unreal_plugin/Content/Python/submit_actions/ugs_render_job_submission.py
+++ b/src/unreal_plugin/Content/Python/submit_actions/ugs_render_job_submission.py
@@ -22,7 +22,6 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job_environment impor
 )
 from deadline.unreal_logger import get_logger
 
-
 logger = get_logger()
 
 

--- a/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_custom_step_handler.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_custom_step_handler.py
@@ -12,7 +12,6 @@ from deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_custom_step_handl
     UnrealCustomStepHandler,
 )
 
-
 unreal_mock = MagicMock()
 sys.modules["unreal"] = unreal_mock
 

--- a/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_render_step_handler.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_render_step_handler.py
@@ -4,7 +4,6 @@ import sys
 import pytest
 from unittest.mock import MagicMock, patch
 
-
 unreal_mock = MagicMock()
 unreal_mock.log = MagicMock()
 sys.modules["unreal"] = unreal_mock

--- a/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_none_guard.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_none_guard.py
@@ -18,7 +18,6 @@ import sys
 import pytest
 from unittest.mock import MagicMock, patch
 
-
 # Ensure ``unreal`` is in ``sys.modules`` before the source module first
 # imports it -- consistent with the other test files in this directory.
 sys.modules.setdefault("unreal", MagicMock())

--- a/test/deadline_submitter_for_unreal/unit/test_settings.py
+++ b/test/deadline_submitter_for_unreal/unit/test_settings.py
@@ -5,7 +5,6 @@ import os
 import pytest
 from unittest.mock import patch
 
-
 # Add the settings module to path since it's not in the standard package structure
 sys.path.insert(
     0, os.path.join(os.path.dirname(__file__), "../../../src/unreal_plugin/Content/Python")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There were a few deps to update but they need to be separate for Python 3.9 which is EoL: 

- https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/pull/322 (black)
- https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/pull/256 (pytest)
- https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/pull/264 (ruff)
- https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/pull/318 (psutil)
- https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/pull/317 (checkout)

So I updated the deps. 

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*