### PR TITLE
feat: Run pre-GUI hooks from the Unreal C++ Details panel

### DIFF
--- a/docs/user_guide/setup-submitter.md
+++ b/docs/user_guide/setup-submitter.md
@@ -206,6 +206,33 @@ This example will use the Meerkat Demo from the Unreal Marketplace:
 1. You can go to Deadline Cloud Monitor and watch the progress of your job. 
 
 
+# Submission Hooks (Pre-GUI)
+
+The submitter runs **pre-GUI** submission hooks sourced from `DEADLINE_HOOKS_DIR`. A pre-GUI hook runs when a Deadline Cloud job's **Details panel is built**, letting a studio pre-populate the job's shared settings (name, description, priority, initial state, maximum failed tasks / retries) and template parameters *before* the artist reviews them.
+
+## Enable pre-GUI hooks
+
+1. Set `DEADLINE_HOOKS_DIR` to a directory containing a `hooks.yaml` with a `preGUI` entry (see the Deadline Cloud submission-hooks documentation for the file format). This environment variable must be set **before** you launch Unreal Editor.
+1. Allow environment-sourced hooks:
+	```
+	deadline config set settings.allow_environment_hooks true
+	```
+1. (Optional) Skip the per-run confirmation dialog:
+	```
+	deadline config set settings.auto_accept true
+	```
+	When `auto_accept` is `false` (the default), opening a job's Details panel shows a confirmation dialog listing the hooks that will run; the hook applies only after you accept.
+
+## When pre-GUI hooks run
+
+Pre-GUI hooks are **panel-tied** — they run when a job's Deadline Cloud Details panel is built:
+
+- **Data asset** — when you open a `DeadlineCloudRenderJob` (`UDeadlineCloudJob`) data asset in the editor.
+- **Movie Render Queue** — when you select a Deadline Cloud job in the Movie Render Queue so its **Preset Overrides** panel is shown. Because **Render (Remote)** submits every job in the queue, open each job you want hooked at least once; a job whose panel is never opened is submitted without the pre-GUI hook applied.
+
+A value a hook sets is skipped (and surfaced as an editor notification instead of written to the job) when it fails the panel's validation, matches no field, or names a parameter the submitter resolves itself at submit time (for example `ProjectFilePath`, `ExtraCmdArgs`, `Frames`, or Perforce settings).
+
+
 # Update Notifications
 
 The submitter plugin automatically checks for newer releases on GitHub when Unreal Editor starts. If an update is available, a dialog will prompt you to visit the release page.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "deadline >= 0.59,< 0.61",
+    "deadline >= 0.60.1,< 0.61",
     "openjd-adaptor-runtime >= 0.9.4,< 0.10",
     "openjd-model >= 0.10.0, < 0.12",
     'p4python == 2026.1.3027817; python_version >= "3.10"',

--- a/scripts/ci/run_unreal_automation_tests.ps1
+++ b/scripts/ci/run_unreal_automation_tests.ps1
@@ -157,8 +157,14 @@ try {
     Write-Host "Test selection: $testSelection"
 
     $previousMetadataDisabled = $env:AWS_EC2_METADATA_DISABLED
+    # Clear DEADLINE_HOOKS_DIR for the editor process. The fixture enables the plugin, so opening a job's
+    # Details panel (DeadlineCloudMRQJobUI / DeadlineCloudJobUI) triggers the pre-GUI hook path. A hooks dir
+    # inherited from the runner would fire real hooks mid-suite - the confirmation modal would block this
+    # headless run, or applied output would perturb the panel state those specs assert on.
+    $previousHooksDir = $env:DEADLINE_HOOKS_DIR
     try {
         $env:AWS_EC2_METADATA_DISABLED = "true"
+        Remove-Item Env:\DEADLINE_HOOKS_DIR -ErrorAction SilentlyContinue
         $startInfo = New-Object System.Diagnostics.ProcessStartInfo
         $startInfo.FileName = $editor
         $startInfo.Arguments = $arguments -join " "
@@ -206,6 +212,12 @@ try {
         }
         else {
             $env:AWS_EC2_METADATA_DISABLED = $previousMetadataDisabled
+        }
+        if ($null -eq $previousHooksDir) {
+            Remove-Item Env:\DEADLINE_HOOKS_DIR -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:DEADLINE_HOOKS_DIR = $previousHooksDir
         }
     }
 
@@ -289,7 +301,8 @@ try {
         "DeadlineCloud.Offline.DeadlineCloudStepUI.StepUI",
         "DeadlineCloud.Offline.DeadlineCloudEnvironmentUI.EnvironmentUI",
         "DeadlineCloud.Offline.DeadlineCloudHostRequirementsUI.HostRequirementsUI",
-        "DeadlineCloud.Offline.DeadlineCloudSavePresetWidget.DeadlineCloudSavePresetWidget"
+        "DeadlineCloud.Offline.DeadlineCloudSavePresetWidget.DeadlineCloudSavePresetWidget",
+        "DeadlineCloud.Offline.FPreGuiHookApplyOutput.applies only the shared-setting fields the hook actually set"
     )
     foreach ($requiredTest in $requiredTests) {
         if ($startedPaths -notcontains $requiredTest) {

--- a/src/deadline/unreal_submitter/submitter.py
+++ b/src/deadline/unreal_submitter/submitter.py
@@ -315,6 +315,12 @@ class UnrealSubmitter:
 
         del self.submitted_job_ids[:]
 
+        # Pre-GUI hooks are NOT run here. In Unreal the true "pre-GUI" point is the C++
+        # UDeadlineCloudJob Details panel (FDeadlineCloudJobDetails::CustomizeDetails), which runs
+        # the hooks and applies their output onto the data asset before the artist edits it. By
+        # submit time the job is already fully configured, so running hooks here would be too late
+        # to be "pre-GUI".
+
         # Get project root directory as absolute path
         project_dir = os.path.abspath(unreal.Paths.project_dir())
         for job in self._jobs:

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -191,6 +191,11 @@ class UnrealOpenJob(UnrealOpenJobEntity):
 
         self._transfer_files_strategy = TransferProjectFilesStrategy.S3
 
+        # Optional Job description; only emitted into the template when set. Populated from the
+        # UDeadlineCloudJob Details panel's Job Shared Settings (which a pre-GUI hook may have
+        # pre-populated) via :meth:`from_data_asset`.
+        self._description: str = ""
+
     @property
     def job_shared_settings(self) -> JobSharedSettings:
         return self._job_shared_settings
@@ -198,6 +203,30 @@ class UnrealOpenJob(UnrealOpenJobEntity):
     @job_shared_settings.setter
     def job_shared_settings(self, value: JobSharedSettings):
         self._job_shared_settings = value
+
+    @property
+    def description(self) -> str:
+        """Returns the Job description (empty unless set from the Details panel)."""
+        return self._description
+
+    @description.setter
+    def description(self, value: str):
+        self._description = value
+
+    @staticmethod
+    def _description_from_data_asset(shared_settings) -> str:
+        """Return the Details-panel Job description to carry into the Job, or "" if unset.
+
+        The description is set on the panel either by an artist or by a pre-GUI hook
+        (``FDeadlineCloudJobDetails`` runs the hook and writes ``JobSharedSettings.Description``
+        before the artist edits). ``"No description"`` is the C++ default (an unset sentinel), so
+        it maps to ``""``. Shared by both ``from_data_asset`` implementations so the description
+        reaches the template on the render (MRQ) path too — not only the base path.
+        """
+        description = shared_settings.description
+        if description and description != "No description":
+            return description
+        return ""
 
     @classmethod
     def from_data_asset(cls, data_asset: unreal.DeadlineCloudJob) -> "UnrealOpenJob":
@@ -230,6 +259,10 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             ),
         )
 
+        # Carry a non-default Job description from the Details panel into the Job (see
+        # _description_from_data_asset) so it reaches the job template.
+        result_job.description = cls._description_from_data_asset(shared_settings)
+
         for step in result_job._steps:
             step.open_job = result_job
 
@@ -253,6 +286,7 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             "specificationVersion",
             "extensions",
             "name",
+            "description",
             "parameterDefinitions",
             "jobEnvironments",
             "steps",
@@ -402,6 +436,13 @@ class UnrealOpenJob(UnrealOpenJobEntity):
             "parameterDefinitions": parameter_definitions,
             "steps": [s.build_template() for s in self._steps],
         }
+
+        # Panel/hook description wins; otherwise fall back to a top-level `description` declared in
+        # the user's YAML job template (mirrors the `extensions` read-back below), so a
+        # template-author's description is not silently dropped.
+        description = self._description or self.get_template_object().get("description")
+        if description:
+            template_dict["description"] = description
 
         extension_list = self.get_template_object().get("extensions")
 
@@ -765,9 +806,20 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             and self._mrq_job.preset_overrides is not None
             and self._mrq_job.preset_overrides.job_shared_settings is not None
         ):
+            override_shared_settings = self._mrq_job.preset_overrides.job_shared_settings
             self.job_shared_settings = JobSharedSettings.from_u_deadline_cloud_job_shared_settings(
-                self._mrq_job.preset_overrides.job_shared_settings
+                override_shared_settings
             )
+            # Description lives in the same shared-settings struct. Mirror the name handling below:
+            # the MRQ preset override wins only when it actually carries a description; the default
+            # "No description" sentinel (mapped to "" by _description_from_data_asset) is treated as
+            # "unset" and leaves the underlying data-asset / pre-GUI-hook description in place rather
+            # than clearing it. PresetOverrides is a stale snapshot, so a description set (by an
+            # artist or the pre-GUI hook) after the preset was assigned would otherwise be silently
+            # erased while the name — which uses the same guard — survived.
+            override_description = self._description_from_data_asset(override_shared_settings)
+            if override_description:
+                self._description = override_description
 
         # Job name set order:
         #   0. Job preset override (high priority)
@@ -836,6 +888,10 @@ class RenderUnrealOpenJob(UnrealOpenJob):
                 shared_settings
             ),
         )
+
+        # Carry the panel/hook-set description on the render (MRQ) path too — this override does not
+        # call super().from_data_asset(), so it must apply the shared helper itself.
+        result_job.description = cls._description_from_data_asset(shared_settings)
 
         for step in result_job._steps:
             step.open_job = result_job

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_shared_settings.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_shared_settings.py
@@ -7,8 +7,18 @@ from typing import Any
 class JobSharedSettings:
     """
     OpenJob shared settings representation.
-    Contains SharedSettings model as dictionary built from template and allows to fill its values
+    Contains SharedSettings model as dictionary built from template and allows to fill its values.
+
+    The serialized ``parameter_values`` list is the single source of truth: the typed getters
+    read from it, and :meth:`update_parameter_value` writes to it. This keeps the values a
+    caller mutates (e.g. a pre-GUI submission hook setting ``deadline:priority``) and the
+    values the getters report from ever diverging.
     """
+
+    _INITIAL_STATE_NAME = "deadline:targetTaskRunStatus"
+    _MAX_FAILED_TASKS_COUNT_NAME = "deadline:maxFailedTasksCount"
+    _MAX_RETRIES_PER_TASK_NAME = "deadline:maxRetriesPerTask"
+    _PRIORITY_NAME = "deadline:priority"
 
     def __init__(
         self,
@@ -17,24 +27,19 @@ class JobSharedSettings:
         max_retries_per_task: int = 2,
         priority: int = 50,
     ):
-        self._initial_state = initial_state
-        self._max_failed_tasks_count = max_failed_tasks_count
-        self._max_retries_per_task = max_retries_per_task
-        self._priority = priority
-
         self.parameter_values: list[dict[str, Any]] = [
             {
-                "name": "deadline:targetTaskRunStatus",
+                "name": JobSharedSettings._INITIAL_STATE_NAME,
                 "type": "STRING",
                 "userInterface": {
                     "control": "DROPDOWN_LIST",
                     "label": "Initial State",
                 },
                 "allowedValues": ["READY", "SUSPENDED"],
-                "value": self.get_initial_state(),
+                "value": initial_state,
             },
             {
-                "name": "deadline:maxFailedTasksCount",
+                "name": JobSharedSettings._MAX_FAILED_TASKS_COUNT_NAME,
                 "description": "Maximum number of Tasks that can fail "
                 "before the Job will be marked as failed.",
                 "type": "INT",
@@ -43,10 +48,10 @@ class JobSharedSettings:
                     "label": "Maximum Failed Tasks Count",
                 },
                 "minValue": 0,
-                "value": self.get_max_failed_tasks_count(),
+                "value": max_failed_tasks_count,
             },
             {
-                "name": "deadline:maxRetriesPerTask",
+                "name": JobSharedSettings._MAX_RETRIES_PER_TASK_NAME,
                 "description": "Maximum number of times that a Task will retry "
                 "before it's marked as failed.",
                 "type": "INT",
@@ -55,9 +60,13 @@ class JobSharedSettings:
                     "label": "Maximum Retries Per Task",
                 },
                 "minValue": 0,
-                "value": self.get_max_retries_per_task(),
+                "value": max_retries_per_task,
             },
