### PR TITLE
test: harden flaky Deadline UI/integration automation tests

### DIFF
--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UI.spec.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/DeadlinePluginTest_UI.spec.cpp
@@ -441,11 +441,28 @@ static FString ConvertLocalPathToFull(const FString& Path)
 	return FullPath;
 }
 
+// Hover and retry to avoid intermittent "Element found but not located under the cursor" failures
+// when the synthetic cursor has not settled over the target yet.
+static bool RobustClick(FAutomationDriverPtr Driver, FDriverElementRef Element, EMouseButtons::Type MouseButton, int32 MaxAttempts = 3)
+{
+	for (int32 Attempt = 0; Attempt < MaxAttempts; ++Attempt)
+	{
+		Element->Hover();
+		Driver->Wait(FTimespan::FromMilliseconds(50));
+		if (Element->Click(MouseButton))
+		{
+			return true;
+		}
+		Driver->Wait(FTimespan::FromMilliseconds(100));
+	}
+	return false;
+}
+
 static void ExpandAllProperties(const FString DetailsPath, FAutomationDriverPtr Driver)
 {
 	FString MainCategoryExpanderArrowPath = DetailsPath + "//<SDetailCategoryTableRow>//<SDetailExpanderArrow>";
 	FDriverElementCollectionRef ParametersCategory = Driver->FindElements(By::Path(MainCategoryExpanderArrowPath));
-	ParametersCategory->GetElements()[0]->Click(EMouseButtons::Type::Right);
+	RobustClick(Driver, ParametersCategory->GetElements()[0], EMouseButtons::Type::Right);
 	Driver->Wait(FTimespan::FromSeconds(1));
 
 	FString PopupElementsPath = "<SWindow>//<SPopup>//<SMultiBoxWidget>//<SBorder>//<SVerticalBox>//<SScrollBox>//<SHorizontalBox>//<SOverlay>//<SScrollPanel>//<SVerticalBox>//<SHorizontalBox>//<SMenuEntryButton>";
@@ -454,7 +471,7 @@ static void ExpandAllProperties(const FString DetailsPath, FAutomationDriverPtr 
 	if (!PopupElements->GetElements().IsEmpty())
 	{
 		PopupElements->GetElements()[2]->Focus();
-		PopupElements->GetElements()[2]->Click(EMouseButtons::Type::Left);
+		RobustClick(Driver, PopupElements->GetElements()[2], EMouseButtons::Type::Left);
 	}
 }
 
@@ -465,14 +482,28 @@ static void ScrollToElement(FAutomationDriverPtr Driver, FDriverElementRef List,
 		return;
 	}
 
-	if (List->Exists() && ScrollBar->Exists())
+	if (!List->Exists() || !ScrollBar->Exists())
 	{
-		uint32 CurrentAttempts = 0;
-		while ((!TargetElement->Exists() || !TargetElement->IsVisible()) && (!ScrollBar->IsScrolledToEnd() && CurrentAttempts < AttemptsLimit))
+		return;
+	}
+
+	// Start from the top so the target is reachable regardless of the prior scroll offset.
+	List->ScrollToBeginning();
+	Driver->Wait(FTimespan::FromMilliseconds(100));
+
+	uint32 CurrentAttempts = 0;
+	while ((!TargetElement->Exists() || !TargetElement->IsVisible()) && CurrentAttempts < AttemptsLimit)
+	{
+		if (ScrollBar->IsScrolledToEnd())
 		{
-			List->ScrollBy(-1);
-			CurrentAttempts++;
+			// Let tall, still-laying-out rows settle and re-check before giving up at the bottom.
+			Driver->Wait(FTimespan::FromMilliseconds(150));
+			return;
 		}
+
+		List->ScrollBy(-1);
+		Driver->Wait(FTimespan::FromMilliseconds(50));
+		CurrentAttempts++;
 	}
 }
 
@@ -523,7 +554,7 @@ AssetType* CreateAndOpenAsset(
     return Asset;
 }
 
-static void InputText(FDriverElementRef Widget, const FString& Text, bool bRemoveTextBeforeInput)
+static void InputText(FDriverElementRef Widget, const FString& Text, bool bRemoveTextBeforeInput, FAutomationDriverPtr Driver = nullptr)
 {
 	if (bRemoveTextBeforeInput)
 	{
@@ -535,6 +566,12 @@ static void InputText(FDriverElementRef Widget, const FString& Text, bool bRemov
 		Widget->Type(Text);
 	}
 	Widget->Type(EKeys::Enter);
+
+	// Enter commits asynchronously; wait so callers don't read back the stale pre-commit value.
+	if (Driver.IsValid())
+	{
+		Driver->Wait(FTimespan::FromMilliseconds(150));
+	}
 }
 
 
@@ -744,7 +781,7 @@ void FDeadlinePluginUISpec::Define()
 				return;
 			}
 			MrqJobWidget->Focus();
