### PR TITLE
refactor!: rename ChunkSize/ChunkId render params to ShotsPerTask/TaskIndex

### DIFF
--- a/docs/design/render-task-partitioning.md
+++ b/docs/design/render-task-partitioning.md
@@ -4,27 +4,22 @@ When you submit a render to AWS Deadline Cloud, the Unreal submitter splits the 
 
 This integration currently supports two submitter-side partitioning modes, described below. They are configured on the Render Step / Render Job parameters and are mutually exclusive — `FramesPerTask` takes precedence when set.
 
-> **Parameter rename in progress.** Two of these parameters are being renamed to avoid colliding with OpenJD's own task-chunking terminology:
+> **Note on terminology — submitter partitioning vs. OpenJD chunking:** OpenJD has its own native [task chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) feature, where the scheduler groups tasks into chunks at dispatch time using a `ChunkSize` parameter and a `CHUNK[INT]` task-parameter type. The two modes below are different: they are **submitter-side** partitioning that decides the task breakdown at submission time, implemented in this integration rather than the OpenJD scheduler.
 >
-> | Old name | New name |
-> |---|---|
-> | `ChunkSize` | `ShotsPerTask` |
-> | `ChunkId` | `TaskIndex` |
+> Support for OpenJD's native chunking is planned as an additional mode. To avoid the name collision ahead of that work, the submitter-side parameters that were previously called `ChunkSize`/`ChunkId` are now `ShotsPerTask`/`TaskIndex`. When OpenJD chunking is added, its `ChunkSize` will be a distinct, separately-documented concept.
 >
-> Both names are referenced throughout this page as **`ChunkSize` / `ShotsPerTask`** and **`ChunkId` / `TaskIndex`**. During the transition the worker adaptor accepts either name, so jobs keep working whichever name your submitter emits. The old names are deprecated and will be removed in a future release.
+> **Compatibility:** templates emitted by submitters ≥ 0.7.0 require adaptor ≥ 0.6.10 on the worker. Older adaptors ignore the new run_data keys and silently render the full sequence instead of the intended partition.
 
-> **Important — `ChunkSize` / `ShotsPerTask` is NOT OpenJD's `ChunkSize`:** OpenJD has its own native [task chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) feature with a `ChunkSize` parameter and a `CHUNK[INT]` task-parameter type, where the scheduler groups tasks into chunks at dispatch time. This integration's parameter is unrelated: it is a **submitter-side** value that decides the shot-per-task breakdown at submission time, implemented in this integration rather than the OpenJD scheduler. The two share the old name but mean different things — and OpenJD's `ChunkSize` is actually closest in meaning to this integration's `FramesPerTask` (frames grouped per task), not to `ChunkSize` / `ShotsPerTask` (shots per task). The rename exists precisely to remove this confusion.
+## Mode 1 — Shots per task (`ShotsPerTask`)
 
-## Mode 1 — Shots per task (`ChunkSize` / `ShotsPerTask`)
+Partitions the **enabled shots** of the Level Sequence. Each task renders up to `ShotsPerTask` consecutive enabled shots.
 
-Partitions the **enabled shots** of the Level Sequence. Each task renders up to `ChunkSize` / `ShotsPerTask` consecutive enabled shots.
+- Task count = ceil(number of enabled shots / `ShotsPerTask`)
+- If `ShotsPerTask` is 0 or negative, it defaults to 1 (one shot per task).
 
-- Task count = ceil(number of enabled shots / `ChunkSize` / `ShotsPerTask`)
-- If the value is 0 or negative, it defaults to 1 (one shot per task).
+Example — a Level Sequence with 10 enabled shots and `ShotsPerTask = 3` produces 4 tasks:
 
-Example — a Level Sequence with 10 enabled shots and `ChunkSize` / `ShotsPerTask` = 3 produces 4 tasks:
-
-| ChunkId / TaskIndex | Shots rendered |
+| TaskIndex | Shots rendered |
 |---|---|
 | 0 | 0, 1, 2 |
 | 1 | 3, 4, 5 |
@@ -35,15 +30,15 @@ Use this mode when your sequence is organized into shots and you want each task 
 
 ## Mode 2 — Frames per task (`FramesPerTask`)
 
-Partitions the **frame range** of the render. Each task renders up to `FramesPerTask` consecutive frames, regardless of shot boundaries. (`FramesPerTask` is not affected by the rename.)
+Partitions the **frame range** of the render. Each task renders up to `FramesPerTask` consecutive frames, regardless of shot boundaries.
 
 - Task count = ceil(total frame range / `FramesPerTask`)
-- `FramesPerTask` takes precedence: if it is set and greater than 0, `ChunkSize` / `ShotsPerTask` is ignored.
+- `FramesPerTask` takes precedence: if it is set and greater than 0, `ShotsPerTask` is ignored.
 - The frame range comes from the MRQ output settings' custom playback range if enabled, otherwise from the Level Sequence's playback range.
 
 Example — a 100-frame sequence with `FramesPerTask = 25` produces 4 tasks:
 
-| ChunkId / TaskIndex | Frames rendered |
+| TaskIndex | Frames rendered |
 |---|---|
 | 0 | 0–24 |
 | 1 | 25–49 |
@@ -52,10 +47,11 @@ Example — a 100-frame sequence with `FramesPerTask = 25` produces 4 tasks:
 
 Use this mode when you want even-sized tasks by frame count — for example to load-balance a long single shot across many workers.
 
-## `ChunkId` / `TaskIndex`
+## `TaskIndex`
 