-            {"name": "deadline:priority", "type": "INT", "value": self.get_priority()},
+            {
+                "name": JobSharedSettings._PRIORITY_NAME,
+                "type": "INT",
+                "value": priority,
+            },
         ]
 
     @classmethod
@@ -86,6 +95,18 @@ class JobSharedSettings:
         """
         return self.parameter_values
 
+    def _get_parameter_value(self, name: str) -> Any:
+        """
+        Return the current value of the shared setting with the given parameter name.
+
+        :param name: Shared setting parameter name, e.g. ``deadline:priority``
+        :type name: str
+
+        :return: The setting's current value
+        :rtype: Any
+        """
+        return next(p["value"] for p in self.parameter_values if p["name"] == name)
+
     def get_initial_state(self) -> str:
         """
         Returns the OpenJob Initial State value
@@ -93,7 +114,7 @@ class JobSharedSettings:
         :return: OpenJob Initial State
         :rtype: str
         """
-        return self._initial_state
+        return self._get_parameter_value(JobSharedSettings._INITIAL_STATE_NAME)
 
     def get_max_failed_tasks_count(self) -> int:
         """
@@ -102,7 +123,7 @@ class JobSharedSettings:
         :return: OpenJob Max Failed Task Count
         :rtype: int
         """
-        return self._max_failed_tasks_count
+        return self._get_parameter_value(JobSharedSettings._MAX_FAILED_TASKS_COUNT_NAME)
 
     def get_max_retries_per_task(self) -> int:
         """
@@ -111,7 +132,7 @@ class JobSharedSettings:
         :return: OpenJob Max Retries Per Task
         :rtype: int
         """
-        return self._max_retries_per_task
+        return self._get_parameter_value(JobSharedSettings._MAX_RETRIES_PER_TASK_NAME)
 
     def get_priority(self) -> int:
         """
@@ -121,4 +142,4 @@ class JobSharedSettings:
         :rtype: int
         """
 
-        return self._priority
+        return self._get_parameter_value(JobSharedSettings._PRIORITY_NAME)

--- a/src/unreal_plugin/Content/Python/init_unreal.py
+++ b/src/unreal_plugin/Content/Python/init_unreal.py
@@ -184,21 +184,38 @@ if remote_execution != "True":
     # These unused imports are REQUIRED!!!
     # Unreal Engine loads any init_unreal.py it finds in its search paths.
     # These imports finish the setup for the plugin.
-    from settings import (
-        DeadlineCloudSettingsLibraryImplementation,  # noqa: F401
-        background_init_s3_client,
-    )
+    # `settings` is imported for background_init_s3_client (used below); importing the module also
+    # registers DeadlineCloudSettingsLibraryImplementation as a side effect.
+    from settings import background_init_s3_client
 
     # UNREAL 5.3 PATCH - Temp fix to maintain support for system default python
     # in Unreal 5.3 (3.9.7)
     _check_patch_pydantic_py397()
 
-    from job_library import DeadlineCloudJobBundleLibraryImplementation  # noqa: F401
-    from open_job_template_api import (  # noqa: F401
-        PythonYamlLibraryImplementation,
-        ParametersConsistencyCheckerImplementation,
-    )
-    import remote_executor  # noqa: F401
+    # These modules register the Python side of their C++ BlueprintImplementableEvent libraries as
+    # an import side effect (the @unreal.uclass()/@unreal.ufunction decorators run on import). Import
+    # them via importlib so no unused names are bound (avoids ruff F401 and CodeQL
+    # py/unused-import / py/unused-global-variable).
+    import importlib
+
+    # job_library, open_job_template_api and remote_executor are load-bearing: open_job_template_api
+    # registers PythonYamlLibrary / ParametersConsistencyChecker (without which UPythonYamlLibrary::Get()
+    # is null across the job/step/environment panels) and remote_executor registers the MRQ remote
+    # executor. A failure importing any of these must stay fatal (loud) — the editor cannot function
+    # without them, so we deliberately do NOT swallow it.
+    for _impl_module in ("job_library", "open_job_template_api", "remote_executor"):
+        importlib.import_module(_impl_module)
+
+    # Only the new pre_gui_hook_library is isolated: a version-skewed C++/Python pair (e.g. the C++
+    # struct a release behind the bundled Python) should degrade just this one feature to a no-op,
+    # not take down the load-bearing registrations above or the init steps below. Log the full
+    # traceback (exc_info) so a missing transitive dep is diagnosable instead of a bare message.
+    try:
+        importlib.import_module("pre_gui_hook_library")
+    except Exception:
+        logger.error(
+            "Failed to register Deadline Cloud module 'pre_gui_hook_library'", exc_info=True
+        )
 
     try:
         background_init_s3_client()

--- a/src/unreal_plugin/Content/Python/pre_gui_hook_library.py
+++ b/src/unreal_plugin/Content/Python/pre_gui_hook_library.py
@@ -1,0 +1,307 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Python implementation of the C++ ``UDeadlineCloudPreGuiHookLibrary`` bridge.
+
+``FDeadlineCloudJobDetails::CustomizeDetails`` (C++) calls ``RunPreGuiHooks`` once per
+``UDeadlineCloudJob`` instance, before the Details-panel field widgets are built, so studios
+can pre-populate the Job Shared Settings from ``DEADLINE_HOOKS_DIR`` pre-GUI hooks — the true
+"pre-GUI" hook point for Unreal.
+
+This runs deadline-cloud's public ``run_pre_gui_hooks`` and routes the merged output through its
+public ``apply_pre_gui_output`` (the same contract the standalone submitter and the other DCCs
+use, so the panel never drifts from it), then marshals the routed result into a
+``FDeadlineCloudPreGuiHookOutput`` UStruct for the C++ side to apply onto the ``UDeadlineCloudJob``.
+The only Unreal-specific step layered on top is mapping the ``deadline:`` shared settings onto the
+struct's typed fields (priority/initial state/max failed/max retries).
+"""
+
+import unreal
+
+from deadline.unreal_logger import get_logger
+
+logger = get_logger()
+
+# deadline: shared-setting keys, each mapped onto a JobSharedSettings field (with a bHas* flag
+# so C++ only overwrites a field the hook actually provided).
+_DEADLINE_PRIORITY = "deadline:priority"
+_DEADLINE_INITIAL_STATE = "deadline:targetTaskRunStatus"
+_DEADLINE_MAX_FAILED = "deadline:maxFailedTasksCount"
+_DEADLINE_MAX_RETRIES = "deadline:maxRetriesPerTask"
+
+# OpenJD template parameters the Unreal submitter resolves from the machine at submit time (project path,
+# extra cmd args, Perforce/UGS settings, conda packages, and the dynamic-chunking frame range). A pre-GUI
+# hook must NOT set these: RenderUnrealOpenJob's _build_parameter_values fills them only when their value is
+# still unset, so a hook-supplied value would suppress the machine-correct one and bake a stale/wrong value
+# onto the submitted job (e.g. a hook that sets Frames makes _build_frames_parameter_value short-circuit,
+# so the MRQ playback range is never computed and the job renders whatever the hook guessed). This is the
+# same protection the (removed) submit-time path enforced via cli_provided_param_names, applied here at the
+# one entry point that remains. Keep in sync with the job-level auto-resolved names in OpenJobParameterNames
+# (deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity).
+_SUBMITTER_MANAGED_PARAMETER_NAMES = frozenset(
+    {
+        "ProjectFilePath",
+        "ProjectName",
+        "ProjectRelativePath",
+        "ExtraCmdArgs",
+        "ExtraCmdArgsFile",
+        "ExecutableRelativePath",
+        "MrqJobDependenciesDescriptor",
+        "CondaPackages",
+        "MarketplacePluginsDir",
+        "PerforceStreamPath",
+        "PerforceChangelistNumber",
+        "PerforceWorkspaceSpecificationTemplate",
+        # Dynamic chunking (TASK_CHUNKING) job-level parameters — derived from the MRQ playback range /
+        # chunking settings; a hook value silently suppresses the machine-computed range.
+        "Frames",
+        "TargetRuntimeSeconds",
+        "RangeConstraint",
+    }
+)
+
+
+def _unreal_hook_confirmation(sources):
+    """Unreal-native confirmation for pre-GUI hooks (Unreal has no Qt).
+
+    Lists the hooks that will run and asks the user through ``unreal.EditorDialog``; returns True
+    to proceed. The detailed per-hook listing relies on deadline-cloud internals
+    (``_generate_hooks_confirmation_message`` and the ``HookManager._original_bundle_dir`` /
+    ``source_label`` attributes). If those private symbols change or disappear within the supported
+    deadline range, we degrade to a generic consent prompt rather than letting the confirmation
+    raise (which would bubble out as a failed hook run and silently skip the hooks) — this dialog
+    remains the informed-consent point for running arbitrary code from ``DEADLINE_HOOKS_DIR``.
+    """
+    try:
+        from deadline.client.job_bundle._hooks import _generate_hooks_confirmation_message
+
+        confirmation_msg = "".join(
+            _generate_hooks_confirmation_message(m.hooks, m._original_bundle_dir, m.source_label)
+            for m in sources
+            if m.hooks
+        )
+    except Exception:
+        logger.warning(
+            "Could not build the detailed pre-GUI hook confirmation message (deadline-cloud "
+            "internals changed?); falling back to a generic consent prompt.",
+            exc_info=True,
+        )
+        source_count = sum(1 for m in sources if getattr(m, "hooks", None))
+        confirmation_msg = (
+            f"{source_count} environment pre-GUI hook source(s) from DEADLINE_HOOKS_DIR "
+            "will run.\n\n"
+        )
+
+    reply = unreal.EditorDialog.show_message(
+        "Job Submission Confirmation",
+        confirmation_msg + "Do you want to run these hooks?",
+        unreal.AppMsgType.YES_NO,
+        unreal.AppReturnType.NO,
+    )
+    return reply == unreal.AppReturnType.YES
+
+
+def _value_type_for(value):
+    """Best-effort parameter value type for a hook-provided value.
+
+    Note: the C++ enum is ``EValueType``, but UnrealEngine's Python bindings strip the leading ``E``
+    from UENUM names, so it is addressed here as ``unreal.ValueType`` (matching the rest of the
+    plugin, e.g. ``open_job_template_api.py``). ``unreal.EValueType`` raises ``AttributeError``.
+    """
+    if isinstance(value, bool):
+        return unreal.ValueType.STRING
+    if isinstance(value, int):
+        return unreal.ValueType.INT
+    if isinstance(value, float):
+        return unreal.ValueType.FLOAT
+    return unreal.ValueType.STRING
+
+
+class _HookSettings:
+    """Assignable ``name`` / ``description`` target for deadline-cloud's ``apply_pre_gui_output``.
+
+    ``apply_pre_gui_output`` is duck-typed: it only needs a settings object with assignable
+    ``name`` / ``description`` and an optional ``parameters`` list. The panel has no job-template
+    parameter list at hook time — the C++ side (``ApplyOutputToJob``) matches parameters onto the
+    job by name afterward — so we expose no ``parameters`` attribute, which makes the router treat
+    every hook parameter as a shared value and route it into our shared-values dict for us to map
+    onto the struct. ``None`` means "the hook did not set this field".
+    """
+
+    def __init__(self):
+        self.name = None
+        self.description = None
+
+
+def _build_output(settings=None, shared_values=None):
+    """Marshal pre-GUI hook results into a ``FDeadlineCloudPreGuiHookOutput`` UStruct.
+
+    ``settings is None`` => a clean no-op output (``ran = False``) so the C++ caller leaves the
+    panel untouched (used for every "no hooks / declined / unavailable / errored" path). Otherwise
+    ``ran = True`` and only the fields the hook actually set (``settings.name``/``description`` and
+    the ``deadline:`` keys in ``shared_values``) are written; other ``shared_values`` become
+    template ``parameters`` or, for unknown ``deadline:`` keys, ``unapplied_keys``.
+
+    Property names: UnrealEngine's Python bindings strip the leading ``b`` from ``bool`` UPROPERTYs,
+    so the C++ ``bRan``/``bHasName``/... fields are addressed here as ``"ran"``/``"has_name"``/...
+    (NOT ``"b_ran"``, which raises "Failed to find property"). Non-bool fields keep their snake_case
+    name (``name``, ``priority``, ``parameters``, ...). This function is the single place that names
+    struct properties, so ``test_pre_gui_hook_library`` can pin them against the real struct.
+    """
+    out = unreal.DeadlineCloudPreGuiHookOutput()
+    if settings is None:
+        out.set_editor_property("ran", False)
+        return out
+
+    out.set_editor_property("ran", True)
+
+    if settings.name is not None:
+        out.set_editor_property("has_name", True)
+        out.set_editor_property("name", str(settings.name))
+    if settings.description is not None:
+        out.set_editor_property("has_description", True)
+        out.set_editor_property("description", str(settings.description))
+
+    template_params = []
+    unapplied = []
+    for key, value in (shared_values or {}).items():
+        if key == _DEADLINE_PRIORITY:
+            out.set_editor_property("has_priority", True)
+            out.set_editor_property("priority", int(value))
+        elif key == _DEADLINE_INITIAL_STATE:
+            out.set_editor_property("has_initial_state", True)
+            out.set_editor_property("initial_state", str(value))
+        elif key == _DEADLINE_MAX_FAILED:
+            out.set_editor_property("has_max_failed_tasks_count", True)
+            out.set_editor_property("maximum_failed_tasks_count", int(value))
+        elif key == _DEADLINE_MAX_RETRIES:
+            out.set_editor_property("has_max_retries_per_task", True)
+            out.set_editor_property("maximum_retries_per_task", int(value))
+        elif key.startswith("deadline:"):
+            # A deadline: property this Unreal panel has no field for.
+            unapplied.append(key)
+        elif key in _SUBMITTER_MANAGED_PARAMETER_NAMES:
+            # Submitter-managed at submit time (ProjectFilePath / ExtraCmdArgs / Perforce / ...); a hook
+            # value here would suppress the machine-resolved one, so route it to unapplied instead of
+            # baking it onto the job. See _SUBMITTER_MANAGED_PARAMETER_NAMES.
+            unapplied.append(key)
+        else:
+            # Job-template parameter — the C++ side applies these onto ParameterDefinition
+            # by name; values that don't match a template param are effectively ignored.
+            pd = unreal.ParameterDefinition()
+            pd.set_editor_property("name", str(key))
+            pd.set_editor_property("type", _value_type_for(value))
+            pd.set_editor_property("value", str(value))
+            template_params.append(pd)
+
+    if template_params:
+        out.set_editor_property("parameters", template_params)
+    if unapplied:
+        out.set_editor_property("unapplied_keys", [str(k) for k in unapplied])
+        logger.warning(
+            "Pre-GUI hook parameter(s) %s have no corresponding Unreal Job Shared Setting "
+            "and were not applied." % ", ".join(sorted(unapplied))
+        )
+
+    return out
+
+
+@unreal.uclass()
+class DeadlineCloudPreGuiHookLibraryImplementation(unreal.DeadlineCloudPreGuiHookLibrary):
+    @unreal.ufunction(override=True)
+    def run_pre_gui_hooks(self, job_name, priority, current_parameters):
+        """Run env-only pre-GUI hooks and return merged output as FDeadlineCloudPreGuiHookOutput.
+
+        ``job_name`` / ``priority`` / ``current_parameters`` carry the job's *current* state into the
+        hook context so hooks can adjust (not just set) it — matching the other DCCs (e.g. "cap
+        priority at 60", "if OutputPath is under /scratch, SUSPEND"). ``current_parameters`` is the
+        list of ``unreal.ParameterDefinition`` the C++ side reads from the job's template params.
+
+        Every failure path (API unavailable, no hooks, user declined, error) returns
+        ``_build_output()`` (``ran = False``) so the C++ caller treats it as a clean no-op.
+        """
+        try:
+            from deadline.client.config import config_file
+            from deadline.client.exceptions import DeadlineOperationCanceled
+            from deadline.client.ui.pre_gui_hooks import (
+                PreGuiHookContext,
+                apply_pre_gui_output,
+                run_pre_gui_hooks,
+            )
+        except Exception:
+            logger.warning(
+                "Pre-GUI hooks unavailable (deadline.client.ui.pre_gui_hooks not importable); "
+                "skipping panel pre-population."
+            )
+            return _build_output()
+
+        # Confirmation gated by settings.auto_accept, matching the submitter and the other DCCs.
+        try:
+            auto_accept = config_file.str2bool(config_file.get_setting("settings.auto_accept"))
+        except Exception:
+            auto_accept = False
+        confirm_callback = None if auto_accept else _unreal_hook_confirmation
+
+        # "Untitled" / "" is the C++ default (unset) Job name; normalize to "" so a hook can tell
+        # "unset" from a real name — matching the ["", "Untitled"] filter in
+        # UnrealOpenJob.from_data_asset. (The final submitted name is resolved later on the MRQ path.)
+        normalized_job_name = "" if str(job_name) in ("", "Untitled") else str(job_name)
+
+        # Current template parameters (unreal.ParameterDefinition list) -> {name: value}, so a hook
+        # can read the job's current parameters and adjust them, matching the other DCCs. Each entry
+        # is read defensively (a malformed one is skipped rather than aborting the whole context).
+        current_params: dict = {}
+        for pd in current_parameters or []:
+            try:
+                current_params[str(pd.get_editor_property("name"))] = str(
+                    pd.get_editor_property("value")
+                )
+            except Exception:
+                continue
+
+        try:
+            merged = run_pre_gui_hooks(
+                PreGuiHookContext(
+                    bundle_dir=None,
+                    job_name=normalized_job_name,
+                    priority=int(priority),
+                    parameters=current_params,
+                    submitter_name="unreal",
+                ),
+                confirm_callback=confirm_callback,
+            )
+        except DeadlineOperationCanceled as e:
+            logger.info(f"Pre-GUI hooks declined by user: {e}")
+            return _build_output()
+        except Exception:
+            import traceback
+
+            logger.warning(
+                f"Pre-GUI hooks failed; leaving panel unchanged:\n{traceback.format_exc()}"
+            )
+            return _build_output()
+
+        if not merged:
+            return _build_output()
+
+        # Route name/description + the template-param vs shared-value split through deadline-cloud's
+        # public apply_pre_gui_output — the same contract the standalone submitter and the other
+        # DCCs use — so this panel never drifts from it. _HookSettings exposes no `parameters` list,
+        # so every hook parameter lands in shared_values; the C++ side (ApplyOutputToJob) matches
+        # template params onto the job by name afterward. _build_output then maps the deadline:
+        # shared settings onto the typed FDeadlineCloudPreGuiHookOutput fields.
+        #
+        # Wrapped so a surprise in the apply/mapping contract (e.g. apply_pre_gui_output requiring a
+        # `parameters` attribute _HookSettings intentionally omits) degrades to a bRan=False no-op
+        # rather than escaping into the C++ BlueprintImplementableEvent caller.
+        try:
+            settings = _HookSettings()
+            shared_values: dict = {}
+            apply_pre_gui_output(merged, settings, shared_values)
+            return _build_output(settings, shared_values)
+        except Exception:
+            import traceback
+
+            logger.warning(
+                "Applying pre-GUI hook output failed; leaving panel unchanged:\n"
+                f"{traceback.format_exc()}"
+            )
+            return _build_output()

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobDetails.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/DeadlineCloudJobSettings/DeadlineCloudJobDetails.cpp
@@ -19,6 +19,7 @@
 #include "PropertyEditorModule.h"
 #include "IDetailsView.h"
 #include "PythonAPILibraries/PythonParametersConsistencyChecker.h"
