### PR TITLE
test: log full Unreal Engine output when an automation test fails

### DIFF
--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -942,6 +942,12 @@ def run_unreal_test(request, reusable_farm_id, reusable_queue_id) -> Callable:
                 logger.warning(f"Could not determine test result for {test_path}")
                 success = False
 
+        # Emit full UE output on failure; real-time stdout is swallowed by pytest-xdist capture
+        if not success:
+            logger.error(
+                "Full Unreal Engine output for failed test %s:\n%s", test_path, output_text
+            )
+
         # Return both success status and output lines
         return success, full_output
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Failures from automated tests are impossible to diagnose from CI logs alone.

### What was the solution? (How)

On failure, re-emit the full captured UE output through the logger module. Failure-only and additive
### What is the impact of this change?

No functional/customer impact. 

### Does this change impact the threat model?

No.


### Was this change documented?

- [x] This change does not impact any documentation.