### PR TITLE
fix: Add timeouts to adaptor environment enter and exit actions

### DIFF
--- a/src/unreal_plugin/Content/Python/openjd_templates/launch_ue_environment.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/launch_ue_environment.yml
@@ -23,6 +23,8 @@ script:
       - file://{{Env.File.initData}}
       cancelation:
         mode: NOTIFY_THEN_TERMINATE
+      # Server start timeout (30s) + Unreal start timeout (86400s) + 10 minute buffer
+      timeout: 87030
     onExit:
       command: unreal-engine-openjd
       args:
@@ -32,3 +34,5 @@ script:
       - '{{Session.WorkingDirectory}}/connection.json'
       cancelation:
         mode: NOTIFY_THEN_TERMINATE
+      # Server end timeout (30s) + Unreal end timeout (30s) + 1 minute buffer
+      timeout: 120

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_launch_ue_environment.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_launch_ue_environment.yml
@@ -23,6 +23,8 @@ script:
       - file://{{Env.File.initData}}
       cancelation:
         mode: NOTIFY_THEN_TERMINATE
+      # Server start timeout (30s) + Unreal start timeout (86400s) + 10 minute buffer
+      timeout: 87030
     onExit:
       command: unreal-engine-openjd
       args:
@@ -32,3 +34,5 @@ script:
       - '{{Session.WorkingDirectory}}/connection.json'
       cancelation:
         mode: NOTIFY_THEN_TERMINATE
+      # Server end timeout (30s) + Unreal end timeout (30s) + 1 minute buffer
+      timeout: 120

--- a/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_launch_ue_environment.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/ugs/ugs_launch_ue_environment.yml
@@ -23,6 +23,8 @@ script:
       - file://{{Env.File.initData}}
       cancelation:
         mode: NOTIFY_THEN_TERMINATE
+      # Server start timeout (30s) + Unreal start timeout (86400s) + 10 minute buffer
+      timeout: 87030
     onExit:
       command: unreal-engine-openjd
       args:
@@ -32,3 +34,5 @@ script:
       - '{{Session.WorkingDirectory}}/connection.json'
       cancelation:
         mode: NOTIFY_THEN_TERMINATE
+      # Server end timeout (30s) + Unreal end timeout (30s) + 1 minute buffer
+      timeout: 120

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
@@ -547,6 +547,27 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMovieQueueCreateJobTest, "DeadlineCloud.Integr
     NewJob->SetSequence(Sequence);
     NewJob->JobName = NewJob->Sequence.GetAssetName();
 