+#include "PythonAPILibraries/DeadlineCloudPreGuiHookLibrary.h"
 #include "IDetailChildrenBuilder.h"
 #include "Misc/MessageDialog.h"
 #include "DeadlineCloudJobSettings/DeadlineCloudDetailsWidgetsHelper.h"
@@ -27,9 +28,10 @@
 #include "DeadlineCloudJobSettings/DeadlineCloudJobPresetDetailsCustomization.h"
 #include "DeadlineCloudJobSettings/DeadlineCloudEnvironmentOverrideCustomization.h"
 #include "Framework/MetaData/DriverMetaData.h"
+#include "Framework/Notifications/NotificationManager.h"
+#include "Widgets/Notifications/SNotificationList.h"
 
 #define LOCTEXT_NAMESPACE "JobDetails"
-
 
 
 /*Details*/
@@ -46,6 +48,40 @@ void FDeadlineCloudJobDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuil
     TArray<TWeakObjectPtr<UObject>> ObjectsBeingCustomized;
     MainDetailLayout->GetObjectsBeingCustomized(ObjectsBeingCustomized);
     Settings = Cast<UDeadlineCloudJob>(ObjectsBeingCustomized[0].Get());
+
+    /*
+     * Pre-GUI hooks: run environment-sourced pre-GUI hooks once per job instance and apply their
+     * output onto the Job Shared Settings before the panel widgets are built, so studios can
+     * pre-populate the job (name/priority/etc.) the artist is about to see and edit. This is the
+     * true "pre-GUI" hook point for Unreal.
+     *
+     * The bPreGuiHooksApplied guard makes this run at most once per job instance (artist edits on
+     * later panel rebuilds are preserved). We mutate the job here, BEFORE the field widgets below
+     * are built, so they read the hook-populated values directly — no ForceRefreshDetails needed
+     * (and OnPathChanged is not yet bound at this point). Runs on the game thread (Slate).
+     *
+     * The latch is set only INSIDE the Get() success branch: UDeadlineCloudPreGuiHookLibrary::Get()
+     * returns the Python-registered implementation, which only exists once init_unreal.py has
+     * imported pre_gui_hook_library. If the panel is customized before that registration (Get() ==
+     * nullptr), we leave the latch clear so the hooks get another chance on a later panel rebuild
+     * rather than being permanently disabled for this job instance.
+     */
+    if (Settings.IsValid() && !Settings->bPreGuiHooksApplied)
+    {
+        if (UDeadlineCloudPreGuiHookLibrary* HookLibrary = UDeadlineCloudPreGuiHookLibrary::Get())
+        {
+            Settings->bPreGuiHooksApplied = true;
+            // Pass the current job state so hooks can adjust (not just set) it — see RunPreGuiHooks.
+            const FDeadlineCloudPreGuiHookOutput HookOutput =
+                HookLibrary->RunPreGuiHooks(
+                    Settings->JobPresetStruct.JobSharedSettings.Name,
+                    Settings->JobPresetStruct.JobSharedSettings.Priority,
+                    Settings->GetJobParameters());
+            const TArray<FString> Unapplied =
+                UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(Settings.Get(), HookOutput);
+            UDeadlineCloudPreGuiHookLibrary::NotifyUnappliedKeys(Unapplied);
+        }
+    }
 
     TSharedPtr<FDeadlineCloudDetailsWidgetsHelper::SConsistencyWidget> ConsistencyUpdateWidget;
     FParametersConsistencyCheckResult result;

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -19,10 +19,13 @@
 #include "AssetToolsModule.h"
 #include "PackageTools.h"
 #include "PythonAPILibraries/PythonYamlLibrary.h"
+#include "PythonAPILibraries/DeadlineCloudPreGuiHookLibrary.h"
 #include "ObjectTools.h"
 #include "UObject/SavePackage.h"
 #include "Serialization/ArchiveReplaceObjectRef.h"
 #include "Framework/MetaData/DriverMetaData.h"
+#include "Framework/Notifications/NotificationManager.h"
+#include "Widgets/Notifications/SNotificationList.h"
 
 namespace
 {
@@ -30,6 +33,7 @@ namespace
 	{
 		return OverridePath.IsValid() && OverridePath == FSoftObjectPath(SourceObj);
 	}
+
 }
 
 UMoviePipelineDeadlineCloudExecutorJob::UMoviePipelineDeadlineCloudExecutorJob()
@@ -443,7 +447,17 @@ void UMoviePipelineDeadlineCloudExecutorJob::ReloadDataFromJobPreset()
 	JobTemplateOverrides.Parameters = JobPreset->GetParametersDataToOverride();
 	JobTemplateOverrides.StepsOverrides = GetStepsToOverride(JobPreset);
 	JobTemplateOverrides.EnvironmentsOverrides = GetEnvironmentsToOverride(JobPreset);
