### PR TITLE
test: fix e2e create-job hang on new fleet and support multiple ue versions in tests

### DIFF
--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -860,6 +860,11 @@ def run_unreal_test(request, reusable_farm_id, reusable_queue_id) -> Callable:
 
         logger.info(f"Running unreal test with farm {reusable_farm_id} queue {reusable_queue_id}")
 
+        # Populate the Deadline config so the plugin's startup precache warms the
+        # credential/S3 session; -testparams alone does not write these defaults.
+        config.set_setting("defaults.farm_id", reusable_farm_id)
+        config.set_setting("defaults.queue_id", reusable_queue_id)
+
         test_params_str = f"-testparams=farm_id={reusable_farm_id};queue_id={reusable_queue_id}"
 
         engine_root = find_engine_root(request.config.getoption("--ueversion"))
@@ -1752,7 +1757,7 @@ def stop_queue_fleet_associations_and_wait(
 
 @pytest.fixture(scope="session")
 def deadline_worker_agent(
-    reusable_farm_id: str, reusable_fleet_id: str
+    request, reusable_farm_id: str, reusable_fleet_id: str
 ) -> Generator[Tuple[subprocess.Popen, str], None, None]:
     """
     Launch deadline-worker-agent as a subprocess using the farm ID and fleet ID from our tests.
@@ -1760,6 +1765,7 @@ def deadline_worker_agent(
     This fixture is session-scoped and ensures the worker agent is stopped during cleanup.
 
     Args:
+        request: The pytest request object (used to read the --ueversion option)
         reusable_farm_id: The farm ID to use
         reusable_fleet_id: The fleet ID to use
 
@@ -1841,8 +1847,13 @@ def deadline_worker_agent(
     env["TERM"] = "dumb"
     env["NO_COLOR"] = "1"
 
-    # Add UE binaries to PATH so the adaptor can find UnrealEditor-Cmd
-    ue_bin_dir = os.path.join(find_engine_root(None), "Engine", "Binaries", "Win64")
+    # Add UE binaries to PATH so the adaptor can find UnrealEditor-Cmd.
+    ue_bin_dir = os.path.join(
+        find_engine_root(request.config.getoption("--ueversion")),
+        "Engine",
+        "Binaries",
+        "Win64",
+    )
     if os.path.isdir(ue_bin_dir):
         env["PATH"] = ue_bin_dir + os.pathsep + env.get("PATH", "")
 


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)

On a clean CI fleet, UE startup's `precache_clients()` reads an empty `farm_id`, `GetQueue` fails, and submission stalls on a cold credential/S3 path until the in-editor test times out (300s). Fleets with leftover config pass — a false pass that hid the issue in gamma.

Support testing on multiple UE versions: The `deadline_worker_agent` fixture used `find_engine_root(None)`, which picks the highest installed UE version and breaks on multi-version machines (review feedback from #312).

## What was the solution? (How)

 In `run_unreal_test`, write `defaults.farm_id`/`defaults.queue_id` to the Deadline config before launching UE so precache warms the session (`-testparams` does not populate these).
`deadline_worker_agent` now uses `--ueversion` via `request` instead of hardcoding `None`.



## What is the impact of this change?

Fixes the e2e `CreateJob` hang on clean CI fleets and resolves the correct UE version on multi-version hosts.

## How was this change tested?

Verified on the gamma CI fleet. `test_create_job` PASSED (~27s) and `test_worker_agent_project_plugins` PASSED (~293s). Deleting the config without the fix reproduced the 324s hang.

## Is this a breaking change?

No.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.