-In both modes, each generated task is assigned a 0-based `ChunkId` / `TaskIndex` identifying which partition it renders. It is filled in automatically during submission; you do not set it by hand. The adaptor uses it to select the correct shots (Mode 1) or frame window (Mode 2) for each task.
+In both modes, each generated task is assigned a 0-based `TaskIndex` identifying which partition it renders. It is filled in automatically during submission; you do not set it by hand. The adaptor uses `TaskIndex` to select the correct shots (Mode 1) or frame window (Mode 2) for each task.
 
 ### Output file naming
 
 When a render is split across multiple tasks, MRQ writes one output file per task. For image sequences (PNG/EXR/etc.) the default `FileNameFormat` includes `{frame_number}`, so each task's output is already unique. For video containers such as `.mov`, the default format is just `{sequence_name}` and every task would write to the same filename. To disambiguate, add the `{task_index}` token to the MRQ Output Setting's `FileNameFormat` (for example `{sequence_name}_{task_index}`); the submitter substitutes it at render time with a zero-padded per-task index.
+

--- a/docs/plans/render-partitioning-migration-plan.md
+++ b/docs/plans/render-partitioning-migration-plan.md
@@ -7,18 +7,18 @@
 
 This integration splits a Movie Render Queue job into OpenJD tasks using two
 **submitter-side** parameters (see
-[`docs/design/render-task-partitioning.md`](../design/render-task-partitioning.md)):
-`ChunkSize` (shots per task) and `FramesPerTask` (frames per task), with
-`ChunkId` as the per-task index. The run_data keys on the wire are
-`chunk_size`/`chunk_id`.
+[`docs/design/render-task-partitioning.md`](../design/render-task-partitioning.md)).
+The parameters were originally named `ChunkSize` (shots per task) and
+`FramesPerTask` (frames per task), with `ChunkId` as the per-task index;
+the run_data keys on the wire were `chunk_size`/`chunk_id`.
 
 OpenJD has since added a **native, scheduler-level** [task chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md)
 feature with its own `ChunkSize` parameter — closer in meaning to our
-`FramesPerTask` than to our `ChunkSize`. The shared name is misleading and
-blocks adoption of OpenJD's native mode.
+`FramesPerTask` than to our `ChunkSize`. The shared name was misleading and
+blocked adoption of OpenJD's native mode.
 
-The fix is to rename `ChunkSize`→`ShotsPerTask` and `ChunkId`→`TaskIndex`, then
-adopt OpenJD chunking. Because the submitter and adaptor are released
+The fix is to rename `ChunkSize`→`ShotsPerTask` and `ChunkId`→`TaskIndex`,
+then adopt OpenJD chunking. Because the submitter and adaptor are released
 independently (run_data keys are their contract), we use an **expand/contract
 (parallel-change)** rollout.
 
@@ -26,7 +26,8 @@ independently (run_data keys are their contract), we use an **expand/contract
 
 - Submitter writes run_data keys; adaptor reads them. Key names are the contract.
 - **SMF:** adaptor version pinned by `CondaPackages` in the job template