-			MrqJobWidget->Click(EMouseButtons::Type::Left);
+			RobustClick(Driver, MrqJobWidget.ToSharedRef(), EMouseButtons::Type::Left);
 
 			if (!InitForMRQ(MRQJob))
 			{
@@ -1220,11 +1257,11 @@ void FDeadlinePluginUISpec::Define()
 			TestTrue("Variable1 widget should exist", bVariable1WidgetExists);
 			if (bVariable1WidgetExists)
 			{
-				InputText(Variable1Widget, "", true);
+				InputText(Variable1Widget, "", true, Driver);
 				TEST_EQUAL(CreatedEnvironmentDataAsset->Variables.Variables["Variable1"], "");
 
 				FString Variable1TextValid = "ValidString";
-				InputText(Variable1Widget, Variable1TextValid, true);
+				InputText(Variable1Widget, Variable1TextValid, true, Driver);
 				TEST_EQUAL(CreatedEnvironmentDataAsset->Variables.Variables["Variable1"], Variable1TextValid);
 			}
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
@@ -555,14 +555,11 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMovieQueueCreateJobTest, "DeadlineCloud.Integr
     }
     UE_LOG(LogCreateJobTest, Display, TEXT("Created job from sequence"));
 
-    // Currently two "expected" warning/error messages which we should try to resolve separately, but don't currently break anything
-    // in our underlying functionality
-    // The QueueManifest message may appear 1 or 2 times depending on whether you've run the test before.
+    // Occurrences -1 suppresses these engine warnings without requiring them, so the test passes on both first-run and reruns.
     AddExpectedError(TEXT("/Engine/MovieRenderPipeline/Editor/QueueManifest"),
-        EAutomationExpectedErrorFlags::Contains, 0);
-    // The -execcmds message may appear 1 or 2 times depending on whether you've run the test before
+        EAutomationExpectedErrorFlags::Contains, -1);
     AddExpectedError(TEXT("Appearance of custom '-execcmds' argument on the Render node can cause unpredictable issues"),
-        EAutomationExpectedErrorFlags::Contains, 0);
+        EAutomationExpectedErrorFlags::Contains, -1);
 
     // Load and use remote executor
     TSubclassOf<UMoviePipelineExecutorBase> ExecutorClass = ProjectSettings->DefaultRemoteExecutor.TryLoadClass<UMoviePipelineExecutorBase>();


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The Unreal automation suite — `DeadlinePluginTest_UI.spec.cpp` and the `DeadlineCloud.Integration.CreateJob` tests are flaky. The failures depended on environmental state.

- **CreateJob** failed on *rerun* within a single editor session (UE 5.6). Its two expected errors (`QueueManifest` and the `-execcmds` warning) were registered with `Occurrences == 0`, which requires the message to appear at least once. Those messages are only emitted on the *first* render of an editor session (the QueueManifest package stays resident and the render node is reused), so any rerun failed.
- The **UI specs** (MRQJobUI, EnvironmentUI) were sensitive to window size, synthetic-cursor timing, and scroll geometry. Maximizing the editor window broke them. Symptoms included `Element found but not located under the cursor`, tall validation-decorated rows falling outside the clipped scroll viewport, and assertions reading back a stale pre-commit bound-property value.

### What was the solution? (How)

- Scroll from a deterministic top position (`ScrollToBeginning`) and add a final layout-settle re-check at the bottom instead of bailing the instant the scrollbar reports the end, so tall validation-decorated rows are reachable regardless of the prior scroll offset.
- Add new helper, RobustClick: hover → settle → retry. Used for the MRQ job widget and property-expansion clicks to absorb the intermittent "not located under the cursor" cursor race.
- Optional post-commit wait so callers don't read back the pre-commit (stale) bound-property value after the async Enter commit.
- CreateJob test: change the `QueueManifest` and `-execcmds` expected errors from `Occurrences 0` to `-1`. `-1` suppresses the messages when present without requiring them, so the test passes on both the first run and reruns within a session.


### What is the impact of this change?

The `DeadlineCloud` automation suite passes deterministically: `CreateJob` passes on both first-run and reruns within a session, and the UI specs pass regardless of window size (including maximized). No change to plugin behavior, adaptor interface, or job output.

### How was this change tested?

Rebuilt and installed the test-enabled plugin in 5.6 and 5.7 and ran the full `DeadlineCloud` automation suite multiple times within a single editor session, including with the editor maximized. All tests pass on both first-run and reruns.

### Have you run a render job successfully with these changes?

Yes — the `DeadlineCloud.Integration.CreateJob` test submits a real Deadline Cloud job through the normal MRQ flow and returns job IDs successfully.

### Was this change documented?

No documentation changes needed. 

### Is this a breaking change?

No. The changes are test-only and do not modify any public contract, adaptor init-data/run-data, or submitter interface.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