+    // Optionally override the submitted job name via '-testparams=...;job_name=<name>'
+    // so each automation/E2E test can be identified by its Deadline Cloud job name.
+    // The preset override name has the highest priority in the Python submitter's
+    // job name resolution, so it wins over the job template's default name.
+    FString TestParamsString;
+    if (FParse::Value(FCommandLine::Get(), TEXT("testparams="), TestParamsString))
+    {
+        TArray<FString> TestParamPairs;
+        TestParamsString.ParseIntoArray(TestParamPairs, TEXT(";"), true);
+        for (const FString& Pair : TestParamPairs)
+        {
+            FString Key, Value;
+            if (Pair.Split(TEXT("="), &Key, &Value) && Key == TEXT("job_name") && !Value.IsEmpty())
+            {
+                UE_LOG(LogCreateJobTest, Display, TEXT("Overriding job name with '%s'"), *Value);
+                NewJob->JobName = Value;
+                NewJob->PresetOverrides.JobSharedSettings.Name = Value;
+            }
+        }
+    }
+
     UMoviePipelineExecutorJob* QueueJob = ActiveQueue->DuplicateJob(NewJob);
     if (!QueueJob)
     {

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/launch_ue_environment.yml
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/openjd_templates/launch_ue_environment.yml
@@ -23,6 +23,8 @@ script:
       - file://{{Env.File.initData}}
       cancelation:
         mode: NOTIFY_THEN_TERMINATE
+      # Server start timeout (30s) + Unreal start timeout (86400s) + 10 minute buffer
+      timeout: 87030
     onExit:
       command: unreal-engine-openjd
       args:
@@ -32,3 +34,5 @@ script:
       - '{{Session.WorkingDirectory}}/connection.json'
       cancelation:
         mode: NOTIFY_THEN_TERMINATE
+      # Server end timeout (30s) + Unreal end timeout (30s) + 1 minute buffer
+      timeout: 120

--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../
 # Now all other imports, including those from your project
 import boto3
 import botocore
+import contextlib
 import deadline.client.config as config
 import json
 import logging
@@ -20,6 +21,7 @@ import signal
 import subprocess
 import tempfile
 import time
+import yaml
 from scripts.build_plugin import find_engine_root
 
 # Import typing information
@@ -417,6 +419,98 @@ def get_build_script_args() -> List[str]:
         List of command line arguments for the build script
     """
     return ["--install", "--test", "--worker"]
+
+
+# Default OpenJD action timeouts (in seconds) of the LaunchUnrealEditor
+# environment, as defined in
+# src/unreal_plugin/Content/Python/openjd_templates/launch_ue_environment.yml:
+# - Enter: server start timeout (30s) + Unreal start timeout (86400s) + 10 minute buffer
+# - Exit: server end timeout (30s) + Unreal end timeout (30s) + 1 minute buffer
+DEFAULT_ENV_ENTER_TIMEOUT_SECONDS = 87030
+DEFAULT_ENV_EXIT_TIMEOUT_SECONDS = 120
+
+
+def get_openjd_templates_directory(ue_version: Optional[str] = None) -> str:
+    """
+    Return the OpenJD templates directory of the plugin installed in the
+    Unreal Engine.
+
+    The plugin's default OpenJD data assets store engine-relative template
+    paths (e.g. '../../Plugins/UnrealDeadlineCloudService/Content/Python/
+    openjd_templates/launch_ue_environment.yml'), so this directory is what
+    MRQ job submissions actually read their environment templates from.
+
+    Args:
+        ue_version: Optional Unreal Engine version used to locate the engine root
+
+    Returns:
+        The absolute path to the installed plugin's OpenJD templates directory
+    """
+    engine_root = find_engine_root(ue_version)
+    return os.path.join(
+        engine_root,
+        "Engine",
+        "Plugins",
+        "UnrealDeadlineCloudService",
+        "Content",
+        "Python",
+        "openjd_templates",
+    )
+
+
+def read_launch_environment_template(templates_directory: str) -> Dict[str, Any]:
+    """
+    Load and parse the LaunchUnrealEditor environment template.
+
+    Args:
+        templates_directory: The OpenJD templates directory to read from
+
+    Returns:
+        The parsed launch_ue_environment.yml template as a dictionary
+    """
+    with open(os.path.join(templates_directory, "launch_ue_environment.yml")) as f:
+        return yaml.safe_load(f)
+
+
+@contextlib.contextmanager
+def openjd_templates_with_env_enter_timeout(
+    enter_timeout_seconds: int, ue_version: Optional[str] = None
+) -> Generator[str, None, None]:
+    """
+    Temporarily override the onEnter timeout of the LaunchUnrealEditor
+    environment template of the plugin installed in the Unreal Engine, so jobs
+    submitted from Unreal embed the overridden timeout.
+
+    The template file is patched in place because the plugin's default OpenJD
+    data assets reference it by engine-relative path; redirecting
+    OPENJD_TEMPLATES_DIRECTORY has no effect on MRQ job submissions. The
+    original file is backed up and restored on exit.
+
+    Args:
+        enter_timeout_seconds: The onEnter action timeout to write into the template
+        ue_version: Optional Unreal Engine version used to locate the engine root
+
+    Yields:
+        The path to the patched template file
+    """
+    template_path = os.path.join(
+        get_openjd_templates_directory(ue_version), "launch_ue_environment.yml"
+    )
+    backup_path = template_path + ".bak"
+    shutil.copy2(template_path, backup_path)
+
+    with open(template_path) as f:
+        template = yaml.safe_load(f)
+    template["script"]["actions"]["onEnter"]["timeout"] = enter_timeout_seconds
+    with open(template_path, "w") as f:
+        yaml.safe_dump(template, f, sort_keys=False)
+    logger.info(f"Patched {template_path} with onEnter timeout of {enter_timeout_seconds} seconds")
+
+    try:
+        yield template_path
+    finally:
+        shutil.move(backup_path, template_path)
+        logger.info(f"Restored original template at {template_path}")
 
 
 def add_content_plugins_to_project(project_path: str, plugins: List[str], enabled: bool) -> None:

--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -934,7 +934,10 @@ def run_unreal_test(request, reusable_farm_id, reusable_queue_id) -> Callable:
     """
 
     def _run_unreal_test(
-        test_path: str, uproject_file: str, deadlineargs: Optional[str] = None
+        test_path: str,
+        uproject_file: str,
+        deadlineargs: Optional[str] = None,
+        job_name: Optional[str] = None,
     ) -> Tuple[bool, List[str]]:
         """
         Runs an Unreal Engine automation test and determines success or failure by analyzing output patterns
@@ -944,6 +947,8 @@ def run_unreal_test(request, reusable_farm_id, reusable_queue_id) -> Callable:
             test_path: Automation test path (e.g. "DeadlineCloud.Integration.CreateJob")
             uproject_file: Path to the uproject file
             deadlineargs: Optional arguments to pass to Deadline, defaults to basic settings if None
+            job_name: Optional name for the submitted Deadline Cloud job. Defaults to the
+                requesting pytest test's name so each job can be traced back to its test
 
         Returns:
             Tuple of (success, output_lines) where success is a boolean indicating whether the test passed,
@@ -951,6 +956,12 @@ def run_unreal_test(request, reusable_farm_id, reusable_queue_id) -> Callable:
         """
         if deadlineargs is None:
             deadlineargs = "-NoLoadingScreen -FixedSeed -log -Unattended -MRQInstance -deterministicaudio -audiomixer"
+
+        if job_name is None:
+            job_name = request.node.name
+        # testparams is a ';'-separated 'key=value' list, so strip characters that
+        # would break its parsing. Deadline Cloud job names are capped at 128 chars.
+        job_name = re.sub(r"[;=]", "_", job_name)[:128]
 
         logger.info(f"Running unreal test with farm {reusable_farm_id} queue {reusable_queue_id}")
 
@@ -960,7 +971,10 @@ def run_unreal_test(request, reusable_farm_id, reusable_queue_id) -> Callable:
         config.set_setting("defaults.queue_id", reusable_queue_id)
         config.set_setting("settings.deadline_regions", TEST_TARGET_REGION)
 
-        test_params_str = f"-testparams=farm_id={reusable_farm_id};queue_id={reusable_queue_id}"
+        test_params_str = (
+            f"-testparams=farm_id={reusable_farm_id};queue_id={reusable_queue_id}"
+            f";job_name={job_name}"
+        )
 
         engine_root = find_engine_root(request.config.getoption("--ueversion"))
 

--- a/test/end_to_end/test_worker_agent.py
+++ b/test/end_to_end/test_worker_agent.py
@@ -2,7 +2,12 @@
 
 import logging
 from conftest import (
+    DEFAULT_ENV_ENTER_TIMEOUT_SECONDS,
+    DEFAULT_ENV_EXIT_TIMEOUT_SECONDS,
     extract_job_info_from_test_output,
+    get_openjd_templates_directory,
+    openjd_templates_with_env_enter_timeout,
+    read_launch_environment_template,
     wait_for_job_state,
     get_last_session_project_plugins,
     add_content_plugins_to_project,
@@ -19,6 +24,7 @@ def test_create_job_with_worker_agent(
     run_unreal_test,
     reusable_queue_fleet_association,
     deadline_worker_agent,
+    request,
 ):
     """
     Run CreateJob automation test from within Unreal with a local worker agent running.
@@ -29,6 +35,16 @@ def test_create_job_with_worker_agent(
     # and will stop it after the test completes
 
     _, uproject_file = create_readonly_test_project
+
+    # Verify the LaunchUnrealEditor environment template used for submission
+    # defines the default OpenJD action timeouts, so the job submitted below
+    # runs with (and completes within) those defaults.
+    templates_directory = get_openjd_templates_directory(request.config.getoption("--ueversion"))
+    launch_environment_actions = read_launch_environment_template(templates_directory)["script"][
+        "actions"
+    ]
+    assert launch_environment_actions["onEnter"]["timeout"] == DEFAULT_ENV_ENTER_TIMEOUT_SECONDS
+    assert launch_environment_actions["onExit"]["timeout"] == DEFAULT_ENV_EXIT_TIMEOUT_SECONDS
 
     logger.info(f"Creating job from project {uproject_file}")
     success, output_lines = run_unreal_test("DeadlineCloud.Integration.CreateJob", uproject_file)
@@ -121,3 +137,64 @@ def test_worker_agent_project_plugins(
     else:
         logger.warning("Could not extract job ID or farm ID from test output")
         assert False, "Could not extract job information from test output"
+
+
+def test_worker_agent_environment_enter_timeout(
+    deadline_client,
+    build_plugin,
+    create_readonly_test_project,
+    run_unreal_test,
+    reusable_queue_fleet_association,
+    deadline_worker_agent,
+    request,
+):
+    """
+    Submit a job whose LaunchUnrealEditor environment onEnter timeout is far
+    too short for the Unreal Editor to start on the worker, and verify the
+    worker agent enforces the OpenJD action timeout by failing the job.
+    """
+
+    # The deadline_worker_agent fixture will start the worker agent before this test runs
+    # and will stop it after the test completes
+
+    _, uproject_file = create_readonly_test_project
+
+    # The environment enter (adaptor daemon start + Unreal Editor launch) takes
+    # far longer than this, so the worker agent must cancel the action when the
+    # timeout elapses and fail the job.
+    short_enter_timeout_seconds = 5
+
+    with openjd_templates_with_env_enter_timeout(
+        enter_timeout_seconds=short_enter_timeout_seconds,
+        ue_version=request.config.getoption("--ueversion"),
+    ):
+        logger.info(
+            f"Creating job with {short_enter_timeout_seconds}s environment enter timeout "
+            f"from project {uproject_file}"
+        )
+        success, output_lines = run_unreal_test(
+            "DeadlineCloud.Integration.CreateJob", uproject_file
+        )
+        assert success, "Create job test failed"
+
+    # Extract job ID and farm ID from the output
+    job_id, farm_id, queue_id = extract_job_info_from_test_output(output_lines)
+
+    assert job_id and farm_id and queue_id, "Could not extract job information from test output"
+
+    success, status, message = wait_for_job_state(
+        deadline_client=deadline_client,
+        farm_id=farm_id,
+        job_id=job_id,
+        queue_id=queue_id,
+        expected_states=["FAILED"],
+        max_wait_time=600,
+        wait_interval=10,
+    )
+
+    assert success, (
+        f"Expected job {job_id} to FAIL because the environment enter exceeds its "
+        f"{short_enter_timeout_seconds}s timeout: {message}"
+    )
+
+    logger.info(f"Job {job_id} FAILED as expected due to environment enter timeout")


### PR DESCRIPTION

Fixes: https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/issues/116

### What was the problem/requirement? (What/Why)

The `LaunchUnrealEditor` environment's `onEnter` and `onExit` actions did not specify an OpenJD `timeout`. If the adaptor daemon start or stop got stuck and the adaptor's internal timeouts failed to fire, the worker agent had no second layer of protection and the session action could hang indefinitely.

### What was the solution? (How)

Added OpenJD `timeout` fields to the environment actions, sized slightly longer than the adaptor's internal timeouts so they act as a backstop rather than the primary mechanism:

- `onEnter: 87030` = server start timeout (30s) + Unreal start timeout (86400s) + 10 minute buffer
- `onExit: 120` = server end timeout (30s) + Unreal end timeout (30s) + 1 minute buffer

Applied to the default, Perforce, and UGS launch environment templates, plus the UE automation test template mirror. The adaptor's internal timeout constants are unchanged.

Also included:

- A new E2E test (`test_worker_agent_environment_enter_timeout`) that patches the engine-installed plugin's `launch_ue_environment.yml` in place (with backup/restore) to a 5s `onEnter` timeout, submits a job through the normal MRQ flow, and verifies the worker agent fails the job. Patching in place is required because the plugin's default OpenJD data assets reference the template by engine-relative path, so redirecting `OPENJD_TEMPLATES_DIRECTORY` has no effect on MRQ submissions.
- The existing `test_create_job_with_worker_agent` now asserts the template used for submission contains the default timeouts.
- E2E jobs are now named after the pytest test that submits them (via a new `job_name` key in `-testparams`, written to `PresetOverrides.JobSharedSettings.Name`), instead of all appearing as "RenderJob", so failing jobs in the Deadline Cloud console can be traced back to their test.

### What is the impact of this change?

- Jobs submitted with the updated templates get worker-agent-enforced timeouts on environment enter/exit. 
- E2E test jobs are individually identifiable by name in the Deadline Cloud console.

### How was this change tested?

- All four modified templates validated against the OpenJD 2023-09 `Environment` model, confirming the `timeout` fields parse and round-trip through the submitter's `parse_model` path.
- `hatch run test`: 543 passed, 2 skipped.
- `hatch run lint` (ruff + black + mypy): clean.
- `hatch run e2e -s`: new tests added. All tests passed
```
==================================================================================== slowest 5 durations ====================================================================================
222.43s setup    test/end_to_end/test_create_job.py::test_create_job
213.85s call     test/end_to_end/test_worker_agent.py::test_worker_agent_project_plugins
211.47s call     test/end_to_end/test_worker_agent.py::test_create_job_with_worker_agent
79.75s call     test/end_to_end/test_worker_agent.py::test_worker_agent_environment_enter_timeout
44.76s call     test/end_to_end/test_create_job.py::test_create_job
=============================================================================== 4 passed in 812.84s (0:13:32) ===============================================================================
```

### Have you run a render job successfully with these changes?

Yes

### Was this change documented?

Docstrings added for all new test helpers. Template comments document the timeout derivation. No README/docs changes needed; adaptor init-data/run-data schemas are unaffected.

### Is this a breaking change?

No. Adding `timeout` to environment actions is backwards compatible — jobs submitted with older submitters simply won't have the timeouts, and the adaptor interface is unchanged.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