-	
+
+	// Pre-GUI hooks: inherit the source preset's applied-state alongside the values just copied above.
+	// If a data-asset panel hook already applied to JobPreset (bPreGuiHooksApplied), the values now in
+	// PresetOverrides / JobTemplateOverrides are already hooked, so the MRQ panel must NOT re-run the
+	// hook — otherwise an "adjust" hook (e.g. +10 priority) applies twice for one submission. If the
+	// preset is un-hooked (the common MRQ workflow, or a freshly-picked preset), this re-arms the latch
+	// so the next panel build applies the hook onto the freshly-loaded values; without it, a preset
+	// change would wipe the previously-applied hook values while the latch blocked re-application.
+	bPreGuiHooksApplied = JobPreset->bPreGuiHooksApplied;
+
+
 	UDeadlineCloudJobBundleLibrary* Library = UDeadlineCloudJobBundleLibrary::Get();
 	if (Library)
 	{
@@ -928,6 +942,59 @@ void FMoviePipelineDeadlineCloudExecutorJobCustomization::CustomizeDetails(IDeta
 		{
 			DetailBuilder.ForceRefreshDetails();
 		});
+
+	/*
+	 * Pre-GUI hooks (MRQ path). The MRQ render submission serializes PresetOverrides (a snapshot of the
+	 * data asset taken at preset-assign time), NOT the live data asset, so the pre-GUI hook must apply
+	 * here to reach an MRQ render — running it only on the data-asset editor panel
+	 * (FDeadlineCloudJobDetails) misses this primary submission path. We run env-sourced hooks once per
+	 * executor-job instance and pre-populate PresetOverrides.JobSharedSettings (+ JobTemplateOverrides
+	 * parameters) before the field widgets below are built.
+	 *
+	 * Panel-tied by design: the hook fires when a job's Details panel is built (i.e. the job is opened in
+	 * the MRQ), matching the cross-DCC "pre-GUI" contract that hooks pre-populate the fields the artist
+	 * reviews before editing. A Render (Remote) submits every queue job (remote_executor iterates
+	 * pipeline_queue.get_jobs()), so a job that is never opened is submitted with its un-hooked
+	 * PresetOverrides. This is intentional — there is deliberately no submit-time hook entry point, as a
+	 * submit-time hook could not pre-populate what the artist reviews. The common single-job workflow
+	 * (open the job, review the hooked values, submit) is unaffected.
+	 *
+	 * The bPreGuiHooksApplied latch is set only INSIDE the Get() success branch (the Python impl only
+	 * exists once init_unreal has registered it) and BEFORE RunPreGuiHooks, so a panel rebuild triggered
+	 * while the confirmation modal is up re-enters with the latch already set and cannot double-run.
+	 */
+	// JobPreset must be non-null: we only pre-populate an MRQ job that has a preset (matching the JobPreset
+	// guards on the save/reset handlers); JobTemplateOverrides.Parameters is populated from the preset by
+	// ReloadDataFromJobPreset. A saved queue whose preset asset was deleted/failed to load, or a job
+	// constructed outside a live engine, can reach CustomizeDetails with a null preset.
+	if (MrqJob.IsValid() && MrqJob->JobPreset && !MrqJob->bPreGuiHooksApplied)
+	{
+		if (UDeadlineCloudPreGuiHookLibrary* HookLibrary = UDeadlineCloudPreGuiHookLibrary::Get())
+		{
+			MrqJob->bPreGuiHooksApplied = true;
+			// Pass the current job state (from the preset-override snapshot the MRQ render actually
+			// submits) so hooks can adjust (not just set) it — see RunPreGuiHooks. Seed the parameter
+			// context from JobTemplateOverrides.Parameters — the SAME hidden-item-filtered list
+			// ApplyOutputToParameters writes back to below — so a hook only sees parameters it can
+			// actually override. GetParameterDefinitionWithOverrides() would start from the unfiltered
+			// JobPreset->ParameterDefinition, so a hidden template parameter would be visible in the
+			// context yet absent from the apply list, producing a spurious "not applied" warning.
+			const FDeadlineCloudPreGuiHookOutput HookOutput =
+				HookLibrary->RunPreGuiHooks(
+					MrqJob->PresetOverrides.JobSharedSettings.Name,
+					MrqJob->PresetOverrides.JobSharedSettings.Priority,
+					MrqJob->JobTemplateOverrides.Parameters);
+			if (HookOutput.bRan)
+			{
+				TArray<FString> Unapplied = HookOutput.UnappliedKeys;
+				UDeadlineCloudPreGuiHookLibrary::ApplyOutputToSharedSettings(
+					MrqJob->PresetOverrides.JobSharedSettings, HookOutput, Unapplied);
+				UDeadlineCloudPreGuiHookLibrary::ApplyOutputToParameters(
+					MrqJob->JobTemplateOverrides.Parameters, HookOutput, Unapplied);
+				UDeadlineCloudPreGuiHookLibrary::NotifyUnappliedKeys(Unapplied);
+			}
+		}
+	}
 
 	for (auto& Property : OutMrpCategoryProperties)
 	{

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/PythonAPILibraries/DeadlineCloudPreGuiHookLibrary.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/PythonAPILibraries/DeadlineCloudPreGuiHookLibrary.cpp
@@ -1,0 +1,234 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+
+#include "PythonAPILibraries/DeadlineCloudPreGuiHookLibrary.h"
+
+#include "DeadlineCloudJobSettings/DeadlineCloudJob.h"
+#include "DeadlineCloudJobSettings/DeadlineCloudInputValidationHelper.h"
+#include "Framework/Notifications/NotificationManager.h"
+#include "Widgets/Notifications/SNotificationList.h"
+
+namespace
+{
+	// deadline:targetTaskRunStatus allowed values, matching the panel dropdown (GetJobInitialStateOptions)
+	// and the Python JobSharedSettings allowedValues ["READY", "SUSPENDED"] (unreal_open_job_shared_settings.py).
+	bool IsAllowedInitialState(const FString& Value)
+	{
+		// FString::operator== is case-INSENSITIVE in UE, but deadline:targetTaskRunStatus is
+		// case-sensitive on the openjd side (allowedValues ["READY","SUSPENDED"], see
+		// unreal_open_job_shared_settings.py). Compare case-sensitively so a lowercase hook typo
+		// (e.g. "ready") is rejected + surfaced here rather than failing at submission.
+		return Value.Equals(TEXT("READY"), ESearchCase::CaseSensitive)
+			|| Value.Equals(TEXT("SUSPENDED"), ESearchCase::CaseSensitive);
+	}
+
+	// Whether a hook-supplied string parses as the parameter's declared OpenJD type. Non-numeric types
+	// (STRING/PATH/...) accept anything; INT/FLOAT must actually parse so a typo in a hook value fails at
+	// hook time (visibly) rather than silently at openjd parse / submission.
+	bool ValueParsesAsType(const FString& Value, EValueType Type)
+	{
+		switch (Type)
+		{
+		case EValueType::INT:
+		{
+			if (Value.IsEmpty())
+			{
+				return false;
+			}
+			int32 Start = (Value[0] == TEXT('-') || Value[0] == TEXT('+')) ? 1 : 0;
+			if (Start >= Value.Len())
+			{
+				return false;
+			}
+			for (int32 i = Start; i < Value.Len(); ++i)
+			{
+				if (!FChar::IsDigit(Value[i]))
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+		case EValueType::FLOAT:
+		{
+			// Not FString::IsNumeric(): it rejects exponent form (e.g. "1e-05", which is how Python
+			// str() renders small/large floats) while accepting "." / "1.". LexTryParseString<double>
+			// matches openjd's numeric parsing (exponent form is valid there).
+			double Parsed = 0.0;
+			return !Value.IsEmpty() && LexTryParseString(Parsed, *Value);
+		}
+		default:
+			return true;
+		}
+	}
+}
+
+void UDeadlineCloudPreGuiHookLibrary::ApplyOutputToSharedSettings(
+	FDeadlineCloudJobSharedSettingsStruct& Shared,
+	const FDeadlineCloudPreGuiHookOutput& Output,
+	TArray<FString>& OutUnappliedKeys)
+{
+	// Only fields the hook actually set (bHas* flags) overwrite the settings, so an empty/partial hook
+	// output leaves everything else untouched. Each value is validated against the same rules the panel
+	// widgets enforce; a value that fails is skipped and recorded in OutUnappliedKeys.
+	if (Output.bHasName)
+	{
+		// JobSharedSettings.Name is declared ValidationType=JobName (DeadlineCloudJob.h) ->
+		// CreateLengthAndIdentifierValidator(1, 64): length 1..64 AND IsValidIdentifier (first char
+		// alpha or '_', remaining alnum or '_'). Validate against the same rule so a hook name the panel
+		// itself would refuse (empty, spaces, hyphens, >64 chars) is skipped + surfaced here rather than
+		// written straight through to fail at submission — matching the description / initial-state /
+		// parameter-type checks.
+		const FString Name = Output.Name.TrimStartAndEnd();
+		FText NameError;
+		if (FDeadlineCloudInputValidationHelper::IsValidLength(Name, 1, 64, NameError)
+			&& FDeadlineCloudInputValidationHelper::IsValidIdentifier(Name, NameError))
+		{
+			Shared.Name = Name;
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning,
+				TEXT("Pre-GUI hook: name '%s' failed validation (%s); skipping."), *Name, *NameError.ToString());
+			OutUnappliedKeys.Add(TEXT("name"));
+		}
+	}
+	if (Output.bHasDescription)
+	{
+		// Validate like the panel's JobDescription widget (length 0..2048, no control chars except
+		// \n\r\t — see DeadlineCloudInputValidationHelper); a value that fails is skipped + surfaced
+		// rather than written straight through to fail at submission.
+		FText DescError;
+		static const TSet<TCHAR> AllowedControl = { TEXT('\n'), TEXT('\r'), TEXT('\t') };
+		if (FDeadlineCloudInputValidationHelper::IsValidLength(Output.Description, 0, 2048, DescError)
+			&& FDeadlineCloudInputValidationHelper::ContainsNoControlCharacters(Output.Description, DescError, AllowedControl))
+		{
+			Shared.Description = Output.Description;
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning,
+				TEXT("Pre-GUI hook: description failed validation (%s); skipping."), *DescError.ToString());
+			OutUnappliedKeys.Add(TEXT("description"));
+		}
+	}
+	if (Output.bHasPriority)
+	{
+		// Panel SpinBox clamps to [0, 100] (ClampMin/ClampMax); mirror that rather than reject.
+		Shared.Priority = FMath::Clamp(Output.Priority, 0, 100);
+	}
+	if (Output.bHasInitialState)
+	{
+		if (IsAllowedInitialState(Output.InitialState))
+		{
+			Shared.InitialState = Output.InitialState;
+		}
+		else
+		{
+			// Free-form string here, but only READY/SUSPENDED are valid; an out-of-range value would show
+			// as an invalid dropdown entry and fail at submission, so skip + surface it instead.
+			UE_LOG(LogTemp, Warning,
+				TEXT("Pre-GUI hook: ignoring invalid InitialState '%s' (expected READY or SUSPENDED)."),
+				*Output.InitialState);
+			OutUnappliedKeys.Add(TEXT("deadline:targetTaskRunStatus"));
+		}
+	}
+	if (Output.bHasMaxFailedTasksCount)
+	{
+		// Panel SpinBox clamps to >= 0 (ClampMin=0).
+		Shared.MaximumFailedTasksCount = FMath::Max(0, Output.MaximumFailedTasksCount);
+	}
+	if (Output.bHasMaxRetriesPerTask)
+	{
+		Shared.MaximumRetriesPerTask = FMath::Max(0, Output.MaximumRetriesPerTask);
+	}
+}
+
+void UDeadlineCloudPreGuiHookLibrary::ApplyOutputToParameters(
+	TArray<FParameterDefinition>& Parameters,
+	const FDeadlineCloudPreGuiHookOutput& Output,
+	TArray<FString>& OutUnappliedKeys)
+{
+	if (Output.Parameters.Num() == 0)
+	{
+		return;
+	}
+
+	// Apply hook-supplied template parameters onto the existing parameter definitions in place, matching
+	// by name. Names with no matching parameter are ignored (same as the submitter). A value that does not
+	// parse as the parameter's declared type is skipped + recorded rather than written unparseable.
+	for (const FParameterDefinition& HookParam : Output.Parameters)
+	{
+		bool bMatchedByName = false;
+		for (FParameterDefinition& JobParam : Parameters)
+		{
+			// Case-SENSITIVE (FString::operator== is not): match the Python submitter's exact-name
+			// matching so a hook key "outputpath" does not clobber template parameter "OutputPath".
+			if (JobParam.Name.Equals(HookParam.Name, ESearchCase::CaseSensitive))
+			{
+				bMatchedByName = true;
+				if (ValueParsesAsType(HookParam.Value, JobParam.Type))
+				{
+					JobParam.Value = HookParam.Value;
+				}
+				else
+				{
+					UE_LOG(LogTemp, Warning,
+						TEXT("Pre-GUI hook: parameter '%s' value '%s' does not parse as its declared type; skipping."),
+						*HookParam.Name, *HookParam.Value);
+					OutUnappliedKeys.Add(HookParam.Name);
+				}
+				break;
+			}
+		}
+		if (!bMatchedByName)
+		{
+			// A hook parameter that matches no job template parameter cannot be applied. Surface it
+			// (rather than dropping it silently) so a hook that set something with no effect is
+			// visible to the artist — the exact case the UnappliedKeys notification exists for.
+			UE_LOG(LogTemp, Warning,
+				TEXT("Pre-GUI hook: parameter '%s' matches no job template parameter; skipping."),
+				*HookParam.Name);
+			OutUnappliedKeys.Add(HookParam.Name);
+		}
+	}
+}
+
+TArray<FString> UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(
+	UDeadlineCloudJob* Job, const FDeadlineCloudPreGuiHookOutput& Output)
+{
+	if (!Job || !Output.bRan)
+	{
+		return TArray<FString>();
+	}
+
+	// Start from the keys the Python side already couldn't map onto a field (Output.UnappliedKeys), then
+	// let the apply helpers append any values they reject during validation, so the caller can surface the
+	// full set to the artist.
+	TArray<FString> Unapplied = Output.UnappliedKeys;
+
+	ApplyOutputToSharedSettings(Job->JobPresetStruct.JobSharedSettings, Output, Unapplied);
+
+	if (Output.Parameters.Num() > 0)
+	{
+		TArray<FParameterDefinition> JobParams = Job->GetJobParameters();
+		ApplyOutputToParameters(JobParams, Output, Unapplied);
+		Job->SetJobParameters(JobParams);
+	}
+
+	return Unapplied;
+}
+
+void UDeadlineCloudPreGuiHookLibrary::NotifyUnappliedKeys(const TArray<FString>& UnappliedKeys)
+{
+	if (UnappliedKeys.Num() == 0)
+	{
+		return;
+	}
+	const FString Joined = FString::Join(UnappliedKeys, TEXT(", "));
+	FNotificationInfo Info(FText::FromString(FString::Printf(
+		TEXT("Deadline Cloud pre-GUI hook: %d value(s) not applied (no matching field or failed validation): %s"),
+		UnappliedKeys.Num(), *Joined)));
+	Info.ExpireDuration = 8.0f;
+	FSlateNotificationManager::Get().AddNotification(Info);
+}

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_PreGuiHook.spec.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_PreGuiHook.spec.cpp
@@ -1,0 +1,407 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#pragma once
+#include "Misc/AutomationTest.h"
+#include "CoreMinimal.h"
+#include "UObject/UObjectGlobals.h"
+#include "DeadlineCloudJobSettings/DeadlineCloudJob.h"
+#include "PythonAPILibraries/PythonYamlLibrary.h"
+#include "PythonAPILibraries/DeadlineCloudPreGuiHookLibrary.h"
+
+
+BEGIN_DEFINE_SPEC(FDeadlinePluginPreGuiHookSpec, "DeadlineCloud.Offline",
+    EAutomationTestFlags::ProductFilter | EAutomationTestFlags::EditorContext);
+
+UDeadlineCloudJob* CreatedJobDataAsset;
+
+END_DEFINE_SPEC(FDeadlinePluginPreGuiHookSpec);
+
+void FDeadlinePluginPreGuiHookSpec::Define()
+{
+    // These specs exercise UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob directly — the pure
+    // C++ mapping that the Details-panel customization runs after the Python BIE returns a merged
+    // hook output. The Python RunPreGuiHooks BIE (which needs a live interpreter + hook scripts)
+    // is out of scope here; deadline-cloud owns hook execution and the Python impl is unit-tested
+    // separately. The design's D1 apply-once guard (bPreGuiHooksApplied) is a plain bool on the
+    // job, so it is validated here too.
+    Describe("FPreGuiHookApplyOutput", [this]()
+        {
+            BeforeEach([this]()
+                {
+                    CreatedJobDataAsset = NewObject<UDeadlineCloudJob>();
+                });
+            AfterEach([this]()
+                {
+                    CreatedJobDataAsset = nullptr;
+                });
+
+            It("does nothing when the hook did not run (bRan=false)", [this]()
+                {
+                    FDeadlineCloudJobSharedSettingsStruct& Shared =
+                        CreatedJobDataAsset->JobPresetStruct.JobSharedSettings;
+                    const FString OriginalName = Shared.Name;
+                    const int32 OriginalPriority = Shared.Priority;
+
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = false;
+                    // Even with fields flagged as present, bRan=false must be a no-op.
+                    Output.bHasName = true;
+                    Output.Name = TEXT("ShouldNotApply");
+                    Output.bHasPriority = true;
+                    Output.Priority = 99;
+
+                    UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+
+                    TestEqual("Name unchanged when hook did not run", Shared.Name, OriginalName);
+                    TestEqual("Priority unchanged when hook did not run", Shared.Priority, OriginalPriority);
+                });
+
+            It("applies only the shared-setting fields the hook actually set", [this]()
+                {
+                    FDeadlineCloudJobSharedSettingsStruct& Shared =
+                        CreatedJobDataAsset->JobPresetStruct.JobSharedSettings;
+                    const FString OriginalDescription = Shared.Description;
+                    const int32 OriginalMaxRetries = Shared.MaximumRetriesPerTask;
+
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = true;
+                    Output.bHasName = true;
+                    Output.Name = TEXT("HookedName");
+                    Output.bHasPriority = true;
+                    Output.Priority = 88;
+                    Output.bHasInitialState = true;
+                    Output.InitialState = TEXT("SUSPENDED");
+                    Output.bHasMaxFailedTasksCount = true;
+                    Output.MaximumFailedTasksCount = 7;
+                    // Description + MaximumRetriesPerTask intentionally left unset (bHas* = false).
+
+                    UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+
+                    TestEqual("Name applied", Shared.Name, FString(TEXT("HookedName")));
+                    TestEqual("Priority applied", Shared.Priority, 88);
+                    TestEqual("InitialState applied", Shared.InitialState, FString(TEXT("SUSPENDED")));
+                    TestEqual("MaximumFailedTasksCount applied", Shared.MaximumFailedTasksCount, 7);
+                    // Fields the hook did not set must be preserved.
+                    TestEqual("Description preserved", Shared.Description, OriginalDescription);
+                    TestEqual("MaximumRetriesPerTask preserved", Shared.MaximumRetriesPerTask, OriginalMaxRetries);
+                });
+
+            It("applies hook template parameters onto matching definitions by name", [this]()
+                {
+                    // Seed two parameters on the job.
+                    TArray<FParameterDefinition> Params;
+                    FParameterDefinition ParamA;
+                    ParamA.Name = TEXT("OutputPath");
+                    ParamA.Type = EValueType::STRING;
+                    ParamA.Value = TEXT("/original/path");
+                    Params.Add(ParamA);
+                    FParameterDefinition ParamB;
+                    ParamB.Name = TEXT("FrameRange");
+                    ParamB.Type = EValueType::STRING;
+                    ParamB.Value = TEXT("1-10");
+                    Params.Add(ParamB);
+                    CreatedJobDataAsset->SetJobParameters(Params);
+
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = true;
+                    // One matching (OutputPath) and one non-matching (Nonexistent) hook param.
+                    FParameterDefinition HookMatch;
+                    HookMatch.Name = TEXT("OutputPath");
+                    HookMatch.Type = EValueType::STRING;
+                    HookMatch.Value = TEXT("/hooked/path");
+                    Output.Parameters.Add(HookMatch);
+                    FParameterDefinition HookMiss;
+                    HookMiss.Name = TEXT("Nonexistent");
+                    HookMiss.Type = EValueType::STRING;
+                    HookMiss.Value = TEXT("ignored");
+                    Output.Parameters.Add(HookMiss);
+
+                    UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+
+                    const TArray<FParameterDefinition> Result = CreatedJobDataAsset->GetJobParameters();
+                    TestEqual("Parameter count unchanged (no params added)", Result.Num(), 2);
+
+                    FString OutputPathValue;
+                    FString FrameRangeValue;
+                    for (const FParameterDefinition& P : Result)
+                    {
+                        if (P.Name == TEXT("OutputPath")) { OutputPathValue = P.Value; }
+                        else if (P.Name == TEXT("FrameRange")) { FrameRangeValue = P.Value; }
+                    }
+                    TestEqual("Matching parameter overwritten", OutputPathValue, FString(TEXT("/hooked/path")));
+                    TestEqual("Non-matching parameter untouched", FrameRangeValue, FString(TEXT("1-10")));
+                });
+
+            It("is safe to call with a null job", [this]()
+                {
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = true;
+                    Output.bHasName = true;
+                    Output.Name = TEXT("Whatever");
+
+                    // Must not crash / dereference null.
+                    UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(nullptr, Output);
+                    TestTrue("Null job handled without crashing", true);
+                });
+
+            It("guards apply-once via bPreGuiHooksApplied (D1)", [this]()
+                {
+                    // The Details customization only runs hooks when bPreGuiHooksApplied is false,
+                    // then latches it true so artist edits on later panel rebuilds are preserved.
+                    TestFalse("Guard starts false on a fresh job", CreatedJobDataAsset->bPreGuiHooksApplied);
+
+                    // Simulate the first CustomizeDetails pass.
+                    if (!CreatedJobDataAsset->bPreGuiHooksApplied)
+                    {
+                        CreatedJobDataAsset->bPreGuiHooksApplied = true;
+                        FDeadlineCloudPreGuiHookOutput Output;
+                        Output.bRan = true;
+                        Output.bHasName = true;
+                        Output.Name = TEXT("FirstPass");
+                        UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+                    }
+                    TestEqual("First pass applied the hook name",
+                        CreatedJobDataAsset->JobPresetStruct.JobSharedSettings.Name, FString(TEXT("FirstPass")));
+
+                    // Simulate an artist edit followed by another CustomizeDetails pass — the guard
+                    // must prevent a second hook application from clobbering the edit.
+                    CreatedJobDataAsset->JobPresetStruct.JobSharedSettings.Name = TEXT("ArtistEdit");
+                    if (!CreatedJobDataAsset->bPreGuiHooksApplied)
+                    {
+                        FDeadlineCloudPreGuiHookOutput Output;
+                        Output.bRan = true;
+                        Output.bHasName = true;
+                        Output.Name = TEXT("SecondPass");
+                        UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+                    }
+                    TestEqual("Artist edit preserved on rebuild (hook did not re-apply)",
+                        CreatedJobDataAsset->JobPresetStruct.JobSharedSettings.Name, FString(TEXT("ArtistEdit")));
+                });
+
+            It("clamps priority to [0,100] and counts to >= 0 (matches panel ClampMin/Max)", [this]()
+                {
+                    FDeadlineCloudJobSharedSettingsStruct& Shared =
+                        CreatedJobDataAsset->JobPresetStruct.JobSharedSettings;
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = true;
+                    Output.bHasPriority = true;
+                    Output.Priority = 250; // over ClampMax
+                    Output.bHasMaxFailedTasksCount = true;
+                    Output.MaximumFailedTasksCount = -5; // under ClampMin
+
+                    UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+
+                    TestEqual("Priority clamped to 100", Shared.Priority, 100);
+                    TestEqual("MaximumFailedTasksCount clamped to 0", Shared.MaximumFailedTasksCount, 0);
+                });
+
+            It("skips an invalid InitialState and reports it as unapplied", [this]()
+                {
+                    FDeadlineCloudJobSharedSettingsStruct& Shared =
+                        CreatedJobDataAsset->JobPresetStruct.JobSharedSettings;
+                    const FString OriginalState = Shared.InitialState;
+
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = true;
+                    Output.bHasInitialState = true;
+                    Output.InitialState = TEXT("PAUSED"); // not READY/SUSPENDED
+
+                    const TArray<FString> Unapplied =
+                        UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+
+                    TestEqual("InitialState unchanged when invalid", Shared.InitialState, OriginalState);
+                    TestTrue("Invalid InitialState reported as unapplied",
+                        Unapplied.Contains(TEXT("deadline:targetTaskRunStatus")));
+                });
+
+            It("skips a Name that fails the JobName rule (identifier) and reports it as unapplied", [this]()
+                {
+                    FDeadlineCloudJobSharedSettingsStruct& Shared =
+                        CreatedJobDataAsset->JobPresetStruct.JobSharedSettings;
+                    const FString OriginalName = Shared.Name;
+
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = true;
+                    Output.bHasName = true;
+                    // Spaces are not valid in a JobName (ValidationType=JobName -> IsValidIdentifier); the
+                    // panel would refuse this, so the hook value must be skipped + surfaced, not written.
+                    Output.Name = TEXT("My Shot 01");
+
+                    const TArray<FString> Unapplied =
+                        UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+
+                    TestEqual("Name unchanged when it fails the JobName rule", Shared.Name, OriginalName);
+                    TestTrue("Invalid Name reported as unapplied", Unapplied.Contains(TEXT("name")));
+                });
+
+            It("skips a parameter value that does not parse as its declared type", [this]()
+                {
+                    TArray<FParameterDefinition> Params;
+                    FParameterDefinition IntParam;
+                    IntParam.Name = TEXT("OutputWidth");
+                    IntParam.Type = EValueType::INT;
+                    IntParam.Value = TEXT("1920");
+                    Params.Add(IntParam);
+                    CreatedJobDataAsset->SetJobParameters(Params);
+
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = true;
+                    FParameterDefinition BadValue;
+                    BadValue.Name = TEXT("OutputWidth");
+                    BadValue.Type = EValueType::INT;
+                    BadValue.Value = TEXT("wide"); // not an integer
+                    Output.Parameters.Add(BadValue);
+
+                    const TArray<FString> Unapplied =
+                        UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+
+                    FString ResultValue;
+                    for (const FParameterDefinition& P : CreatedJobDataAsset->GetJobParameters())
+                    {
+                        if (P.Name == TEXT("OutputWidth")) { ResultValue = P.Value; }
+                    }
+                    TestEqual("Unparseable INT value not written", ResultValue, FString(TEXT("1920")));
+                    TestTrue("Bad-type parameter reported as unapplied", Unapplied.Contains(TEXT("OutputWidth")));
+                });
+
+            It("surfaces Python-provided UnappliedKeys back to the caller", [this]()
+                {
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = true;
+                    Output.UnappliedKeys.Add(TEXT("deadline:unknownThing"));
+
+                    const TArray<FString> Unapplied =
+                        UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+
+                    TestTrue("Python unapplied key passed through",
+                        Unapplied.Contains(TEXT("deadline:unknownThing")));
+                });
+
+            It("reports a hook template parameter matching no job parameter as unapplied", [this]()
+                {
+                    TArray<FParameterDefinition> Params;
+                    FParameterDefinition ParamA;
+                    ParamA.Name = TEXT("OutputPath");
+                    ParamA.Type = EValueType::STRING;
+                    ParamA.Value = TEXT("/original/path");
+                    Params.Add(ParamA);
+                    CreatedJobDataAsset->SetJobParameters(Params);
+
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = true;
+                    FParameterDefinition HookMiss;
+                    HookMiss.Name = TEXT("Nonexistent");
+                    HookMiss.Type = EValueType::STRING;
+                    HookMiss.Value = TEXT("ignored");
+                    Output.Parameters.Add(HookMiss);
+
+                    const TArray<FString> Unapplied =
+                        UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+
+                    TestEqual("No parameter added for the unmatched name",
+                        CreatedJobDataAsset->GetJobParameters().Num(), 1);
+                    TestTrue("Unmatched hook parameter reported as unapplied",
+                        Unapplied.Contains(TEXT("Nonexistent")));
+                });
+
+            It("rejects a lowercase InitialState (case-sensitive) and reports it unapplied", [this]()
+                {
+                    FDeadlineCloudJobSharedSettingsStruct& Shared =
+                        CreatedJobDataAsset->JobPresetStruct.JobSharedSettings;
+                    const FString OriginalState = Shared.InitialState;
+
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = true;
+                    Output.bHasInitialState = true;
+                    Output.InitialState = TEXT("ready"); // real word, wrong case (openjd is case-sensitive)
+
+                    const TArray<FString> Unapplied =
+                        UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+
+                    TestEqual("Lowercase InitialState not written", Shared.InitialState, OriginalState);
+                    TestTrue("Lowercase InitialState reported as unapplied",
+                        Unapplied.Contains(TEXT("deadline:targetTaskRunStatus")));
+                });
+
+            It("matches template parameter names case-sensitively", [this]()
+                {
+                    TArray<FParameterDefinition> Params;
+                    FParameterDefinition ParamA;
+                    ParamA.Name = TEXT("OutputPath");
+                    ParamA.Type = EValueType::STRING;
+                    ParamA.Value = TEXT("/original");
+                    Params.Add(ParamA);
+                    CreatedJobDataAsset->SetJobParameters(Params);
+
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = true;
+                    FParameterDefinition HookWrongCase;
+                    HookWrongCase.Name = TEXT("outputpath"); // wrong case, must NOT match OutputPath
+                    HookWrongCase.Type = EValueType::STRING;
+                    HookWrongCase.Value = TEXT("/hooked");
+                    Output.Parameters.Add(HookWrongCase);
+
+                    const TArray<FString> Unapplied =
+                        UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+
+                    FString OutputPathValue;
+                    for (const FParameterDefinition& P : CreatedJobDataAsset->GetJobParameters())
+                    {
+                        if (P.Name == TEXT("OutputPath")) { OutputPathValue = P.Value; }
+                    }
+                    TestEqual("Case-mismatched name did not overwrite", OutputPathValue, FString(TEXT("/original")));
+                    TestTrue("Case-mismatched hook name reported as unapplied",
+                        Unapplied.Contains(TEXT("outputpath")));
+                });
+
+            It("accepts a FLOAT parameter in exponent form (e.g. 1e-05)", [this]()
+                {
+                    TArray<FParameterDefinition> Params;
+                    FParameterDefinition FloatParam;
+                    FloatParam.Name = TEXT("Threshold");
+                    FloatParam.Type = EValueType::FLOAT;
+                    FloatParam.Value = TEXT("0.5");
+                    Params.Add(FloatParam);
+                    CreatedJobDataAsset->SetJobParameters(Params);
+
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = true;
+                    FParameterDefinition HookFloat;
+                    HookFloat.Name = TEXT("Threshold");
+                    HookFloat.Type = EValueType::FLOAT;
+                    HookFloat.Value = TEXT("1e-05"); // Python str(0.00001)
+                    Output.Parameters.Add(HookFloat);
+
+                    const TArray<FString> Unapplied =
+                        UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+
+                    FString ResultValue;
+                    for (const FParameterDefinition& P : CreatedJobDataAsset->GetJobParameters())
+                    {
+                        if (P.Name == TEXT("Threshold")) { ResultValue = P.Value; }
+                    }
+                    TestEqual("Exponent-form FLOAT applied", ResultValue, FString(TEXT("1e-05")));
+                    TestFalse("Exponent-form FLOAT not reported unapplied",
+                        Unapplied.Contains(TEXT("Threshold")));
+                });
+
+            It("skips an over-length description (panel rule) and reports it unapplied", [this]()
+                {
+                    FDeadlineCloudJobSharedSettingsStruct& Shared =
+                        CreatedJobDataAsset->JobPresetStruct.JobSharedSettings;
+                    const FString OriginalDesc = Shared.Description;
+
+                    FDeadlineCloudPreGuiHookOutput Output;
+                    Output.bRan = true;
+                    Output.bHasDescription = true;
+                    Output.Description = FString::ChrN(3000, TEXT('x')); // > 2048 chars (panel-invalid)
+
+                    const TArray<FString> Unapplied =
+                        UDeadlineCloudPreGuiHookLibrary::ApplyOutputToJob(CreatedJobDataAsset, Output);
+
+                    TestEqual("Over-length description not written", Shared.Description, OriginalDesc);
+                    TestTrue("Over-length description reported as unapplied",
+                        Unapplied.Contains(TEXT("description")));
+                });
+        });
+}

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudJob.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudJob.h
@@ -272,6 +272,24 @@ public:
 
 	FHiddenItemsManager& GetHiddenManager() { return HiddenVarsManager; }
 	const FHiddenItemsManager& GetHiddenManager() const { return HiddenVarsManager; }
+
+	/**
+	 * Guards the pre-GUI hook so it runs at most once per job instance (not on every
+	 * Details-panel rebuild). Transient: never serialized to the .uasset, so it resets
+	 * on load, and hooks re-run the first time a freshly-loaded job's panel is shown.
+	 * Set by FDeadlineCloudJobDetails::CustomizeDetails.
+	 *
+	 * By design the pre-GUI hook is an AUTHORITATIVE pre-populator: because this guard is transient
+	 * while JobSharedSettings is serialized, a hook re-applies its output the first time a saved
+	 * job's panel is opened in a new editor session (studio policy wins over stale saved values).
+	 * The hook mutates the in-memory data asset only — it does not Modify()/MarkPackageDirty(), so
+	 * it never silently dirties or persists the asset on its own. If a future requirement is instead
+	 * "the artist's saved edits must win", persist this guard (and call Modify()) rather than leaving
+	 * it transient.
+	 */
+	UPROPERTY(Transient)
+	bool bPreGuiHooksApplied = false;
+
 private:
 
 	UPROPERTY()

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.h
@@ -158,7 +158,19 @@ public:
     FJobTemplateOverrides JobTemplateOverrides = FJobTemplateOverrides();
 
     void JobPresetChanged();
-    
+
+    /**
+     * Guards the pre-GUI hook so it runs at most once per executor-job instance (not on every MRQ Details
+     * rebuild), pre-populating PresetOverrides.JobSharedSettings before the artist edits them. Transient:
+     * never serialized, so it resets on load and the hook re-runs the first time a job's MRQ panel is shown
+     * in a new editor session. This is the MRQ counterpart of UDeadlineCloudJob::bPreGuiHooksApplied — the
+     * MRQ path submits from PresetOverrides (a snapshot of the data asset taken at preset-assign time), so
+     * the hook must land here to reach an MRQ render submission, not only on the data-asset editor panel.
+     *
+     */
+    UPROPERTY(Transient)
+    bool bPreGuiHooksApplied = false;
+
     static bool IsAssetFileValid(const FString& FilePath);
 	static bool IsAssetDirectoryValid(const FString& DirectoryPath);
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudPreGuiHookLibrary.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/PythonAPILibraries/DeadlineCloudPreGuiHookLibrary.h
@@ -1,0 +1,157 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "PythonAPILibrary.h"
+#include "PythonYamlLibrary.h"
+#include "UObject/Object.h"
+#include "DeadlineCloudPreGuiHookLibrary.generated.h"
+
+class UDeadlineCloudJob;
+// Referenced only by reference in ApplyOutputToSharedSettings below; the full definition
+// (DeadlineCloudJobSettings/DeadlineCloudJob.h) is included in the .cpp.
+struct FDeadlineCloudJobSharedSettingsStruct;
+
+/**
+ * Merged output of a pre-GUI hook run, returned from Python to C++.
+ *
+ * Each scalar field is paired with a bHas* flag so the C++ side only overwrites a
+ * Job Shared Settings field when the hook actually set it (a hook may emit only some keys).
+ * See DeadlineCloudPreGuiHookLibraryImplementation.run_pre_gui_hooks in
+ * Content/Python/pre_gui_hook_library.py.
+ */
+USTRUCT(BlueprintType)
+struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudPreGuiHookOutput
+{
+	GENERATED_BODY()
+
+	/** Whether any pre-GUI hook actually ran and produced output. False => no hooks / declined / API unavailable => the caller must treat this as a no-op. */
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	bool bRan = false;
+
+	/** Job name (deadline-cloud "name"). Applied to JobSharedSettings.Name when bHasName. */
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	bool bHasName = false;
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	FString Name;
+
+	/** Job description (deadline-cloud "description"). */
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	bool bHasDescription = false;
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	FString Description;
+
+	/** deadline:priority */
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	bool bHasPriority = false;
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	int32 Priority = 50;
+
+	/** deadline:targetTaskRunStatus */
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	bool bHasInitialState = false;
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	FString InitialState;
+
+	/** deadline:maxFailedTasksCount */
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	bool bHasMaxFailedTasksCount = false;
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	int32 MaximumFailedTasksCount = 0;
+
+	/** deadline:maxRetriesPerTask */
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	bool bHasMaxRetriesPerTask = false;
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	int32 MaximumRetriesPerTask = 2;
+
+	/** Template parameters the hook set (name -> value); applied onto the job's ParameterDefinition in place. */
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	TArray<FParameterDefinition> Parameters;
+
+	/** Hook parameter names that matched neither a template parameter nor a shared setting; surfaced to the user as a warning. */
+	UPROPERTY(BlueprintReadWrite, Category = "Deadline Cloud")
+	TArray<FString> UnappliedKeys;
+};
+
+/**
+ * Deadline Cloud "pre-GUI hook" function library. Intended to be implemented in Python:
+ * Content/Python/pre_gui_hook_library.py -> DeadlineCloudPreGuiHookLibraryImplementation.
+ *
+ * The C++ Details customization (FDeadlineCloudJobDetails) calls RunPreGuiHooks once per
+ * UDeadlineCloudJob instance, before the panel field widgets are populated, so studios can
+ * pre-populate Job Shared Settings from DEADLINE_HOOKS_DIR pre-GUI hooks.
+ */
+UCLASS()
+class UNREALDEADLINECLOUDSERVICE_API UDeadlineCloudPreGuiHookLibrary
+	: public UObject, public TPythonAPILibraryBase<UDeadlineCloudPreGuiHookLibrary>
+{
+	GENERATED_BODY()
+
+public:
+	/**
+	 * Run environment-sourced pre-GUI hooks and return their merged output.
+	 * Confirmation (gated by settings.auto_accept) is handled inside the Python implementation.
+	 * The current job state is passed into the hook context so hooks can *adjust* (not just set) it
+	 * — matching the other DCCs, where a hook can read the current priority/parameters (e.g. "cap
+	 * priority at 60", "if OutputPath is under /scratch, SUSPEND").
+	 * @param JobName Current job name, passed to hooks as the initial jobName in the hook context.
+	 * @param Priority Current job priority, passed to hooks as the initial priority in the context.
+	 * @param CurrentParameters Current job template parameters (name/value/type), passed to hooks as
+	 *        the initial parameters dict in the context.
+	 * @return Merged pre-GUI output; bRan=false means no-op (no hooks / declined / unavailable).
+	 */
+	UFUNCTION(BlueprintImplementableEvent)
+	FDeadlineCloudPreGuiHookOutput RunPreGuiHooks(
+		const FString& JobName,
+		int32 Priority,
+		const TArray<FParameterDefinition>& CurrentParameters);
+
+	/**
+	 * Apply merged pre-GUI hook output onto a job's Job Shared Settings + parameter definitions.
+	 * Only fields the hook actually set (bHas* flags) overwrite the job; if Output.bRan is false
+	 * this is a no-op. Static (no Python impl needed) so the C++ Details customization and the
+	 * automation spec share one code path. Thin wrapper over ApplyOutputToSharedSettings +
+	 * ApplyOutputToParameters for the UDeadlineCloudJob data-asset panel path.
+	 * @return the keys the hook set that were not applied (unmappable or failed validation), so the
+	 *         caller can surface them to the artist. Empty when everything applied (or Output.bRan false).
+	 */
+	static TArray<FString> ApplyOutputToJob(UDeadlineCloudJob* Job, const FDeadlineCloudPreGuiHookOutput& Output);
+
+	/**
+	 * Apply the hook's shared-setting fields onto a FDeadlineCloudJobSharedSettingsStruct, validating
+	 * each against the same rules the panel widgets enforce (Name = JobName rule: length 1..64 +
+	 * IsValidIdentifier; Description length 0..2048 + no control chars; Priority clamped to [0,100];
+	 * counts >= 0; InitialState restricted to READY/SUSPENDED). A value that fails validation is skipped
+	 * and its key appended to OutUnappliedKeys instead of being written (so a malformed hook degrades visibly
+	 * at hook time rather than at submission). Shared by the data-asset job and the MRQ executor job's
+	 * PresetOverrides, so both submission surfaces enforce identical protection.
+	 */
+	static void ApplyOutputToSharedSettings(
+		FDeadlineCloudJobSharedSettingsStruct& Shared,
+		const FDeadlineCloudPreGuiHookOutput& Output,
+		TArray<FString>& OutUnappliedKeys);
+
+	/**
+	 * Apply the hook's template parameters onto ParameterDefinitions in place, matching by name.
+	 * A hook value that does not parse as the parameter's declared EValueType (e.g. "wide" for an INT)
+	 * is skipped and its name appended to OutUnappliedKeys rather than baked onto the job to fail later
+	 * at submission. Names with no matching parameter are ignored. (Submitter-managed parameters such
+	 * as ProjectFilePath / ExtraCmdArgs / Perforce settings are filtered out on the Python side, in
+	 * pre_gui_hook_library._build_output, so they never reach here.)
+	 */
+	static void ApplyOutputToParameters(
+		TArray<FParameterDefinition>& Parameters,
+		const FDeadlineCloudPreGuiHookOutput& Output,
+		TArray<FString>& OutUnappliedKeys);
+
+	/**
+	 * Surface pre-GUI hook keys that could not be applied (unmappable / failed validation / no matching
+	 * parameter) as a transient editor Slate notification, so a hook that set something which silently
+	 * did not take effect is visible to the artist rather than only logged. Defined once here and called
+	 * from both panel sites (data-asset + MRQ) — a single definition avoids duplicate anonymous-namespace
+	 * copies, which collide as a redefinition when UE's unity build concatenates the two .cpp files.
+	 */
+	static void NotifyUnappliedKeys(const TArray<FString>& UnappliedKeys);
+};

--- a/test/deadline_submitter_for_unreal/unit/test_pre_gui_hook_library.py
+++ b/test/deadline_submitter_for_unreal/unit/test_pre_gui_hook_library.py
@@ -1,0 +1,199 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""Regression tests for the plugin's pre-GUI hook library.
+
+Target: ``src/unreal_plugin/Content/Python/pre_gui_hook_library.py`` ``_build_output`` — the single
+place that names ``FDeadlineCloudPreGuiHookOutput`` UStruct properties. UnrealEngine's Python
+bindings strip the leading ``b`` from ``bool`` UPROPERTYs (``bRan`` -> ``ran``), and a wrong name
+(e.g. ``b_ran``) raises "Failed to find property" only inside a real editor. Because these unit
+tests mock ``unreal`` (a plain ``MagicMock`` would silently accept any name), we install a STRICT
+fake output struct that rejects any name not on the real struct — so a property-naming regression
+(the ``b_ran`` bug that made the pre-GUI hook silently no-op in the live panel) fails here.
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# FDeadlineCloudPreGuiHookOutput's real UE Python property names (bool UPROPERTYs lose the leading
+# 'b'). Mirrors DeadlineCloudPreGuiHookLibrary.h; verified against UE 5.7's get_editor_property.
+_VALID_OUTPUT_PROPS = {
+    "ran",
+    "has_name",
+    "name",
+    "has_description",
+    "description",
+    "has_priority",
+    "priority",
+    "has_initial_state",
+    "initial_state",
+    "has_max_failed_tasks_count",
+    "maximum_failed_tasks_count",
+    "has_max_retries_per_task",
+    "maximum_retries_per_task",
+    "parameters",
+    "unapplied_keys",
+}
+
+
+class _StrictStruct:
+    """Stand-in for a UStruct that rejects unknown property names, like UE editor-property access."""
+
+    def __init__(self, valid_props):
+        self._valid = valid_props
+        self._props = {}
+
+    def set_editor_property(self, name, value):
+        if name not in self._valid:
+            raise Exception(f"Failed to find property '{name}' for attribute '{name}'")
+        self._props[name] = value
+
+    def get_editor_property(self, name):
+        if name not in self._valid:
+            raise Exception(f"Failed to find property '{name}' for attribute '{name}'")
+        return self._props.get(name)
+
+
+@pytest.fixture
+def pre_gui_hook_library():
+    """Import Content/Python/pre_gui_hook_library.py with ``unreal`` mocked + a strict output struct."""
+    plugin_py = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "src",
+            "unreal_plugin",
+            "Content",
+            "Python",
+        )
+    )
+
+    unreal_mock = MagicMock()
+    # uclass()/ufunction(...) become identity decorators so the real module-level functions and the
+    # implementation class survive import unchanged.
+    unreal_mock.uclass.return_value = lambda cls: cls
+    unreal_mock.ufunction.return_value = lambda fn: fn
+    # The implementation class subclasses this, so it must be a real class, not a MagicMock instance.
+    unreal_mock.DeadlineCloudPreGuiHookLibrary = type(
+        "DeadlineCloudPreGuiHookLibrary", (object,), {}
+    )
+    # Every _build_output() constructs one of these; the strict struct is the regression trap.
+    unreal_mock.DeadlineCloudPreGuiHookOutput.side_effect = lambda: _StrictStruct(
+        _VALID_OUTPUT_PROPS
+    )
+    # ParameterDefinition stays loose — only the output struct's property names are under test.
+    unreal_mock.ParameterDefinition.side_effect = MagicMock
+
+    saved_unreal = sys.modules.get("unreal")
+    saved_mod = sys.modules.pop("pre_gui_hook_library", None)
+    sys.modules["unreal"] = unreal_mock
+    if plugin_py not in sys.path:
+        sys.path.insert(0, plugin_py)
+    try:
+        import pre_gui_hook_library as mod
+
+        yield mod
+    finally:
+        sys.modules.pop("pre_gui_hook_library", None)
+        if saved_mod is not None:
+            sys.modules["pre_gui_hook_library"] = saved_mod
+        if saved_unreal is not None:
+            sys.modules["unreal"] = saved_unreal
+        else:
+            sys.modules.pop("unreal", None)
+
+
+def test_build_output_noop_sets_ran_false(pre_gui_hook_library):
+    # No settings => clean no-op the C++ side treats as "leave the panel alone".
+    out = pre_gui_hook_library._build_output()
+    assert out.get_editor_property("ran") is False
+    assert out.get_editor_property("has_name") is None
+    assert out.get_editor_property("has_priority") is None
+
+
+def test_build_output_maps_name_description_and_shared_settings(pre_gui_hook_library):
+    # This call raises inside _build_output if any set_editor_property name is wrong (the b_ran bug).
+    settings = SimpleNamespace(name="PREGUI RAN", description="populated by pre-GUI hook")
+    shared_values = {
+        "deadline:priority": 88,
+        "deadline:targetTaskRunStatus": "SUSPENDED",
+        "deadline:maxFailedTasksCount": 3,
+        "deadline:maxRetriesPerTask": 5,
+    }
+
+    out = pre_gui_hook_library._build_output(settings, shared_values)
+
+    assert out.get_editor_property("ran") is True
+    assert out.get_editor_property("has_name") is True
+    assert out.get_editor_property("name") == "PREGUI RAN"
+    assert out.get_editor_property("has_description") is True
+    assert out.get_editor_property("description") == "populated by pre-GUI hook"
+    assert out.get_editor_property("has_priority") is True
+    assert out.get_editor_property("priority") == 88
+    assert out.get_editor_property("has_initial_state") is True
+    assert out.get_editor_property("initial_state") == "SUSPENDED"
+    assert out.get_editor_property("has_max_failed_tasks_count") is True
+    assert out.get_editor_property("maximum_failed_tasks_count") == 3
+    assert out.get_editor_property("has_max_retries_per_task") is True
+    assert out.get_editor_property("maximum_retries_per_task") == 5
+
+
+def test_build_output_only_sets_fields_the_hook_provided(pre_gui_hook_library):
+    # Hook set only the name -> priority/description flags stay False (bHas* gating).
+    settings = SimpleNamespace(name="OnlyName", description=None)
+    out = pre_gui_hook_library._build_output(settings, {})
+    assert out.get_editor_property("has_name") is True
+    assert out.get_editor_property("has_description") is None
+    assert out.get_editor_property("has_priority") is None
+
+
+def test_build_output_routes_unknown_deadline_key_to_unapplied(pre_gui_hook_library):
+    settings = SimpleNamespace(name=None, description=None)
+    out = pre_gui_hook_library._build_output(settings, {"deadline:someUnknownSetting": "x"})
+    assert out.get_editor_property("ran") is True
+    assert out.get_editor_property("unapplied_keys") == ["deadline:someUnknownSetting"]
+
+
+def test_build_output_routes_plain_key_to_template_parameter(pre_gui_hook_library):
+    settings = SimpleNamespace(name=None, description=None)
+    out = pre_gui_hook_library._build_output(settings, {"MyTemplateParam": "v"})
+    params = out.get_editor_property("parameters")
+    assert params is not None
+    assert len(params) == 1
+
+
+def test_build_output_routes_submitter_managed_param_to_unapplied(pre_gui_hook_library):
+    # A submitter-managed parameter (resolved from the machine at submit time) must NOT be baked onto the
+    # job by a hook — it is routed to unapplied_keys instead of becoming a template parameter, so it cannot
+    # clobber the machine-resolved value (#8). A non-managed param alongside it still becomes a template
+    # parameter.
+    settings = SimpleNamespace(name=None, description=None)
+    out = pre_gui_hook_library._build_output(
+        settings,
+        {"ProjectFilePath": "C:/stale/wrong.uproject", "MyTemplateParam": "v"},
+    )
+    assert "ProjectFilePath" in list(out.get_editor_property("unapplied_keys"))
+    params = out.get_editor_property("parameters")
+    assert params is not None and len(params) == 1  # only MyTemplateParam became a template param
+
+
+def test_build_output_routes_dynamic_chunking_and_conda_params_to_unapplied(pre_gui_hook_library):
+    # Frames / TargetRuntimeSeconds / RangeConstraint (dynamic chunking) and CondaPackages are resolved by
+    # the submitter at submit time (from the MRQ playback range / UE version) via a fill-if-unset builder;
+    # a hook value would make that builder short-circuit and bake a stale one — e.g. a hook-set Frames
+    # suppresses the computed MRQ range and renders whatever the hook guessed. They must route to
+    # unapplied_keys, not become template parameters. Regression guard that the frozenset stays in sync
+    # with the job-level auto-resolved names in OpenJobParameterNames.
+    for managed in ("Frames", "TargetRuntimeSeconds", "RangeConstraint", "CondaPackages"):
+        assert managed in pre_gui_hook_library._SUBMITTER_MANAGED_PARAMETER_NAMES
+        settings = SimpleNamespace(name=None, description=None)
+        out = pre_gui_hook_library._build_output(settings, {managed: "1-100"})
+        assert managed in list(out.get_editor_property("unapplied_keys")), managed
+        params = out.get_editor_property("parameters")
+        assert params is None or all(
+            p.get_editor_property("name") != managed for p in params
+        ), managed

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_description_in_template.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_description_in_template.py
@@ -1,0 +1,198 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Unit tests for the optional Job ``description`` reaching the built OpenJD template.
+
+``UnrealOpenJob`` carries an optional ``description`` populated from the ``UDeadlineCloudJob``
+Details panel (which a pre-GUI hook may have pre-populated) via :meth:`from_data_asset`. These
+tests cover the DCC-owned piece: a set description flows into the template dict handed to openjd,
+an unset one is omitted, and ``serialize_template`` preserves the key ordering.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from test.deadline_submitter_for_unreal import fixtures
+
+unreal_mock = MagicMock()
+sys.modules["unreal"] = unreal_mock
+
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job import (  # noqa: E402
+    RenderUnrealOpenJob,
+    UnrealOpenJob,
+    UnrealOpenJobParameterDefinition,
+)
+
+_JOB_SHARED_SETTINGS_PATCH = (
+    "deadline.unreal_submitter.unreal_open_job.unreal_open_job."
+    "JobSharedSettings.from_u_deadline_cloud_job_shared_settings"
+)
+
+_TEMPLATE_PATCH = (
+    "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+    "UnrealOpenJobEntity.get_template_object"
+)
+
+
+def _make_job() -> UnrealOpenJob:
+    with patch(_TEMPLATE_PATCH, return_value=fixtures.f_job_template_default()):
+        return UnrealOpenJob(
+            file_path="",
+            name="OriginalName",
+            extra_parameters=[
+                UnrealOpenJobParameterDefinition.from_dict(p)
+                for p in fixtures.f_job_template_default()["parameterDefinitions"]
+            ],
+        )
+
+
+class TestDescriptionInTemplate:
+    """The description set on the Job (from the Details panel) must reach the built template."""
+
+    def test_description_passed_into_built_template(self):
+        """A set description is placed into the dict handed to openjd's parse_model."""
+        job = _make_job()
+        job.description = "rendered by pipeline"
+
+        with (
+            patch(_TEMPLATE_PATCH, return_value=fixtures.f_job_template_default()),
+            patch(
+                "deadline.unreal_submitter.unreal_open_job.unreal_open_job.parse_model"
+            ) as parse_model_mock,
+        ):
+            job._build_template()
+
+        template_dict = parse_model_mock.call_args.kwargs["obj"]
+        assert template_dict["description"] == "rendered by pipeline"
+
+    def test_no_description_omits_key_from_built_template(self):
+        """With no description, no description key is emitted into the template dict."""
+        job = _make_job()
+
+        with (
+            patch(_TEMPLATE_PATCH, return_value=fixtures.f_job_template_default()),
+            patch(
+                "deadline.unreal_submitter.unreal_open_job.unreal_open_job.parse_model"
+            ) as parse_model_mock,
+        ):
+            job._build_template()
+
+        template_dict = parse_model_mock.call_args.kwargs["obj"]
+        assert "description" not in template_dict
+
+    def test_description_survives_serialize_template(self):
+        """serialize_template keeps the description key (it is in the ordered key list)."""
+        import json
+
+        template_json = {
+            "specificationVersion": "jobtemplate-2023-09",
+            "name": "JobA",
+            "description": "kept",
+            "parameterDefinitions": [],
+            "steps": [{"name": "S"}],
+        }
+        template = MagicMock()
+        template.json.return_value = json.dumps(template_json)
+
+        ordered = UnrealOpenJob.serialize_template(template)
+
+        assert ordered["description"] == "kept"
+        # description is ordered right after name
+        keys = list(ordered.keys())
+        assert keys.index("description") == keys.index("name") + 1
+
+
+def _data_asset_with_description(description: str) -> MagicMock:
+    """A minimal DeadlineCloud(Render)Job data-asset mock whose shared settings carry a description."""
+    data_asset = MagicMock()
+    data_asset.steps = []
+    data_asset.environments = []
+    data_asset.get_job_parameters.return_value = []
+    data_asset.path_to_template.file_path = ""
+    shared_settings = data_asset.job_preset_struct.job_shared_settings
+    shared_settings.name = "Untitled"
+    shared_settings.description = description
+    return data_asset
+
+
+class TestDescriptionFromDataAsset:
+    """The shared ``_description_from_data_asset`` maps the panel value, and BOTH from_data_asset
+    paths (base + the RenderUnrealOpenJob override) carry it — the override previously dropped it.
+    """
+
+    def test_helper_maps_default_sentinel_to_empty(self):
+        ss = MagicMock()
+        ss.description = "No description"  # C++ unset sentinel
+        assert UnrealOpenJob._description_from_data_asset(ss) == ""
+
+    def test_helper_maps_empty_to_empty(self):
+        ss = MagicMock()
+        ss.description = ""
+        assert UnrealOpenJob._description_from_data_asset(ss) == ""
+
+    def test_helper_passes_real_description_through(self):
+        ss = MagicMock()
+        ss.description = "populated by pre-GUI hook"
+        assert UnrealOpenJob._description_from_data_asset(ss) == "populated by pre-GUI hook"
+
+    def test_render_from_data_asset_carries_description(self):
+        """RenderUnrealOpenJob.from_data_asset (the MRQ render path) must emit the panel/hook
+        description — its override does not call super(), so it must apply the shared helper."""
+        data_asset = _data_asset_with_description("populated by pre-GUI hook")
+        with (
+            patch(_TEMPLATE_PATCH, return_value=fixtures.f_job_template_default()),
+            patch.object(RenderUnrealOpenJob, "render_steps_count", return_value=1),
+            patch(_JOB_SHARED_SETTINGS_PATCH, return_value=MagicMock()),
+        ):
+            job = RenderUnrealOpenJob.from_data_asset(data_asset)
+
+        assert job.description == "populated by pre-GUI hook"
+
+    def test_render_from_data_asset_drops_default_description(self):
+        data_asset = _data_asset_with_description("No description")
+        with (
+            patch(_TEMPLATE_PATCH, return_value=fixtures.f_job_template_default()),
+            patch.object(RenderUnrealOpenJob, "render_steps_count", return_value=1),
+            patch(_JOB_SHARED_SETTINGS_PATCH, return_value=MagicMock()),
+        ):
+            job = RenderUnrealOpenJob.from_data_asset(data_asset)
+
+        assert job.description == ""
+
+
+def _render_job_with_mrq_override(asset_description: str, override_description: str):
+    """A RenderUnrealOpenJob seeded with ``asset_description`` (as if from the data asset), then
+    handed an MRQ job whose ``preset_overrides`` carry ``override_description``."""
+    with (
+        patch(_TEMPLATE_PATCH, return_value=fixtures.f_job_template_default()),
+        patch(_JOB_SHARED_SETTINGS_PATCH, return_value=MagicMock()),
+    ):
+        job = RenderUnrealOpenJob(file_path="", name="OriginalName")
+        job.description = asset_description
+
+        mrq_job = MagicMock()
+        # Skip the extra-parameter override block; keep the preset name at the unset sentinel so
+        # only the description path is exercised.
+        mrq_job.job_template_overrides.parameters = []
+        mrq_job.preset_overrides.job_shared_settings.name = "Untitled"
+        mrq_job.preset_overrides.job_shared_settings.description = override_description
+
+        job.mrq_job = mrq_job
+    return job
+
+
+class TestDescriptionFromMrqPresetOverride:
+    """On the MRQ render path the description is re-resolved from ``preset_overrides`` alongside
+    priority/name/etc. — but, like the name, only when the override actually carries one. The
+    default "No description" sentinel is treated as "unset" so the underlying data-asset /
+    pre-GUI-hook description is kept rather than cleared (PresetOverrides is a stale snapshot, so a
+    description set after the preset was assigned must not be silently erased)."""
+
+    def test_override_description_replaces_asset_description(self):
+        job = _render_job_with_mrq_override("asset desc", "override desc")
+        assert job.description == "override desc"
+
+    def test_override_default_sentinel_keeps_asset_description(self):
+        # Mirror the name handling: the "No description" sentinel is "unset", so the underlying
+        # data-asset / pre-GUI-hook description survives rather than being cleared.
+        job = _render_job_with_mrq_override("asset desc", "No description")
+        assert job.description == "asset desc"

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_shared_settings.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_shared_settings.py
@@ -29,3 +29,17 @@ class TestJobSharedSettings:
         assert settings.get_max_failed_tasks_count() == u_settings_mock.maximum_failed_tasks_count
         assert settings.get_max_retries_per_task() == u_settings_mock.maximum_retries_per_task
         assert settings.get_priority() == u_settings_mock.priority
