### PR TITLE
test: pin e2e farm discovery to the test region

### DIFF
--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -864,6 +864,7 @@ def run_unreal_test(request, reusable_farm_id, reusable_queue_id) -> Callable:
         # credential/S3 session; -testparams alone does not write these defaults.
         config.set_setting("defaults.farm_id", reusable_farm_id)
         config.set_setting("defaults.queue_id", reusable_queue_id)
+        config.set_setting("settings.deadline_regions", TEST_TARGET_REGION)
 
         test_params_str = f"-testparams=farm_id={reusable_farm_id};queue_id={reusable_queue_id}"
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

After the dependency bump `deadline` to `>=0.59`, the `CreateJob` e2e test started failing. deadline 0.59 fans `ListFarms` out across all Deadline Cloud regions, but the CI role only has deadline permissions in `us-west-2`. The other regions return `AccessDeniedException`, which the plugin logs as `LogPython: Error`. The test fails — even though job creation itself succeeded (the job ID is emitted before the failures).

### What was the solution? (How)

Set `settings.deadline_regions` to the test region, so farm discovery scans only that region and does not fan out.

### What is the impact of this change?

The `CreateJob` e2e test passes on the deadline 0.59 stack. No product code change; test-only.

### How was this change tested?

Verified on the gamma CI fleet.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*