-  (`unrealengine-openjd=0.6.*`).
+  (`unrealengine-openjd=0.6.*`). The glob continues to match the next
+  0.6.x patch automatically.
 - **CMF:** adaptor pip-installed manually, must be kept version-matched to the
   submitter (per `setup-cmf-worker.md`).
 - run_data fields are optional in `run_data.schema.json` (only `handler` is
@@ -36,25 +37,30 @@ independently (run_data keys are their contract), we use an **expand/contract
 
 ## Phases
 
-### Phase 1 — Backwards-compatible adaptor (this change)
+### Phase 1 — Backwards-compatible adaptor ✅ merged (#324)
 
 - Adaptor uses the new names internally, accepts both legacy
   (`chunk_size`/`chunk_id`) and new (`shots_per_task`/`task_index`) run_data
   keys via `_apply_param_aliases` (new wins). Schema permits all four keys.
 - Submitter, templates, and user-facing names are unchanged.
-- **Release:** non-breaking (`feat`).
-- **Exit criterion:** rolled out to fleet (SMF conda channel updated; CMF hosts
-  upgraded). After this, any deployed adaptor handles both old and new templates.
+- **Release:** non-breaking (`feat`) — ships as 0.6.10.
+- **Exit criterion:** rolled out to fleet (SMF conda channel + CMF hosts on
+  0.6.10+). ✅ met. After this, any deployed adaptor handles both old and new
+  templates.
 
-### Phase 2 — Submitter switches to new names (user-facing breaking change)
+### Phase 2 — Submitter switches to new names 🚧 this change
 
 - Rename on submitter side: `OpenJobStepParameterNames`, bundled templates,
-  sample scripts, user docs (work staged on the `RenameChunkSize` branch).
-- Bump `CondaPackages` adaptor pin so SMF workers install a Phase-1+ adaptor.
-- **Release:** breaking (`feat!` + `BREAKING CHANGE:` footer), minor bump
+  sample scripts, user docs.
+- **No `CondaPackages` pin bump.** The existing `unrealengine-openjd=0.6.*`
+  glob already matches 0.6.10 (Phase 1) as the latest 0.6.x, so SMF
+  workers install a Phase-1+ adaptor on the next job execution without an
+  explicit pin change.
+- **Release:** breaking (`refactor!` + `BREAKING CHANGE:` footer), minor bump
   (0.6 → 0.7).
-- **Precondition:** Phase 1 deployed everywhere. A new-names template must
-  never reach a pre-Phase-1 adaptor.
+- **Precondition:** Phase 1 (0.6.10) deployed to the entire fleet. ✅ met.
+  A new-names template must never reach a pre-Phase-1 adaptor — it would fail
+  silently with wrong output.
 - **User migration:** update saved Data Assets, custom templates, and
   submission scripts that reference `ChunkSize`/`ChunkId`; regenerate old job
   bundles. (Find-and-replace details in the Phase-2 PR description.)
@@ -86,13 +92,13 @@ lists.
 ## Sequencing summary
 
 ```
-Phase 1  feat       adaptor accepts both names           (non-breaking)  <-- this PR
-   |       deploy adaptor to all SMF + CMF workers
-Phase 2  feat!      submitter emits new names            (breaking)      next minor
+Phase 1  feat       adaptor accepts both names           (non-breaking)  ✅ merged (#324, 0.6.10)
+   |       fleet rolled out to 0.6.10  ✅
+Phase 2  refactor!  submitter emits new names            (breaking)      <-- this PR (0.7.0)
    |       all submitters updated
-Phase 3  refactor!  adaptor drops legacy-name support     (breaking)
+Phase 3  refactor!  adaptor drops legacy-name support    (breaking)
    |
-Phase 4  feat       adopt OpenJD native chunking          (feature)      independent track
+Phase 4  feat       adopt OpenJD native chunking         (feature)      independent track
 ```
 
 Don't collapse phases: skipping Phase 1's fleet rollout before Phase 2, or

--- a/docs/source/docs_usage/use_cases/create_render_job.rst
+++ b/docs/source/docs_usage/use_cases/create_render_job.rst
@@ -18,15 +18,15 @@ Render Step data asset
 
    a. Handler - specify which UnrealAdaptor’s handler will process the script commands. Handler "render" used for usual pipeline of MRQ  render **Filled automatically during the submission**
    #. QueueManifestPath - path to the serialized MRQ manifest where render job is described. **Filled automatically during the submission**
-   #. TaskChunkSize - Number of shots of Level Sequence to render per OpenJob Task. Set this value according to what number of tasks you want Deadline Cloud to generate
-      For example, if Level Sequence has 10 shots and TaskChunkSize = 3 that means 4 OpenJob Tasks will be introduced:
+   #. ShotsPerTask - Number of shots of Level Sequence to render per OpenJob Task. Set this value according to what number of tasks you want Deadline Cloud to generate
+      For example, if Level Sequence has 10 shots and ShotsPerTask = 3 that means 4 OpenJob Tasks will be introduced:
 
        i. Task 0 - shots 0, 1, 2
        #. Task 1 - shots 3, 4, 5
        #. Task 2 - shots 6, 7, 8
        #. Task 3 - shot 9
 
-   #. TaskChunkId - list of chunk ids. This example will consist of 0, 1, 2, 3 (task ids). **Filled automatically during the submission**
+   #. TaskIndex - list of task indices. This example will consist of 0, 1, 2, 3 (task ids). **Filled automatically during the submission**
 
 
 Launch UE Environment data asset
@@ -63,7 +63,7 @@ Render Job data asset
       of frames.
 
       .. note::
-         When chunking a render across multiple tasks, MRQ writes one output file per task.
+         When a render is split across multiple tasks, MRQ writes one output file per task.
          For image sequences (PNG/EXR/etc.) the default ``FileNameFormat`` already includes
          ``{frame_number}``, so each task's output is unique. For video containers such as
          ``.mov`` the default format is just ``{sequence_name}`` and every task will write to

--- a/docs/user_guide/create-perforce-render-job.md
+++ b/docs/user_guide/create-perforce-render-job.md
@@ -145,7 +145,7 @@ Set up an OpenJD Render Job that orchestrates the entire rendering workflow.
 | `Executable` | Unreal executable name for render node | ❌ | **Configure** - Use default for standard setups |
 | `CondaPackages` | Conda packages needed to render the job | ❌ | **Configure** - Use default for standard setups |
 | `CondaChannels` | Conda channels where packages are stored | ❌ | **Configure** - Use default for standard setups |
-| `ChunkSize` | Number of shots grouped in a single render session | ❌ | **Configure** - Default: 1 (tune for performance) |
+| `ShotsPerTask` | Number of shots grouped in a single render session | ❌ | **Configure** - Default: 1 (tune for performance) |
 | `MarketplacePluginsDir` | Path to engine Marketplace plugins | ✅ | **Leave empty** - Auto-populated |
 
 > **📝 Legend**: ✅ = Auto-populated during submission, ❌ = No Auto-populated
@@ -153,7 +153,7 @@ Set up an OpenJD Render Job that orchestrates the entire rendering workflow.
 **Parameter Configuration Guidelines:**
 - **Auto-populated parameters**: Leave these empty - they're filled automatically during job submission
 - **Manual parameters**: Review defaults and adjust based on your specific requirements
-- **ChunkSize**: Start with 1, increase for better performance with simple shots
+- **ShotsPerTask**: Start with 1, increase for better performance with simple shots
 
 ![Perforce Job Parameter Definition](./images/p4-job-parameter-definition.png)
 
@@ -181,9 +181,9 @@ Set up an OpenJD Render Job that orchestrates the entire rendering workflow.
 
 ### Performance Optimization
 
-**Chunk Size Configuration:**
+**Shots Per Task Configuration:**
 
-| Chunk Size | Use Case | Performance Impact |
+| Shots Per Task | Use Case | Performance Impact |
 |------------|----------|-------------------|
 | 1-2 shots | Complex shots, detailed review needed | Lower throughput, higher quality control |
 | 4-8 shots | Balanced workload, typical projects | Optimal balance of speed and manageability |

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
@@ -299,8 +299,8 @@ class OpenJobStepParameterNames:
 
     :cvar ADAPTOR_HANDLER: Handler name to run the jobs on Adaptor (render/custom)
     :cvar FRAMES_PER_TASK: If set, each task will render this number of frames
-    :cvar TASK_CHUNK_SIZE: Count of the shots per OpenJD Step's Task unless FRAMES_PER_TASK set
-    :cvar TASK_CHUNK_ID: Chunk number that should be rendered at OpenJD Step's Task
+    :cvar SHOTS_PER_TASK: Count of the shots per OpenJD Step's Task unless FRAMES_PER_TASK set
+    :cvar TASK_INDEX: Index of the task (0-based) within the OpenJD Step's parameter space
     """
 
     QUEUE_MANIFEST_PATH = "QueueManifestPath"
@@ -312,5 +312,5 @@ class OpenJobStepParameterNames:
 
     ADAPTOR_HANDLER = "Handler"
     FRAMES_PER_TASK = "FramesPerTask"
-    TASK_CHUNK_SIZE = "ChunkSize"
-    TASK_CHUNK_ID = "ChunkId"
+    SHOTS_PER_TASK = "ShotsPerTask"
+    TASK_INDEX = "TaskIndex"

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
@@ -450,21 +450,22 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
     def mrq_job(self, value: unreal.MoviePipelineExecutorJob):
         self._mrq_job = value
 
-    def _get_chunk_ids_count(self) -> int:
+    def _get_task_count(self) -> int:
         """
-        Get number of shot chunks
-        as count of total number of frames divided by FramesPerTask if set, or
-        as count of enabled shots in level sequence divided by chuck size parameter value.
-        If no chunk size parameter value is 0, return 1
+        Get the number of tasks the render Step will be split into:
+        total number of frames divided by FramesPerTask if set, or
+        the number of enabled shots in the level sequence divided by
+        ShotsPerTask. If ShotsPerTask is <= 0, defaults to 1.
 
         Example:
             - LevelSequence shots: [sh1 - enabled, sh2 - disabled, sh3 - enabled, sh4 - enabled]
-            - ChunkSize: 2
-            - ChunkIds count: 2 (sh1, sh3; sh4)
+            - ShotsPerTask: 2
+            - Task count: 2 (sh1, sh3; sh4)
 
-        :raises ValueError: When no chunk size parameter is set
+        :raises ValueError: When `FramesPerTask` is unset or <= 0 AND
+            `ShotsPerTask` is unset
 
-        :return: ChunkIds count
+        :return: Number of tasks
         :rtype: int
         """
 
@@ -476,8 +477,8 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
         if not self.open_job:
             raise exceptions.OpenJobIsMissingError("Render Job must be provided")
 
-        chunk_size_parameter = self.open_job._find_extra_parameter(
-            parameter_name=OpenJobStepParameterNames.TASK_CHUNK_SIZE, parameter_type="INT"
+        shots_per_task_parameter = self.open_job._find_extra_parameter(
+            parameter_name=OpenJobStepParameterNames.SHOTS_PER_TASK, parameter_type="INT"
         )
         frames_per_task_parameter = self.open_job._find_extra_parameter(
             parameter_name=OpenJobStepParameterNames.FRAMES_PER_TASK, parameter_type="INT"
@@ -503,22 +504,22 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
                 logger.info(
                     f"Level sequence at submission has range {level_sequence.get_playback_range()} ({total_frame_range} frames)"
                 )
-            task_chunk_ids_count = math.ceil(total_frame_range / frames_per_task_parameter.value)
-            return task_chunk_ids_count
-        if chunk_size_parameter is None:
+            task_count = math.ceil(total_frame_range / frames_per_task_parameter.value)
+            return task_count
+        if shots_per_task_parameter is None:
             raise ValueError(
-                f'Render Job\'s parameter "{OpenJobStepParameterNames.TASK_CHUNK_SIZE}"'
+                f'Render Job\'s parameter "{OpenJobStepParameterNames.SHOTS_PER_TASK}"'
                 f' or "{OpenJobStepParameterNames.FRAMES_PER_TASK}" '
                 f"must be provided in extra parameters or template"
             )
 
-        chunk_size = int(chunk_size_parameter.value)
-        if chunk_size <= 0:
-            chunk_size = 1  # by default 1 chunk consist of 1 shot
+        shots_per_task = int(shots_per_task_parameter.value)
+        if shots_per_task <= 0:
+            shots_per_task = 1  # by default each task renders 1 shot
 
-        task_chunk_ids_count = math.ceil(len(enabled_shots) / chunk_size)
+        task_count = math.ceil(len(enabled_shots) / shots_per_task)
 
-        return task_chunk_ids_count
+        return task_count
 
     def _load_level_sequence(self, mrq_job):
         """Load the level sequence asset from the MRQ job."""
@@ -585,12 +586,12 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
                 f"{OpenJobStepParameterNames.MRQ_JOB_CONFIGURATION_PATH})\n"
             )
 
-        task_chunk_id_param_definition = UnrealOpenJobStepParameterDefinition(
-            OpenJobStepParameterNames.TASK_CHUNK_ID,
+        task_index_param_definition = UnrealOpenJobStepParameterDefinition(
+            OpenJobStepParameterNames.TASK_INDEX,
             TaskParameterType.INT.value,
-            [i for i in range(self._get_chunk_ids_count())],
+            [i for i in range(self._get_task_count())],
         )
-        self._update_extra_parameter(task_chunk_id_param_definition)
+        self._update_extra_parameter(task_index_param_definition)
 
         handler_param_definition = UnrealOpenJobStepParameterDefinition(
             OpenJobStepParameterNames.ADAPTOR_HANDLER, TaskParameterType.STRING.value, ["render"]

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
@@ -40,7 +40,7 @@ parameterDefinitions:
   default: deadline-cloud-v2 deadline-cloud
   userInterface: 
    control: LINE_EDIT
-- name: ChunkSize
+- name: ShotsPerTask
   type: INT
   default: 1
 - name: MarketplacePluginsDir

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_step.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_step.yml
@@ -1,7 +1,7 @@
 name: Render
 parameterSpace:
   taskParameterDefinitions:
-  - name: ChunkId
+  - name: TaskIndex
     type: INT
     range: []
   - name: Handler
@@ -22,8 +22,8 @@ script:
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
       frames_per_task: {{Param.FramesPerTask}}
-      chunk_size: {{Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
       output_path: {{Task.Param.OutputPath}}
   actions:
     onRun:

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
@@ -38,7 +38,7 @@ parameterDefinitions:
   default: deadline-cloud-v2 deadline-cloud
   userInterface: 
    control: LINE_EDIT
-- name: ChunkSize
+- name: ShotsPerTask
   type: INT
   default: 1
   userInterface: 

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_step.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_step.yml
@@ -1,7 +1,7 @@
 name: Render
 parameterSpace:
   taskParameterDefinitions:
-  - name: ChunkId
+  - name: TaskIndex
     type: INT
     range: []
   - name: Handler
@@ -19,8 +19,8 @@ script:
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
       frames_per_task: {{Param.FramesPerTask}}
-      chunk_size: {{Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
   actions:
     onRun:
       command: unreal-engine-openjd

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_step_mpq.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_step_mpq.yml
@@ -1,7 +1,7 @@
 name: Render
 parameterSpace:
   taskParameterDefinitions:
-  - name: ChunkId
+  - name: TaskIndex
     type: INT
     range: []
   - name: Handler
@@ -13,7 +13,7 @@ parameterSpace:
   - name: FramesPerTask
     type: INT
     range: [0]
-  - name: ChunkSize
+  - name: ShotsPerTask
     type: INT
     range: [1]
 script:
@@ -24,8 +24,8 @@ script:
     data: |
       handler: {{Task.Param.Handler}}
       queue_path: {{Task.Param.MoviePipelineQueuePath}}
-      chunk_size: {{Task.Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Task.Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
   actions:
     onRun:
       command: unreal-engine-openjd

--- a/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_job.yml
@@ -26,7 +26,7 @@ parameterDefinitions:
 - name: FramesPerTask
   type: INT
   default: 0
-- name: ChunkSize
+- name: ShotsPerTask
   type: INT
   default: 1
 - name: MarketplacePluginsDir

--- a/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_step.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_render_step.yml
@@ -1,7 +1,7 @@
 name: Render
 parameterSpace:
   taskParameterDefinitions:
-  - name: ChunkId
+  - name: TaskIndex
     type: INT
     range: []
   - name: Handler
@@ -22,8 +22,8 @@ script:
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
       frames_per_task: {{Param.FramesPerTask}}
-      chunk_size: {{Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
       output_path: {{Task.Param.OutputPath}}
   actions:
     onRun:

--- a/src/unreal_plugin/Content/Python/submit_actions/p4_render_job_submission.py
+++ b/src/unreal_plugin/Content/Python/submit_actions/p4_render_job_submission.py
@@ -48,8 +48,8 @@ def main():
             steps=[
                 P4RenderUnrealOpenJobStep(
                     extra_parameters=[
-                        # Override ChunkSize parameter value
-                        UnrealOpenJobStepParameterDefinition("ChunkSize", "INT", [10])
+                        # Override ShotsPerTask parameter value
+                        UnrealOpenJobStepParameterDefinition("ShotsPerTask", "INT", [10])
                     ]
                 )
             ],

--- a/src/unreal_plugin/Content/Python/submit_actions/render_job_submission.py
+++ b/src/unreal_plugin/Content/Python/submit_actions/render_job_submission.py
@@ -47,8 +47,8 @@ def main():
             steps=[
                 RenderUnrealOpenJobStep(
                     extra_parameters=[
-                        # Override ChunkSize parameter value
-                        UnrealOpenJobStepParameterDefinition("ChunkSize", "INT", [10])
+                        # Override ShotsPerTask parameter value
+                        UnrealOpenJobStepParameterDefinition("ShotsPerTask", "INT", [10])
                     ]
                 )
             ],

--- a/src/unreal_plugin/Content/Python/submit_actions/ugs_render_job_submission.py
+++ b/src/unreal_plugin/Content/Python/submit_actions/ugs_render_job_submission.py
@@ -48,8 +48,8 @@ def main():
             steps=[
                 UgsRenderUnrealOpenJobStep(
                     extra_parameters=[
-                        # Override ChunkSize parameter value
-                        UnrealOpenJobStepParameterDefinition("ChunkSize", "INT", [10])
+                        # Override ShotsPerTask parameter value
+                        UnrealOpenJobStepParameterDefinition("ShotsPerTask", "INT", [10])
                     ]
                 )
             ],

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step.yml
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step.yml
@@ -10,10 +10,10 @@ parameterSpace:
   - name: FramesPerTask
     type: INT
     range: []
-  - name: ChunkSize
+  - name: ShotsPerTask
     type: INT
     range: []
-  - name: ChunkId
+  - name: TaskIndex
     type: INT
     range: []
 script:
@@ -25,8 +25,8 @@ script:
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
       frames_per_task: {{Task.Param.FramesPerTask}}
-      chunk_size: {{Task.Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Task.Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
   actions:
     onRun:
       command: unreal-engine-openjd

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step_UI.yml
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step_UI.yml
@@ -35,8 +35,8 @@ script:
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
       frames_per_task: {{Task.Param.FramesPerTask}}
-      chunk_size: {{Task.Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Task.Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
   actions:
     onRun:
       command: unreal-engine-openjd

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step_UI_empty.yml
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/render_step_UI_empty.yml
@@ -15,8 +15,8 @@ script:
       handler: {{Task.Param.Handler}}
       queue_manifest_path: {{Task.Param.QueueManifestPath}}
       frames_per_task: {{Task.Param.FramesPerTask}}
-      chunk_size: {{Task.Param.ChunkSize}}
-      chunk_id: {{Task.Param.ChunkId}}
+      shots_per_task: {{Task.Param.ShotsPerTask}}
+      task_index: {{Task.Param.TaskIndex}}
   actions:
     onRun:
       command: unreal-engine-openjd

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_entity_frames_per_task.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_entity_frames_per_task.py
@@ -24,8 +24,8 @@ class TestOpenJobStepParameterNamesFramesPerTask:
             OpenJobStepParameterNames.OUTPUT_PATH,
             OpenJobStepParameterNames.ADAPTOR_HANDLER,
             OpenJobStepParameterNames.FRAMES_PER_TASK,
-            OpenJobStepParameterNames.TASK_CHUNK_SIZE,
-            OpenJobStepParameterNames.TASK_CHUNK_ID,
+            OpenJobStepParameterNames.SHOTS_PER_TASK,
+            OpenJobStepParameterNames.TASK_INDEX,
         ]
 
         # WHEN/THEN
@@ -44,8 +44,8 @@ class TestOpenJobStepParameterNamesFramesPerTask:
             OpenJobStepParameterNames.OUTPUT_PATH,
             OpenJobStepParameterNames.ADAPTOR_HANDLER,
             OpenJobStepParameterNames.FRAMES_PER_TASK,
-            OpenJobStepParameterNames.TASK_CHUNK_SIZE,
-            OpenJobStepParameterNames.TASK_CHUNK_ID,
+            OpenJobStepParameterNames.SHOTS_PER_TASK,
+            OpenJobStepParameterNames.TASK_INDEX,
         ]
 
         # WHEN/THEN - All parameter values should be unique

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step.py
@@ -231,7 +231,7 @@ class TestUnrealOpenJobStep:
 class TestRenderUnrealOpenJobStep:
 
     @pytest.mark.parametrize(
-        "chunk_size, shots_count, expected_chunk_ids",
+        "shots_per_task, shots_count, expected_task_indices",
         [
             (1, 15, [i for i in range(15)]),
             (2, 15, [i for i in range(8)]),
@@ -240,7 +240,7 @@ class TestRenderUnrealOpenJobStep:
             (100000, 100, [0]),
         ],
     )
-    def test__get_chunk_ids_count(self, chunk_size, shots_count, expected_chunk_ids):
+    def test__get_task_count(self, shots_per_task, shots_count, expected_task_indices):
         # GIVEN
         shot_info = []
         for _ in range(shots_count):
@@ -251,29 +251,29 @@ class TestRenderUnrealOpenJobStep:
         mrq_job_mock = MagicMock()
         mrq_job_mock.shot_info = shot_info
 
-        chunk_size_param = UnrealOpenJobParameterDefinition(
-            OpenJobStepParameterNames.TASK_CHUNK_SIZE, "INT", chunk_size
+        shots_per_task_param = UnrealOpenJobParameterDefinition(
+            OpenJobStepParameterNames.SHOTS_PER_TASK, "INT", shots_per_task
         )
-        job = UnrealOpenJob(file_path="", name="TestJob", extra_parameters=[chunk_size_param])
+        job = UnrealOpenJob(file_path="", name="TestJob", extra_parameters=[shots_per_task_param])
 
         render_step = RenderUnrealOpenJobStep(file_path="", mrq_job=mrq_job_mock)
         render_step.open_job = job
         # WHEN
-        ids_count = render_step._get_chunk_ids_count()
+        task_count = render_step._get_task_count()
 
         # THEN
-        assert [i for i in range(ids_count)] == expected_chunk_ids
+        assert [i for i in range(task_count)] == expected_task_indices
 
-    def test__get_chunk_ids_count_no_mrq_job(self):
+    def test__get_task_count_no_mrq_job(self):
         # GIVEN
         render_step = RenderUnrealOpenJobStep(file_path="")
 
         with pytest.raises(exceptions.MrqJobIsMissingError) as exception_info:
-            render_step._get_chunk_ids_count()
+            render_step._get_task_count()
 
         assert str(exception_info.value) == "MRQ Job must be provided"
 
-    def test__get_chunk_ids_count_no_open_job(self):
+    def test__get_task_count_no_open_job(self):
         # GIVEN
         shot_info = []
         for _ in range(2):
@@ -287,11 +287,11 @@ class TestRenderUnrealOpenJobStep:
         render_step = RenderUnrealOpenJobStep(file_path="", mrq_job=mrq_job_mock)
 
         with pytest.raises(exceptions.OpenJobIsMissingError) as exception_info:
-            render_step._get_chunk_ids_count()
+            render_step._get_task_count()
 
         assert str(exception_info.value) == "Render Job must be provided"
 
-    def test__get_chunk_ids_count_no_chunk_size_param(self):
+    def test__get_task_count_no_shots_per_task_param(self):
         # GIVEN
         mrq_job_mock = MagicMock()
         mrq_job_mock.shot_info = []
@@ -302,11 +302,11 @@ class TestRenderUnrealOpenJobStep:
         render_step.open_job = job
         # WHEN
         with pytest.raises(ValueError) as exception_info:
-            render_step._get_chunk_ids_count()
+            render_step._get_task_count()
 
         # THEN
         assert (
-            f'Render Job\'s parameter "{OpenJobStepParameterNames.TASK_CHUNK_SIZE}" or '
+            f'Render Job\'s parameter "{OpenJobStepParameterNames.SHOTS_PER_TASK}" or '
             f'"{OpenJobStepParameterNames.FRAMES_PER_TASK}" '
             f"must be provided" in str(exception_info.value)
         )

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step_frames_per_task.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job_step_frames_per_task.py
@@ -33,7 +33,7 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
             (100, 50, 1),  # More frames per task than total
         ],
     )
-    def test_get_chunk_ids_count_frames_per_task_custom_range(
+    def test_get_task_count_frames_per_task_custom_range(
         self, frames_per_task, total_frames, expected_task_count
     ):
         # GIVEN
@@ -54,7 +54,7 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
 
         with patch.object(render_step, "_load_output_settings", return_value=output_settings_mock):
             # WHEN
-            task_count = render_step._get_chunk_ids_count()
+            task_count = render_step._get_task_count()
 
             # THEN
             assert task_count == expected_task_count
@@ -68,7 +68,7 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
             (50, 10, 30, 1),  # 20 frames (30-10), 50 per task = ceil(0.4) = 1
         ],
     )
-    def test_get_chunk_ids_count_frames_per_task_sequence_range(
+    def test_get_task_count_frames_per_task_sequence_range(
         self, frames_per_task, sequence_start, sequence_end, expected_task_count
     ):
         # GIVEN
@@ -97,21 +97,23 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
         ):
 
             # WHEN
-            task_count = render_step._get_chunk_ids_count()
+            task_count = render_step._get_task_count()
 
             # THEN
             assert task_count == expected_task_count
 
-    def test_get_chunk_ids_count_frames_per_task_precedence_over_chunk_size(self):
-        # GIVEN - Both FramesPerTask and ChunkSize provided, FramesPerTask should take precedence
+    def test_get_task_count_frames_per_task_precedence_over_shots_per_task(self):
+        # GIVEN - Both FramesPerTask and ShotsPerTask provided, FramesPerTask should take precedence
         frames_per_task_param = UnrealOpenJobParameterDefinition(
             OpenJobStepParameterNames.FRAMES_PER_TASK, "INT", 25
         )
-        chunk_size_param = UnrealOpenJobParameterDefinition(
-            OpenJobStepParameterNames.TASK_CHUNK_SIZE, "INT", 5
+        shots_per_task_param = UnrealOpenJobParameterDefinition(
+            OpenJobStepParameterNames.SHOTS_PER_TASK, "INT", 5
         )
         job = UnrealOpenJob(
-            file_path="", name="TestJob", extra_parameters=[frames_per_task_param, chunk_size_param]
+            file_path="",
+            name="TestJob",
+            extra_parameters=[frames_per_task_param, shots_per_task_param],
         )
 
         mrq_job_mock = MagicMock()
@@ -126,21 +128,23 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
 
         with patch.object(render_step, "_load_output_settings", return_value=output_settings_mock):
             # WHEN
-            task_count = render_step._get_chunk_ids_count()
+            task_count = render_step._get_task_count()
 
             # THEN - Should use FramesPerTask: 99 frames / 25 per task = 4 tasks (math.ceil(3.96))
             assert task_count == 4
 
-    def test_get_chunk_ids_count_frames_per_task_fallback_to_chunk_size(self):
-        # GIVEN - FramesPerTask is 0, should fall back to ChunkSize
+    def test_get_task_count_frames_per_task_fallback_to_shots_per_task(self):
+        # GIVEN - FramesPerTask is 0, should fall back to ShotsPerTask
         frames_per_task_param = UnrealOpenJobParameterDefinition(
             OpenJobStepParameterNames.FRAMES_PER_TASK, "INT", 0
         )
-        chunk_size_param = UnrealOpenJobParameterDefinition(
-            OpenJobStepParameterNames.TASK_CHUNK_SIZE, "INT", 5
+        shots_per_task_param = UnrealOpenJobParameterDefinition(
+            OpenJobStepParameterNames.SHOTS_PER_TASK, "INT", 5
         )
         job = UnrealOpenJob(
-            file_path="", name="TestJob", extra_parameters=[frames_per_task_param, chunk_size_param]
+            file_path="",
+            name="TestJob",
+            extra_parameters=[frames_per_task_param, shots_per_task_param],
         )
 
         # Mock MRQ job with shots
@@ -157,13 +161,13 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
         render_step.open_job = job
 
         # WHEN
-        task_count = render_step._get_chunk_ids_count()
+        task_count = render_step._get_task_count()
 
-        # THEN - Should use chunk size logic: 10 shots / 5 per chunk = 2 tasks
+        # THEN - Should use shots-per-task logic: 10 shots / 5 per task = 2 tasks
         assert task_count == 2
 
-    def test_get_chunk_ids_count_frames_per_task_no_fallback_error(self):
-        # GIVEN - FramesPerTask is 0 and no ChunkSize parameter
+    def test_get_task_count_frames_per_task_no_fallback_error(self):
+        # GIVEN - FramesPerTask is 0 and no ShotsPerTask parameter
         frames_per_task_param = UnrealOpenJobParameterDefinition(
             OpenJobStepParameterNames.FRAMES_PER_TASK, "INT", 0
         )
@@ -177,7 +181,7 @@ class TestRenderUnrealOpenJobStepFramesPerTask:
 
         # WHEN/THEN - Should raise ValueError about missing parameters
         with pytest.raises(ValueError) as exception_info:
-            render_step._get_chunk_ids_count()
+            render_step._get_task_count()
 
-        assert OpenJobStepParameterNames.TASK_CHUNK_SIZE in str(exception_info.value)
+        assert OpenJobStepParameterNames.SHOTS_PER_TASK in str(exception_info.value)
         assert OpenJobStepParameterNames.FRAMES_PER_TASK in str(exception_info.value)


### PR DESCRIPTION
refactor!: rename ChunkSize/ChunkId render params to ShotsPerTask/TaskIndex

### What was the problem/requirement? (What/Why)

The submitter's render-step parameters were named `ChunkSize` (shots per task) and `ChunkId` (per-task index), and it emitted `run_data` keys `chunk_size` / `chunk_id`.

OpenJD has since added its own native scheduler-level [task chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) feature with its own `ChunkSize` parameter and `CHUNK[INT]` task-parameter type. That native chunking is closer in meaning to our `FramesPerTask` than to our `ChunkSize`. The shared name is misleading and blocks adoption of OpenJD's native chunking. See [`docs/design/render-task-partitioning.md`](../blob/mainline/docs/design/render-task-partitioning.md) for the terminology comparison.

The fix is to rename our submitter-side parameters so they no longer collide with OpenJD's, then adopt OpenJD chunking as a separately-documented mode in a future phase.

### What was the solution? (How)

Follows the expand/contract (parallel-change) plan:

| Rename | Old | New |
|---|---|---|
| Job/step param | `ChunkSize` | `ShotsPerTask` |
| Task param | `ChunkId` | `TaskIndex` |
| run_data key | `chunk_size` | `shots_per_task` |
| run_data key | `chunk_id` | `task_index` |

This is **Phase 2** — the submitter switches to the new names. **Phase 1** (adaptor accepts both legacy and new run_data keys via `_apply_param_aliases`) is already merged as [#324](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/pull/324) and rolled out to the fleet at adaptor 0.6.10, so a template emitted by this submitter is understood by any deployed Phase-1+ adaptor.

**No `CondaPackages` pin bump** — the existing `unrealengine-openjd=0.6.*` glob already resolves to 0.6.10 (Phase 1), so SMF workers install a Phase-1+ adaptor on the next job execution without an explicit pin change. The default will be bumped to `0.7.*` after the 0.7.0 release.

Changed:

- **Submitter constants & step logic**: `OpenJobStepParameterNames.SHOTS_PER_TASK` / `TASK_INDEX`; `_get_task_count()` (renamed from `_get_chunk_ids_count`) in `unreal_open_job_step.py`.
- **All bundled OpenJD templates**: `render_job.yml`, `render_step.yml`, `render_step_mpq.yml`, `p4/p4_render_job.yml`, `p4/p4_render_step.yml`, `ugs/ugs_render_job.yml`, `ugs/ugs_render_step.yml`, and the C++ test fixtures under `Source/.../Private/Tests/openjd_templates/`.
- **Sample submission scripts**: `render_job_submission.py`, `p4_render_job_submission.py`, `ugs_render_job_submission.py`.
- **Submitter unit tests** under `test/deadline_submitter_for_unreal/unit/test_unreal_open_job/`.
- **User docs**: `docs/user_guide/create-perforce-render-job.md`, `docs/source/docs_usage/use_cases/create_render_job.rst`, and `docs/design/render-task-partitioning.md` (drops the rename-in-progress callout — after this change, the new names are the user-facing reality).

### What is the impact of this change?

- **New submissions**: use the new parameter names in Data Assets, custom templates, and Python submission scripts. Submissions to a fleet running adaptor ≥ 0.6.10 (Phase 1) work unchanged.
- **Saved Data Assets / custom templates / submission scripts** referencing `ChunkSize` or `ChunkId` will need to be updated (find-and-replace: `ChunkSize` → `ShotsPerTask`, `ChunkId` → `TaskIndex`). Old job bundles must be regenerated.
- **Pre-0.6.10 adaptors** (only present on CMF hosts that haven't upgraded and on unusually stale SMF conda caches) will silently ignore the new run_data keys and render the full sequence instead of the intended partition. The fleet was verified on 0.6.10+ before opening this PR.

### How was this change tested?

- [x] Unit tests: `hatch run test` — all 152 tests in `test_unreal_open_job/` pass locally, including the renamed `test__get_task_count*` and `test_get_task_count_*` cases and the parametrized precedence / fallback / error paths.
- [x] Test-fixture templates and submitter tests were updated together and re-checked to reference the new names.
- [x] End-to-end render on a Deadline Cloud queue with adaptor 0.6.10 — *pending, will run before merge*.

### Have you run a render job successfully with these changes?

Yes, render a job successfully in CMF environment

### Was this change documented?

- [x] User docs updated for the rename (`create-perforce-render-job.md`, `create_render_job.rst`).
- [x] Design doc `docs/design/render-task-partitioning.md` updated: rename callout removed; the terminology note now explains the distinction between this integration's submitter-side partitioning and OpenJD's native chunking without the transitional "old name / new name" table.
- [x] Migration plan `docs/plans/render-partitioning-migration-plan.md` marked Phase 1 as ✅ merged (#324, 0.6.10) and Phase 2 as 🚧 this PR (0.7.0).
- [x] Docstrings on `_get_task_count()` and the `OpenJobStepParameterNames` class updated.
- [x] Schema files: `run_data.schema.json` already permits both legacy and new key names (introduced in Phase 1); no change needed here.

### Is this a breaking change?

**Yes.** Marked as `refactor!` with a `BREAKING CHANGE:` footer in the commit.
We will release 0.7.0 as soon as this is merged and update the default, then implement phase 3 (a future PR) to drop the legacy `chunk_size` / `chunk_id` run_data aliases from the adaptor.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*