+
+    def test_getters_reflect_direct_parameter_values_mutation(self):
+        """parameter_values is the single source of truth: even a caller mutating the
+        serialized list directly (e.g. legacy code) is reflected by the typed getters."""
+        # GIVEN
+        settings = JobSharedSettings()
+
+        # WHEN
+        for parameter_value in settings.parameter_values:
+            if parameter_value["name"] == "deadline:priority":
+                parameter_value["value"] = 75
+
+        # THEN
+        assert settings.get_priority() == 75


### PR DESCRIPTION
Fixes: N/A — feature adoption of the Qt-free pre-GUI hooks API (aws-deadline/deadline-cloud#1255), matching the Maya/Nuke adoptions.

### What was the problem/requirement? (What/Why)

Unreal's Deadline Cloud submitter couldn't run **pre-GUI** submission hooks — the `DEADLINE_HOOKS_DIR` mechanism studios use to pre-populate job fields *before* the artist edits them. deadline-cloud 0.60.1 exposed a Qt-free `deadline.client.ui.pre_gui_hooks` API; this adopts it in Unreal. Unlike Maya/Nuke there is no submit dialog — the fields an artist edits live in the **C++ Slate Details panels**, so the true "pre-GUI" moment is when those panels are built.

### What was the solution? (How)

Pre-GUI hooks run when either Details panel that backs a submission surface is built:

- **Data-asset panel** (`FDeadlineCloudJobDetails`) — the authoring path (`UnrealOpenJobDataAssetSubmitter`).
- **MRQ executor-job panel** (`FMoviePipelineDeadlineCloudExecutorJobCustomization`) — the primary **Movie Render Queue → Render (Remote)** path, which submits a `PresetOverrides` *snapshot*, not the live asset, so a data-asset-only hook would never reach it.

Both apply the merged hook output through shared, unit-tested statics (`ApplyOutputToSharedSettings` / `ApplyOutputToParameters`). A C++→Python bridge (`UDeadlineCloudPreGuiHookLibrary`) routes name/description + the template-param/shared-value split through deadline-cloud's public `apply_pre_gui_output` (the same contract as Maya/Nuke). Key properties:

- **Adjust, not just set** — the bridge passes the job's current priority + parameters into the hook context, so a hook can read-and-modify (e.g. "cap priority at 60").
- **Once per submission** — a transient `bPreGuiHooksApplied` latch, propagated across `ReloadDataFromJobPreset`, prevents double-apply while preserving artist edits.
- **Validated like the panel widgets** — Name (JobName rule: length 1–64 + identifier), Description, Priority `[0,100]`, counts `>= 0`, InitialState `READY`/`SUSPENDED`, and typed template params. Anything that fails validation, is submitter-managed (`ProjectFilePath` / `ExtraCmdArgs` / `Frames` / Perforce / …, which the machine resolves), or matches no field is **skipped and surfaced to the artist** (`UnappliedKeys` notification) rather than silently written to fail at submission.
- **Panel-only** — env-sourced (`DEADLINE_HOOKS_DIR`), gated by `settings.allow_environment_hooks`, confirmation-gated by `settings.auto_accept` via an `unreal.EditorDialog` prompt. No submit-time entry point; headless/panel-less submissions get no pre-GUI run.

### What is the impact of this change?

Studios can pre-populate the Deadline Cloud job an Unreal artist is about to edit from `DEADLINE_HOOKS_DIR` pre-GUI hooks, on **both** the data-asset authoring path and the primary **MRQ Render (Remote)** path. Hooks apply once, are validated before write, and any unapplied keys are shown to the artist. Hooks mutate only in-memory panel state — they do not dirty or auto-save the `.uasset`. No behavior change for the render adaptor or for headless/panel-less paths.

### How was this change tested?

- **Python unit tests** (`test/deadline_submitter_for_unreal/unit/test_pre_gui_hook_library.py`) pin the `FDeadlineCloudPreGuiHookOutput` property names against a strict fake struct (regression-guards the UE bool-UPROPERTY `ran`-not-`b_ran` binding) and the submitter-managed-parameter routing. Full submitter unit suite + `ruff`/`black` clean. **Yes — unit tests were run.**
- **C++ automation spec** — `DeadlineCloud.Offline.FPreGuiHookApplyOutput` (15 cases): `bRan=false` no-op, selective `bHas*` apply, param-by-name, null-safe, apply-once guard, Priority/count clamping, invalid Name / invalid + lowercase InitialState / non-parsing type → unapplied, case-sensitive matching, exponent-form FLOAT accepted, unmatched-name → unapplied, Python `UnappliedKeys` pass-through. It runs headless in the offline UI-automation suite (`scripts/ci/run_unreal_automation_tests.ps1`) and passes on a build-capable UE 5.7.
- **Live on-editor verification** (UE 5.7, freshly compiled plugin) on **both** panels: the confirmation dialog listed the `DEADLINE_HOOKS_DIR` hooks and, on accept, the pre-GUI hook applied **Name = `PREGUI RAN`**, **Description = `populated by pre-GUI hook`**, **Initial State = `READY`**, **Max Failed = `5`**, **Max Retries = `3`**, **Priority = `88`** onto the Job Shared Settings. The hook's received context confirmed the current priority + parameters were passed in (adjust-capable).

**Path B — data-asset panel (`UDeadlineCloudJob`):** Name → `PREGUI RAN`, Priority → `88`.

![Pre-GUI hook applied in the live UDeadlineCloudJob Details panel](https://raw.githubusercontent.com/leon-li-inspire/deadline-cloud-for-unreal-engine/pregui-assets/pregui_hook_proof.png)

**Path A — MRQ executor-job panel (Movie Render Queue → Preset Overrides):** the primary Render (Remote) path, all shared settings populated by the hook.

![Pre-GUI hook applied in the live Movie Render Queue Deadline Cloud panel](https://raw.githubusercontent.com/leon-li-inspire/deadline-cloud-for-unreal-engine/pregui-assets/pregui_mrq_panel_proof.png)

### Have you run a render job successfully with these changes?

Yes. A Deadline Cloud job submitted from the same environment reached `taskRunStatus: SUCCEEDED` on the farm, and a full Movie Render Queue **Render (Remote)** submission (which fires the pre-submission and post-submission `DEADLINE_HOOKS_DIR` hooks) was verified end-to-end.

### Was this change documented?

Yes — docstrings on the new `UDeadlineCloudPreGuiHookLibrary` bridge and `pre_gui_hook_library.py` (including the UE bool-UPROPERTY `ran`-not-`b_ran` naming note), plus inline rationale comments at both panel hook sites.

### Is this a breaking change?

No. The change is additive (new pre-GUI hook points in the Details panels). It does not modify the adaptor's init-data or run-data or any public contract; a job submitted with an older submitter still works with the adaptor.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
