### PR TITLE
feat: add OpenJD TASK_CHUNKING dynamic chunking support

### DIFF
--- a/docs/design/images/render-task-partitioning-mode1.png
+++ b/docs/design/images/render-task-partitioning-mode1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e77ca29305e4d5bb5240d1b75a3f6dd2b159d6dc38942ce92adf156404fe5ea
+size 25331

--- a/docs/design/images/render-task-partitioning-mode2.png
+++ b/docs/design/images/render-task-partitioning-mode2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15f226a7b38ff57468a4ec99e46b35b9c342c1600cdb07a1ec84651ad040cd63
+size 29260

--- a/docs/design/images/render-task-partitioning-mode3.png
+++ b/docs/design/images/render-task-partitioning-mode3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:823ad912454018f2a7cba9732edfc8c9933ffadae9ae9b50cd38bc723abb14a3
+size 38029

--- a/docs/design/render-task-partitioning.md
+++ b/docs/design/render-task-partitioning.md
@@ -2,20 +2,16 @@
 
 When you submit a render to AWS Deadline Cloud, the Unreal submitter splits the work in a Movie Render Queue (MRQ) job into multiple OpenJD **tasks** so they can be distributed across worker hosts.
 
-This integration currently supports two submitter-side partitioning modes, described below. They are configured on the Render Step / Render Job parameters and are mutually exclusive — `FramesPerTask` takes precedence when set.
+This integration supports three partitioning modes, described below. Modes 1 and 2 are **submitter-side**: the task breakdown is decided at submission time and configured on the Render Step / Render Job parameters. Mode 3 is **scheduler-side**: chunk boundaries are computed by Deadline Cloud at dispatch time using OpenJD's native [task chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) (`TASK_CHUNKING`) extension. The modes are mutually exclusive — Mode 3 is selected by using the dynamic-chunking template pair, and within the submitter-side modes `FramesPerTask` takes precedence when set.
 
-> **Note on terminology — submitter partitioning vs. OpenJD chunking:** OpenJD has its own native [task chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) feature, where the scheduler groups tasks into chunks at dispatch time using a `ChunkSize` parameter and a `CHUNK[INT]` task-parameter type. The two modes below are different: they are **submitter-side** partitioning that decides the task breakdown at submission time, implemented in this integration rather than the OpenJD scheduler.
->
-> Support for OpenJD's native chunking is planned as an additional mode. To avoid the name collision ahead of that work, the submitter-side parameters that were previously called `ChunkSize`/`ChunkId` are now `ShotsPerTask`/`TaskIndex`. When OpenJD chunking is added, its `ChunkSize` will be a distinct, separately-documented concept.
->
-> **Compatibility:** templates emitted by submitters ≥ 0.7.0 require adaptor ≥ 0.6.10 on the worker. Older adaptors ignore the new run_data keys and silently render the full sequence instead of the intended partition.
+> **Naming history:** the submitter-side parameters were originally called `ChunkSize`/`ChunkId`. They were renamed to `ShotsPerTask`/`TaskIndex` to avoid colliding with OpenJD's own `ChunkSize` parameter, which Mode 3 uses with OpenJD's meaning (frames per chunk). See the [version compatibility](#version-compatibility) section for which releases use which names.
 
 ## Mode 1 — Shots per task (`ShotsPerTask`)
 
 Partitions the **enabled shots** of the Level Sequence. Each task renders up to `ShotsPerTask` consecutive enabled shots.
 
 - Task count = ceil(number of enabled shots / `ShotsPerTask`)
-- If `ShotsPerTask` is 0 or negative, it defaults to 1 (one shot per task).
+- `ShotsPerTask` defaults to 1 (one shot per task). If it is 0 or negative, the submitter also uses 1.
 
 Example — a Level Sequence with 10 enabled shots and `ShotsPerTask = 3` produces 4 tasks:
 
@@ -27,6 +23,12 @@ Example — a Level Sequence with 10 enabled shots and `ShotsPerTask = 3` produc
 | 3 | 9 |
 
 Use this mode when your sequence is organized into shots and you want each task to cover a whole number of shots.
+
+### How to use
+
+Use the default `DeadlineCloudRenderJob` Job Preset and set `FramesPerTask` to `0` in the MRQ job's **Job Template Overrides**. With `FramesPerTask` disabled, partitioning falls back to `ShotsPerTask`, which defaults to 1 (one shot per task). To change the number of shots per task, customize the Render Step Data Asset and set its `ShotsPerTask` parameter.
+
+![Job Template Overrides with FramesPerTask set to 0](./images/render-task-partitioning-mode1.png)
 
 ## Mode 2 — Frames per task (`FramesPerTask`)
 
@@ -47,11 +49,70 @@ Example — a 100-frame sequence with `FramesPerTask = 25` produces 4 tasks:
 
 Use this mode when you want even-sized tasks by frame count — for example to load-balance a long single shot across many workers.
 
+### How to use
+
+Use the default `DeadlineCloudRenderJob` Job Preset and set `FramesPerTask` to the number of frames per task in the MRQ job's **Job Template Overrides**. Any value greater than 0 enables this mode (`ShotsPerTask` is then ignored).
+
+![Job Template Overrides with FramesPerTask set to 25](./images/render-task-partitioning-mode2.png)
+
+## Mode 3 — Dynamic chunking (OpenJD `TASK_CHUNKING`)
+
+Partitions the **frame range** of the render, like Mode 2 — but the chunk boundaries are computed by the Deadline Cloud scheduler at **dispatch time**, not by the submitter at submission time. This uses OpenJD's native [task chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) extension (`TASK_CHUNKING`) with a `CHUNK[INT]` task parameter.
+
+Dynamic chunking is **opt-in** via the dedicated template pair `dynamic_chunking/dynamic_chunking_render_job.yml` + `dynamic_chunking_render_step.yml`.
+
+How it works:
+
+- At submission, the submitter populates a hidden `Frames` job parameter with the render's frame range (formatted `<start>-<end>`, e.g. `0-99`) from the MRQ output settings' custom playback range if enabled, otherwise from the Level Sequence's playback range.
+- The step's `DynamicChunking` task parameter (type `CHUNK[INT]`) ranges over `Frames`, producing one task per frame — chunking does **not** reduce the task count. At dispatch time the scheduler groups those tasks into chunks and runs each chunk as a single session action, handing it one contiguous sub-range via the `dynamic_chunked_frames` run_data key (e.g. `25-49`, inclusive on both ends).
+- The adaptor parses that range and sets MRQ's `custom_start_frame`/`custom_end_frame` for the task (converting the scheduler's inclusive end to Unreal's exclusive end).
+
+Job parameters on the dynamic-chunking template:
+
+| Parameter | Meaning |
+|---|---|
+| `ChunkSize` | Default number of frames per chunk (OpenJD's `defaultTaskCount`). Default: 50. |
+| `TargetRuntimeSeconds` | Optional target runtime per chunk. When greater than 0, the scheduler may adjust chunk sizes toward this runtime as chunks complete. When 0 (default), all chunks use `ChunkSize`. |
+| `Frames` | Frame range expression. Populated automatically by the submitter; you do not set it by hand. |
+
+Key differences from Mode 2:
+
+- **Chunk boundaries can adapt.** With `TargetRuntimeSeconds` set, the scheduler can resize later chunks based on how long earlier chunks took — something submission-time partitioning cannot do.
+- **No `TaskIndex`.** Chunks are identified by their frame sub-range, not by a 0-based index. For output file naming, the adaptor substitutes the chunk's **start frame** for the `{task_index}` filename token (chunk start frames are unique across chunks of a contiguous range).
+- **Contiguous ranges only.** Unreal's Movie Render Queue only accepts contiguous frame ranges (`custom_start_frame`/`custom_end_frame`), so the template pins `rangeConstraint: CONTIGUOUS`. Non-contiguous chunk lists (e.g. pick-up frames `1,5,10`) are not supported until MRQ can render non-sequential frames.
+
+Requirements: see [version compatibility](#version-compatibility).
+
+### How to use
+
+Dynamic chunking is not selectable from the default `DeadlineCloudRenderJob` Job Preset. To opt in, create your own Job and Step Data Assets whose template paths point at `dynamic_chunking/dynamic_chunking_render_job.yml` and `dynamic_chunking/dynamic_chunking_render_step.yml`, and set `ChunkSize` (frames per chunk) and optionally `TargetRuntimeSeconds` on the job. `Frames` is populated automatically at submission.
+
+![Dynamic chunking overrides with ChunkSize set to 50 and TargetRuntimeSeconds set to 0](./images/render-task-partitioning-mode3.png)
+
 ## `TaskIndex`
 
-In both modes, each generated task is assigned a 0-based `TaskIndex` identifying which partition it renders. It is filled in automatically during submission; you do not set it by hand. The adaptor uses `TaskIndex` to select the correct shots (Mode 1) or frame window (Mode 2) for each task.
+In Modes 1 and 2, each generated task is assigned a 0-based `TaskIndex` identifying which partition it renders. It is filled in automatically during submission; you do not set it by hand. The adaptor uses `TaskIndex` to select the correct shots (Mode 1) or frame window (Mode 2) for each task. Mode 3 has no `TaskIndex` — chunks are identified by their frame sub-range instead.
 
 ### Output file naming
 
-When a render is split across multiple tasks, MRQ writes one output file per task. For image sequences (PNG/EXR/etc.) the default `FileNameFormat` includes `{frame_number}`, so each task's output is already unique. For video containers such as `.mov`, the default format is just `{sequence_name}` and every task would write to the same filename. To disambiguate, add the `{task_index}` token to the MRQ Output Setting's `FileNameFormat` (for example `{sequence_name}_{task_index}`); the submitter substitutes it at render time with a zero-padded per-task index.
+When a render is split across multiple tasks, MRQ writes one output file per task. For image sequences (PNG/EXR/etc.) the default `FileNameFormat` includes `{frame_number}`, so each task's output is already unique. For video containers such as `.mov`, the default format is just `{sequence_name}` and every task would write to the same filename. To disambiguate, add the `{task_index}` token to the MRQ Output Setting's `FileNameFormat` (for example `{sequence_name}_{task_index}`); the submitter substitutes it at render time with a zero-padded value: the per-task index (Modes 1 and 2) or the chunk's start frame (Mode 3).
+
+## Version compatibility
+
+The submitter (Unreal plugin) and the adaptor (worker-side `unrealengine-openjd` package) are released independently. Their contract is the set of run_data keys the submitter's templates emit and the adaptor reads. The partitioning parameters were renamed across three minor versions (`ChunkSize`→`ShotsPerTask` on the wire `chunk_size`→`shots_per_task`, and `ChunkId`→`TaskIndex` on the wire `chunk_id`→`task_index`):
+
+| Version | Submitter emits | Adaptor accepts |
+|---|---|---|
+| 0.6.x (≥ 0.6.10) | legacy names (`chunk_size`/`chunk_id`) | **both** legacy and new |
+| 0.7.x | new names (`shots_per_task`/`task_index`) | **both** legacy and new |
+| 0.8.x | new names | new names only |
+
+Any submitter/adaptor pairing within one minor version of each other keeps working. Because run_data fields are optional in the adaptor's schema (only `handler` is required), a mismatched pairing fails **silently with wrong output** — the task renders the full sequence instead of its partition — rather than loudly. The two mismatches to avoid:
+
+- A 0.7+ submitter's template reaching a pre-0.6.10 adaptor (adaptor doesn't know the new keys).
+- A legacy (pre-0.7) template reaching a 0.8+ adaptor (adaptor no longer accepts the old keys). Regenerate old job bundles and update custom templates or submission scripts that still reference `ChunkSize`/`ChunkId`.
+
+On service-managed fleets the adaptor version is selected by the `CondaPackages` parameter in the job template (the bundled templates pin the adaptor minor version matching the submitter). On customer-managed fleets the adaptor is installed manually and must be kept version-matched to the submitter.
+
+Mode 3 (dynamic chunking) additionally requires `TASK_CHUNKING` extension support in the fleet's worker agent and an adaptor that understands the `dynamic_chunked_frames` run_data key.
 

--- a/docs/design/render-task-partitioning.md
+++ b/docs/design/render-task-partitioning.md
@@ -95,7 +95,7 @@ In Modes 1 and 2, each generated task is assigned a 0-based `TaskIndex` identify
 
 ### Output file naming
 
-When a render is split across multiple tasks, MRQ writes one output file per task. For image sequences (PNG/EXR/etc.) the default `FileNameFormat` includes `{frame_number}`, so each task's output is already unique. For video containers such as `.mov`, the default format is just `{sequence_name}` and every task would write to the same filename. To disambiguate, add the `{task_index}` token to the MRQ Output Setting's `FileNameFormat` (for example `{sequence_name}_{task_index}`); the submitter substitutes it at render time with a zero-padded value: the per-task index (Modes 1 and 2) or the chunk's start frame (Mode 3).
+When a render is split across multiple tasks, MRQ writes one output file per task. For image sequences (PNG/EXR/etc.) the default `FileNameFormat` includes `{frame_number}`, so each task's output is already unique. For video containers such as `.mov`, the default format is just `{sequence_name}` and every task would write to the same filename. To disambiguate, add the `{task_index}` token to the MRQ Output Setting's `FileNameFormat` (for example `{sequence_name}_{task_index}`); the adaptor substitutes it at render time with a zero-padded value: the per-task index (Modes 1 and 2) or the chunk's start frame (Mode 3).
 
 ## Version compatibility
 
@@ -107,7 +107,7 @@ The submitter (Unreal plugin) and the adaptor (worker-side `unrealengine-openjd`
 | 0.7.x | new names (`shots_per_task`/`task_index`) | **both** legacy and new |
 | 0.8.x | new names | new names only |
 
-Any submitter/adaptor pairing within one minor version of each other keeps working. Because run_data fields are optional in the adaptor's schema (only `handler` is required), a mismatched pairing fails **silently with wrong output** — the task renders the full sequence instead of its partition — rather than loudly. The two mismatches to avoid:
+Any submitter/adaptor pairing within one minor version of each other keeps working, provided a 0.6.x adaptor is at least 0.6.10. Because run_data fields are optional in the adaptor's schema (only `handler` is required), a mismatched pairing fails **silently with wrong output** — the task renders the full sequence instead of its partition — rather than loudly. The two mismatches to avoid:
 
 - A 0.7+ submitter's template reaching a pre-0.6.10 adaptor (adaptor doesn't know the new keys).
 - A legacy (pre-0.7) template reaching a 0.8+ adaptor (adaptor no longer accepts the old keys). Regenerate old job bundles and update custom templates or submission scripts that still reference `ChunkSize`/`ChunkId`.

--- a/docs/plans/render-partitioning-migration-plan.md
+++ b/docs/plans/render-partitioning-migration-plan.md
@@ -28,7 +28,7 @@ independently (run_data keys are their contract), we use an **expand/contract
 - **SMF:** adaptor version pinned by `CondaPackages` in the job template.
   As of Phase 2 this default is `unrealengine-openjd=0.7.*` (bumped from
   `0.6.*`); the glob matches the latest 0.7.x patch automatically.
-- **CMF:** adaptor pip-installed manually, must be kept version-matched to the
+- **Customer-managed fleets:** adaptor pip-installed manually, must be kept version-matched to the
   submitter (per `setup-cmf-worker.md`).
 - run_data fields are optional in `run_data.schema.json` (only `handler` is
   required). A mismatch therefore fails **silently with wrong output** (a task
@@ -48,9 +48,9 @@ The durable copy of this matrix lives in
 | 0.8.x | new names | new names only |
 
 Any submitter/adaptor pairing within one minor version of each other keeps
-working; the silent wrong-output failure mode only occurs when a 0.7+
-submitter's template reaches a pre-0.6.10 adaptor, or a legacy template
-reaches a 0.8+ adaptor.
+working, provided a 0.6.x adaptor is at least 0.6.10. The silent wrong-output
+failure mode occurs when a 0.7+ submitter's template reaches a pre-0.6.10
+adaptor, or a legacy template reaches a 0.8+ adaptor.
 
 ## Phases
 
@@ -61,7 +61,7 @@ reaches a 0.8+ adaptor.
   keys via `_apply_param_aliases` (new wins). Schema permits all four keys.
 - Submitter, templates, and user-facing names are unchanged.
 - **Release:** non-breaking (`feat`) — ships as 0.6.10.
-- **Exit criterion:** rolled out to fleet (SMF conda channel + CMF hosts on
+- **Exit criterion:** rolled out to fleet (SMF conda channel + customer-managed fleet hosts on
   0.6.10+). ✅ met. After this, any deployed adaptor handles both old and new
   templates.
 
@@ -84,9 +84,8 @@ reaches a 0.8+ adaptor.
   bundles. (Find-and-replace details in the Phase-2 PR description.)
   - Includes internal canary/test job bundles that hand-author OpenJD
     templates rather than going through the submitter — these are just as
-    exposed to Phase 4 dropping legacy support as any customer template.
-    See `BealineTestJobBundles` CR-290057236 (conda branch) and
-    CR-290945992 (mainline branch) for the Unreal fountain canaries.
+    exposed to Phase 4 dropping legacy support as any customer template and
+    are tracked internally.
 - **Exit criterion:** all submitters in use emit new names.
 
 ### Phase 3 — Adopt OpenJD native chunking 🚧 in progress (this change)
@@ -209,8 +208,7 @@ them.
 - **Preconditions (⛔ not yet met):**
   - No submitter in use emits legacy names; no old job bundles in flight.
   - All internal test/canary bundles across all DCC integrations (not just
-    Unreal) audited for hand-authored legacy names — including the CMF-side
-    canaries found in `BealineTestJobBundles` (see CR-290057236).
+    Unreal) audited for hand-authored legacy names (tracked internally).
   - A soak period on 0.7.x with no observed legacy-name usage, or an
     explicit customer communication + waiting period.
   - Re-review these preconditions with the team before merging.
@@ -226,7 +224,7 @@ them.
 Phase 1  feat       adaptor accepts both names           (non-breaking)  ✅ merged (#324, 0.6.10)
    |       fleet rolled out to 0.6.10  ✅
 Phase 2  refactor!  submitter emits new names            (breaking, 0.7.0) ✅ merged (#338)
-   |       0.7.0 deployed everywhere (Gamma + Prod)  ✅
+   |       0.7.0 deployed to all production environments  ✅
    |       + default CondaPackages pin bump 0.6.* -> 0.7.*  ✅ merged (#343)
    |       all submitters updated
 Phase 3  feat       adopt OpenJD native chunking         (non-breaking, 0.7.x) 🚧 this change

--- a/docs/plans/render-partitioning-migration-plan.md
+++ b/docs/plans/render-partitioning-migration-plan.md
@@ -35,6 +35,23 @@ independently (run_data keys are their contract), we use an **expand/contract
   renders the full sequence instead of its partition), not loudly. This drives
   the per-phase ordering below.
 
+## Version compatibility matrix
+
+The durable copy of this matrix lives in
+[`docs/design/render-task-partitioning.md`](../design/render-task-partitioning.md#version-compatibility)
+(this plan file is deleted when the project completes). Summary:
+
+| Version | Submitter emits | Adaptor accepts |
+|---|---|---|
+| 0.6.x (≥ 0.6.10) | legacy names (`chunk_size`/`chunk_id`) | **both** legacy and new |
+| 0.7.x | new names (`shots_per_task`/`task_index`) | **both** legacy and new |
+| 0.8.x | new names | new names only |
+
+Any submitter/adaptor pairing within one minor version of each other keeps
+working; the silent wrong-output failure mode only occurs when a 0.7+
+submitter's template reaches a pre-0.6.10 adaptor, or a legacy template
+reaches a 0.8+ adaptor.
+
 ## Phases
 
 ### Phase 1 — Backwards-compatible adaptor ✅ merged (#324)
@@ -52,12 +69,11 @@ independently (run_data keys are their contract), we use an **expand/contract
 
 - Rename on submitter side: `OpenJobStepParameterNames`, bundled templates,
   sample scripts, user docs.
-- **`CondaPackages` pin bump (final Phase 2 step).** With 0.7.0 published to
-  the SMF conda channel and validated, the default `CondaPackages` pin is
-  bumped `unrealengine-openjd=0.6.*` → `0.7.*` in the render job templates
-  (this change) so SMF workers install the 0.7.x adaptor by default. This
-  merge is gated on 0.7 being available in the production conda channel — a
-  new-names default must not resolve on a fleet that lacks a Phase-1+ adaptor.
+- **`CondaPackages` pin bump (final Phase 2 step).** ✅ merged
+  ([#343](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/pull/343)).
+  With 0.7.0 published to the SMF conda channel and validated, the default
+  `CondaPackages` pin was bumped `unrealengine-openjd=0.6.*` → `0.7.*` in the
+  render job templates so SMF workers install the 0.7.x adaptor by default.
 - **Release:** breaking (`refactor!` + `BREAKING CHANGE:` footer), minor bump
   (0.6 → 0.7).
 - **Precondition:** Phase 1 (0.6.10) deployed to the entire fleet. ✅ met.
@@ -66,48 +82,164 @@ independently (run_data keys are their contract), we use an **expand/contract
 - **User migration:** update saved Data Assets, custom templates, and
   submission scripts that reference `ChunkSize`/`ChunkId`; regenerate old job
   bundles. (Find-and-replace details in the Phase-2 PR description.)
-- **Status:** submitter rename merged and released as 0.7.0; adaptor 0.7 built
-  and validated in the conda channel's pre-production stage; production
-  promotion in progress; default `CondaPackages` pin bump prepared (this
-  change), to merge once 0.7 reaches the production channel.
+  - Includes internal canary/test job bundles that hand-author OpenJD
+    templates rather than going through the submitter — these are just as
+    exposed to Phase 4 dropping legacy support as any customer template.
+    See `BealineTestJobBundles` CR-290057236 (conda branch) and
+    CR-290945992 (mainline branch) for the Unreal fountain canaries.
 - **Exit criterion:** all submitters in use emit new names.
 
-### Phase 3 — Drop legacy support from the adaptor
+### Phase 3 — Adopt OpenJD native chunking 🚧 in progress (this change)
 
-- Remove `_apply_param_aliases` and the legacy keys from
-  `run_data.schema.json`. Optionally set `additionalProperties: false` so a
-  stale legacy template fails loudly at validation.
-- **Release:** breaking (`refactor!` + `BREAKING CHANGE:` footer).
-- **Precondition:** no submitter in use emits legacy names; no old job bundles
-  in flight.
-- **Exit criterion:** rename complete.
+> **Ordering note:** this phase was previously sequenced *after* dropping
+> legacy adaptor support. The two are independent, and removing legacy
+> support is disruptive to users still migrating off the old names — so the
+> removal is deliberately sequenced last (Phase 4, released as 0.8.0), and
+> the new feature work proceeds first on 0.7.x.
 
-### Phase 4 — Adopt OpenJD native chunking (separate feature track)
+A distinct feature unblocked by the rename: add support for OpenJD's
+scheduler-level [`CHUNK[INT]` task chunking](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md)
+(the `TASK_CHUNKING` extension) as a **third, mutually-exclusive** chunking
+mode alongside the existing `ShotsPerTask` (shot-based) and `FramesPerTask`
+(frame-based) modes. Chunk boundaries are computed by Deadline Cloud at
+dispatch time from a `Frames` integer-range expression, rather than by the
+submitter at submission time.
 
-A distinct feature unblocked by the rename: replace `FramesPerTask` with
-OpenJD's scheduler-level `CHUNK[INT]` task chunking, where chunks are formed at
-dispatch time rather than at submission. `ShotsPerTask` likely remains
-submitter-side since OpenJD chunking operates on integer ranges, not shot
-lists.
+This is independent of the rename phases. Dynamic chunking is new
+functionality, added alongside the existing modes, not a replacement for
+them.
 
-- **Dependencies:** requires `TASK_CHUNKING` extension support in
-  worker-agent / openjd-sessions on target fleets.
-- **Release:** feature (`feat`); potentially breaking depending on whether
-  `FramesPerTask` is kept as an alias or removed.
+- **Dependencies:** requires `openjd-model` with `ChunkIntTaskParameterDefinition`
+  / `ExtensionName` / `TaskChunksDefinition` support (confirmed present in the
+  current dependency set) and `TASK_CHUNKING` extension support on the
+  worker-agent / openjd-sessions side of target fleets.
+- **Scope constraint:** Unreal's Movie Render Queue only accepts contiguous
+  frame ranges via `custom_start_frame`/`custom_end_frame`. Only
+  `rangeConstraint: CONTIGUOUS` is supported; `NONCONTIGUOUS` is out of scope
+  until MRQ supports non-sequential frame ranges (tracked separately).
+- **Template scope:** Phase 3 intentionally ships a **single template pair**
+  based on the base render job only
+  (`dynamic_chunking/dynamic_chunking_render_job.yml` + `_render_step.yml`).
+  Dynamic-chunking variants of the P4, UGS, and MPQ templates are follow-up
+  work, not part of this phase. The default submission path is unchanged:
+  the standard templates continue to use shots-per-task (`ShotsPerTask`)
+  mode, and dynamic chunking is strictly opt-in via the dedicated template.
+- **Prior attempt:** [PR #261](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/pull/261)
+  implemented this against an older revision of the codebase, before the
+  Phase 2 submitter rename landed. Its parameter and method names
+  (`ChunkSize`/`ChunkId`/`_get_chunk_ids_count()`/`enable_shots_by_chunk()`/
+  `chunk_size`/`chunk_id` run_data keys) are stale — the current codebase
+  uses `ShotsPerTask`/`TaskIndex`/`_get_task_count()`/`enable_shots_for_task()`/
+  `shots_per_task`/`task_index`. The design and test coverage from #261 are
+  reused; every identifier is re-mapped onto current names. The current
+  `run_script()` also carries `_apply_task_index_to_filename()`, added after
+  #261, which is not present in that PR and must be preserved/extended.
+- **Release:** feature (`feat`), non-breaking — ships as a 0.7.x patch.
+  Dynamic chunking is opt-in via a new template using the `TASK_CHUNKING`
+  extension and `CHUNK[INT]` type; existing `ShotsPerTask`/`FramesPerTask`
+  templates are unchanged.
+- **Release-ordering caveat:** the dynamic template's
+  `unrealengine-openjd=0.7.*` pin resolves to the *latest* 0.7.x. The adaptor
+  side of this change (the `dynamic_chunked_frames` run_data key) ships in
+  the same release, so the pin is satisfied as soon as that release reaches
+  the conda channel — but a fleet that resolves an older 0.7.x (stale cache,
+  explicit pin) silently renders the full sequence per chunk. A hard version
+  floor (`>=0.7.N`) is not currently expressible: the submitter's
+  `normalize_openjd_version_param` only recognizes `=X.Y.Z`-style pins and
+  would mangle a `>=` spec (fixing that normalizer is a prerequisite for
+  floor pins, tracked as follow-up). Do not promote the dynamic-chunking
+  template to users before the containing release is live in the production
+  conda channel.
+- **Design (mapped onto current names):**
+  - New job-level parameters: `OpenJobParameterNames.FRAMES` (`"Frames"`),
+    `TARGET_RUNTIME_SECONDS`, `RANGE_CONSTRAINT` (hardcoded `CONTIGUOUS` in
+    the bundled template).
+  - New step-level task parameter: `OpenJobStepParameterNames.DYNAMIC_CHUNKING`
+    (`"DynamicChunking"`, type `CHUNK[INT]`).
+  - `DynamicChunkingHelper` (new module,
+    `unreal_open_job_dynamic_chunking.py`): detects `CHUNK[INT]` usage in a
+    step template, validates `rangeConstraint`/`Frames` format, enforces at
+    most one `CHUNK[INT]` parameter per step.
+  - `RenderUnrealOpenJobStep._build_template()`: when a step uses dynamic
+    chunking, skip `_get_task_count()`/`TaskIndex` range calculation entirely
+    (chunk boundaries are computed by the scheduler, not the submitter).
+  - `RenderUnrealOpenJob._build_parameter_values()`: populate the `Frames`
+    job parameter from the MRQ job's frame range at submission time.
+  - Adaptor `UnrealRenderStepHandler.run_script()`: new
+    `dynamic_chunked_frames` run_data key, parsed by a new
+    `parse_dynamic_chunked_frames()` static method into `(start, end)`, with
+    the scheduler's inclusive end converted to Unreal's exclusive
+    `custom_end_frame` (`end + 1`). Integrates with, rather than replaces,
+    the existing `frames_per_task`/`shots_per_task` branches and
+    `_apply_task_index_to_filename()`.
+  - New bundled template pair:
+    `dynamic_chunking/dynamic_chunking_render_job.yml` and
+    `dynamic_chunking_render_step.yml`, added alongside the existing
+    `render_job.yml`/`render_step.yml` (opt-in, not a replacement).
+  - `open_job_template_api.py`: skip parameter types unsupported by Unreal's
+    `ValueType` enum (i.e. `CHUNK[INT]`) when converting step parameters for
+    the Data Asset UI, rather than erroring.
+- **Exit criterion:** a dynamic-chunking template renders correctly end to
+  end (unit tests + e2e job submission), with the legacy `ShotsPerTask`/
+  `FramesPerTask` templates unaffected and their existing tests still green.
+
+### Phase 4 — Drop legacy support from the adaptor, release 0.8 ⏸️ deferred
+
+> **Ordering note:** deliberately sequenced **last** (previously Phase 3).
+> Removing the legacy aliases is disruptive to any user still on the old
+> names, and it fails **silently** (a stale template renders the full
+> sequence instead of its partition, with no error). Deferring it behind the
+> dynamic-chunking feature work gives users the entire 0.7.x line as a
+> migration window, and makes the cut-over an explicit, plannable minor
+> release (0.8.0) rather than a change folded in alongside other work.
+
+- Remove `_apply_param_aliases` and the legacy `chunk_size`/`chunk_id` keys
+  from `run_data.schema.json`.
+  - Not doing (out of scope): setting `additionalProperties: false`. The
+    schema is currently missing `frames_per_task` (a live, actively-used key
+    emitted by the bundled templates), so locking down `additionalProperties`
+    now would newly reject it. That requires a separate audit of every
+    emitted run_data key before it can be enabled safely.
+- **Release: 0.8.0** — breaking (`refactor!` + `BREAKING CHANGE:` footer),
+  minor bump (0.7 → 0.8). After this release the rename is complete on both
+  sides: the submitter emits only new names (since 0.7.0) and the adaptor
+  accepts only new names. Follow with a `CondaPackages` default pin bump
+  `unrealengine-openjd=0.7.*` → `0.8.*` once 0.8 is validated in the
+  production conda channel (same gated two-step as the Phase 2 pin bump).
+- **Preconditions (⛔ not yet met):**
+  - No submitter in use emits legacy names; no old job bundles in flight.
+  - All internal test/canary bundles across all DCC integrations (not just
+    Unreal) audited for hand-authored legacy names — including the CMF-side
+    canaries found in `BealineTestJobBundles` (see CR-290057236).
+  - A soak period on 0.7.x with no observed legacy-name usage, or an
+    explicit customer communication + waiting period.
+  - Re-review these preconditions with the team before merging.
+- **Status: deferred, deliberately not merging yet.** The implementation
+  branch that previously existed for this work has since been removed while
+  the hold is in effect; re-create it from this plan when resuming.
+- **Exit criterion:** 0.8.0 released; rename complete in both submitter and
+  adaptor.
 
 ## Sequencing summary
 
 ```
 Phase 1  feat       adaptor accepts both names           (non-breaking)  ✅ merged (#324, 0.6.10)
    |       fleet rolled out to 0.6.10  ✅
-Phase 2  refactor!  submitter emits new names            (breaking)      ✅ merged (#338, 0.7.0)
-   |       + default CondaPackages pin bumped 0.6.* -> 0.7.*  <-- this change
+Phase 2  refactor!  submitter emits new names            (breaking, 0.7.0) ✅ merged (#338)
+   |       0.7.0 deployed everywhere (Gamma + Prod)  ✅
+   |       + default CondaPackages pin bump 0.6.* -> 0.7.*  ✅ merged (#343)
    |       all submitters updated
-Phase 3  refactor!  adaptor drops legacy-name support    (breaking)
+Phase 3  feat       adopt OpenJD native chunking         (non-breaking, 0.7.x) 🚧 this change
    |
-Phase 4  feat       adopt OpenJD native chunking         (feature)      independent track
+Phase 4  refactor!  adaptor drops legacy-name support    (breaking, 0.8.0) ⏸️ DEFERRED
+           preconditions not met: cannot yet confirm no legacy-name
+           submitters/bundles remain in flight
 ```
 
+End state by version: **0.6** — old names in the submitter, adaptor accepts
+both; **0.7** — new names in the submitter, adaptor accepts both; **0.8** —
+new names in both submitter and adaptor.
+
 Don't collapse phases: skipping Phase 1's fleet rollout before Phase 2, or
-Phase 2's rollout before Phase 3, reintroduces the silent wrong-output failure
-this plan exists to avoid.
+Phase 2's rollout before Phase 4's legacy removal, reintroduces the silent
+wrong-output failure this plan exists to avoid.

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/run_data.schema.json
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/run_data.schema.json
@@ -14,6 +14,10 @@
         "chunk_id": { "type": "integer" },
         "shots_per_task": { "type": "integer" },
         "task_index": { "type": "integer" },
+        "dynamic_chunked_frames": {
+            "type": "string",
+            "description": "Contiguous frame range chunk '<start>-<end>' (inclusive) computed by the OpenJD TASK_CHUNKING extension. Mutually exclusive with frames_per_task/shots_per_task."
+        },
         "output_path": { "type":  "string" },
         "submit_mode": {
             "type": "string",

--- a/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
+++ b/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
@@ -402,6 +402,45 @@ class UnrealRenderStepHandler(BaseStepHandler):
         )
 
     @staticmethod
+    def parse_dynamic_chunked_frames(dynamic_chunked_frames: str) -> tuple[int, int]:
+        """
+        Parse a contiguous frame chunk expression into start and end frames.
+
+        IMPORTANT: Only CONTIGUOUS rangeConstraint is supported. Non-contiguous frame lists
+        (e.g., "1,5,10" or "1-5,10-15") are NOT supported because Unreal Engine's Movie Render
+        Queue (MRQ) only accepts contiguous frame ranges via custom_start_frame/custom_end_frame.
+        MRQ does not provide an API to render arbitrary non-contiguous frames in a single job.
+
+        Supported format:
+            Range: "<start>-<end>" (e.g., "1-10", "5-5", "0-100", "-100--76", "-50-10")
+
+        :param dynamic_chunked_frames: Frame chunk expression string from TASK_CHUNKING extension
+            (must be CONTIGUOUS rangeConstraint)
+        :return: Tuple of (start_frame, end_frame)
+        :raises ValueError: If dynamic_chunked_frames is empty, malformed, or not in range format
+        """
+        if not dynamic_chunked_frames or not dynamic_chunked_frames.strip():
+            raise ValueError("dynamic_chunked_frames cannot be empty")
+
+        dynamic_chunked_frames = dynamic_chunked_frames.strip()
+
+        # CONTIGUOUS mode always returns range format: "<start>-<end>"
+        match = re.match(r"^(-?\d+)-(-?\d+)$", dynamic_chunked_frames)
+        if match:
+            start = int(match.group(1))
+            end = int(match.group(2))
+            if start > end:
+                raise ValueError(
+                    f"Invalid frame range: start ({start}) cannot be greater than end ({end})"
+                )
+            return (start, end)
+
+        raise ValueError(
+            f"Invalid dynamic_chunked_frames format: '{dynamic_chunked_frames}'. "
+            "Expected range format '<start>-<end>' (e.g., '1-10', '5-5', '-100-100')"
+        )
+
+    @staticmethod
     def _apply_param_aliases(args: dict) -> dict:
         """Accept both the legacy and new run_data keys for the render
         partitioning parameters, for backwards compatibility during the
@@ -471,7 +510,50 @@ class UnrealRenderStepHandler(BaseStepHandler):
         if "task_index" in args:
             task_index: int = args["task_index"]
         for job in subsystem.get_queue().get_jobs():
-            if args.get("frames_per_task") and "task_index" in args:
+            # Dynamic chunking, frame-based and shot-based chunking are mutually
+            # exclusive modes, checked in that priority order.
+            dynamic_chunk_start_frame: Optional[int] = None
+            if "dynamic_chunked_frames" in args:
+                # Dynamic chunking: the scheduler (TASK_CHUNKING extension) computes the
+                # frame range and passes it pre-computed via dynamic_chunked_frames.
+                start_frame, end_frame = self.parse_dynamic_chunked_frames(
+                    args["dynamic_chunked_frames"]
+                )
+                # The scheduler returns inclusive frame ranges (e.g., "10-10" means 1 frame),
+                # but Unreal's custom_end_frame is exclusive. Add 1 to convert the
+                # inclusive scheduler end to Unreal's exclusive end.
+                end_frame = end_frame + 1
+                dynamic_chunk_start_frame = start_frame
+                # Always resolve output settings for the CURRENT job - caching
+                # across the queue loop would apply the first job's settings
+                # object to every subsequent job in the queue.
+                output_settings = job.get_configuration().find_or_add_setting_by_class(
+                    unreal.MoviePipelineOutputSetting
+                )
+                level_sequence = unreal.EditorAssetLibrary.load_asset(
+                    unreal.SystemLibrary.conv_soft_object_reference_to_string(
+                        unreal.SystemLibrary.conv_soft_obj_path_to_soft_obj_ref(job.sequence)
+                    )
+                )
+                # Dynamic chunking requires explicit custom playback range
+                output_settings.use_custom_playback_range = True
+                output_settings.custom_start_frame = start_frame
+                output_settings.custom_end_frame = end_frame
+
+                if level_sequence is not None:
+                    level_sequence.set_playback_start(start_frame)
+                    level_sequence.set_playback_end(end_frame)
+                    logger.info(
+                        f"Rendering custom frame range from {output_settings.custom_start_frame} to {output_settings.custom_end_frame} with sequence playback start {level_sequence.get_playback_start()} end {level_sequence.get_playback_end()}"
+                    )
+                else:
+                    logger.warning(
+                        "Rendering dynamic chunk frame range "
+                        f"[{output_settings.custom_start_frame}, "
+                        f"{output_settings.custom_end_frame}] without a resolved "
+                        "LevelSequence; relying on output_settings.use_custom_playback_range"
+                    )
+            elif args.get("frames_per_task") and "task_index" in args:
                 frames_per_task: int = args["frames_per_task"]
                 if not output_settings:
                     output_settings = job.get_configuration().find_or_add_setting_by_class(
@@ -527,7 +609,20 @@ class UnrealRenderStepHandler(BaseStepHandler):
                     task_index=task_index,
                 )
 
-            if "task_index" in args and (args.get("frames_per_task") or "shots_per_task" in args):
+            if "dynamic_chunked_frames" in args and dynamic_chunk_start_frame is not None:
+                # Dynamic chunking has no task_index in args (chunks are not indexed that
+                # way). Chunk start frames are unique across chunks of a CONTIGUOUS range,
+                # so substitute the chunk start frame for the {task_index} filename token
+                # to keep per-task output filenames from colliding.
+                logger.info(
+                    "Dynamic chunking provides no task index; substituting the chunk "
+                    f"start frame ({dynamic_chunk_start_frame}) for the {{task_index}} "
+                    "filename token to disambiguate per-task output"
+                )
+                UnrealRenderStepHandler._apply_task_index_to_filename(
+                    job, dynamic_chunk_start_frame
+                )
+            elif "task_index" in args and (args.get("frames_per_task") or "shots_per_task" in args):
                 UnrealRenderStepHandler._apply_task_index_to_filename(job, task_index)
 
             if "output_path" in args:

--- a/src/deadline/unreal_submitter/exceptions.py
+++ b/src/deadline/unreal_submitter/exceptions.py
@@ -65,5 +65,11 @@ class FailedToDetectFilesTransferStrategy(DeadlineCloudSubmitterException):
     """Raised when its failed to detect which strategy to use for transfer files to render"""
 
 
+class SubmitterInputValidationError(DeadlineCloudSubmitterException):
+    """Raised when user input validation fails during job submission"""
+
+    pass
+
+
 class ProjectIsNotUnderWorkspaceError(Exception):
     """Raised when current Unreal Project is not under the current Workspace"""

--- a/src/deadline/unreal_submitter/settings.py
+++ b/src/deadline/unreal_submitter/settings.py
@@ -27,3 +27,10 @@ P4_ASSEMBLE_SHELVES_STEP_TEMPLATE_DEFAULT_PATH = "p4/p4_assemble_shelves_step.ym
 P4_LAUNCH_ENVIRONMENT_TEMPLATE_DEFAULT_PATH = "p4/p4_launch_ue_environment.yml"
 P4_SYNC_CMF_ENVIRONMENT_TEMPLATE_DEFAULT_PATH = "p4/p4_sync_cmf_environment.yml"
 P4_SYNC_SMF_ENVIRONMENT_TEMPLATE_DEFAULT_PATH = "p4/p4_sync_smf_environment.yml"
+
+DYNAMIC_CHUNKING_RENDER_JOB_TEMPLATE_DEFAULT_PATH = (
+    "dynamic_chunking/dynamic_chunking_render_job.yml"
+)
+DYNAMIC_CHUNKING_RENDER_STEP_TEMPLATE_DEFAULT_PATH = (
+    "dynamic_chunking/dynamic_chunking_render_step.yml"
+)

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -99,6 +99,9 @@ class UnrealOpenJobParameterDefinition:
         build_kwargs = dict(name=u_param.name, type=u_param.type.name)
         if u_param.value:
             python_class = PARAMETER_DEFINITION_MAPPING[u_param.type.name].python_class
+            # Unreal's ValueType enum never maps to task-only types such as CHUNK[INT],
+            # so a python_class is always available here.
+            assert python_class is not None
             build_kwargs["value"] = python_class(u_param.value)
         return cls(**build_kwargs)
 
@@ -380,13 +383,23 @@ class UnrealOpenJob(UnrealOpenJobEntity):
         :rtype: JobTemplate
         """
 
+        parameter_definitions = []
+        for param in self.get_template_object()["parameterDefinitions"]:
+            job_parameter_class = PARAMETER_DEFINITION_MAPPING[
+                param["type"]
+            ].job_parameter_openjd_class
+            if job_parameter_class is None:
+                # Task-only types (e.g. CHUNK[INT]) have no job-level equivalent
+                raise exceptions.SubmitterInputValidationError(
+                    f'Job parameter "{param.get("name")}" has type "{param["type"]}" '
+                    f"which is not valid at the job level"
+                )
+            parameter_definitions.append(job_parameter_class(**param))
+
         template_dict = {
             "specificationVersion": settings.JOB_TEMPLATE_VERSION,
             "name": self.name,
-            "parameterDefinitions": [
-                PARAMETER_DEFINITION_MAPPING[param["type"]].job_parameter_openjd_class(**param)
-                for param in self.get_template_object()["parameterDefinitions"]
-            ],
+            "parameterDefinitions": parameter_definitions,
             "steps": [s.build_template() for s in self._steps],
         }
 
@@ -1148,6 +1161,109 @@ class RenderUnrealOpenJob(UnrealOpenJob):
 
         return parameter_values
 
+    def _is_using_dynamic_chunking(self) -> bool:
+        """
+        Check if any step in this job uses dynamic chunking (CHUNK[INT] type).
+
+        :return: True if any step uses dynamic chunking, False otherwise
+        :rtype: bool
+        """
+        from deadline.unreal_submitter.unreal_open_job.unreal_open_job_dynamic_chunking import (
+            DynamicChunkingHelper,
+        )
+
+        for step in self._steps:
+            try:
+                step_template_object = step.get_template_object()
+                if DynamicChunkingHelper.is_using_dynamic_chunking(step_template_object):
+                    return True
+            except FileNotFoundError:
+                # A step without a resolvable template file cannot declare
+                # CHUNK[INT]; other exceptions propagate so real bugs surface.
+                continue
+        return False
+
+    def _build_frames_parameter_value(self, parameter_values: list[dict]) -> list[dict]:
+        """
+        Build and return the Frames parameter value for dynamic chunking templates.
+
+        Extracts the frame range from MRQ settings:
+        - If custom playback range is enabled, uses custom_start_frame and custom_end_frame
+        - Otherwise, uses the level sequence's playback range
+
+        The frame range is formatted as "<start>-<end>" (e.g., "0-99" for 100 frames).
+
+        :param parameter_values: list of parameter values to be updated
+        :type parameter_values: list[dict]
+
+        :return: list of updated parameter values
+        :rtype: list[dict]
+        """
+        # Check if Frames parameter exists in the parameter values (indicates dynamic chunking)
+        frames_param = next(
+            (p for p in parameter_values if p["name"] == OpenJobParameterNames.FRAMES), None
+        )
+        if not frames_param:
+            return parameter_values
+
+        # Skip if Frames already has a value
+        if frames_param.get("value") is not None:
+            return parameter_values
+
+        # Need MRQ job to extract frame range
+        if not self._mrq_job:
+            logger.warning(
+                "Cannot populate Frames parameter: MRQ job is not set. "
+                "Dynamic chunking requires frame range from MRQ settings."
+            )
+            return parameter_values
+
+        # Load output settings and level sequence from MRQ job
+        output_settings = self._mrq_job.get_configuration().find_setting_by_class(
+            unreal.MoviePipelineOutputSetting
+        )
+        level_sequence = unreal.EditorAssetLibrary.load_asset(
+            unreal.SystemLibrary.conv_soft_object_reference_to_string(
+                unreal.SystemLibrary.conv_soft_obj_path_to_soft_obj_ref(self._mrq_job.sequence)
+            )
+        )
+
+        if not level_sequence:
+            logger.warning(
+                "Cannot populate Frames parameter: Level sequence not found. "
+                "Dynamic chunking requires frame range from level sequence."
+            )
+            return parameter_values
+
+        # Extract frame range from MRQ settings
+        if output_settings and output_settings.use_custom_playback_range:
+            start_frame = output_settings.custom_start_frame
+            end_frame = output_settings.custom_end_frame
+            logger.info(
+                f"Using custom playback range for Frames parameter: {start_frame}-{end_frame}"
+            )
+        else:
+            start_frame = level_sequence.get_playback_range().get_start_frame()
+            end_frame = level_sequence.get_playback_range().get_end_frame()
+            logger.info(
+                f"Using level sequence playback range for Frames parameter: {start_frame}-{end_frame}"
+            )
+
+        # Format as "<start>-<end>" for OpenJD IntRangeExpr. MRQ end frames
+        # (custom_end_frame / playback range end) are EXCLUSIVE, while OpenJD
+        # integer range expressions are INCLUSIVE on both ends ("10-20" is 11
+        # frames) - subtract 1 so the last chunk doesn't render a frame past
+        # the end of the sequence.
+        frames_value = f"{start_frame}-{end_frame - 1}"
+
+        parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
+            job_parameter_values=parameter_values,
+            job_parameter_name=OpenJobParameterNames.FRAMES,
+            job_parameter_value=frames_value,
+        )
+
+        return parameter_values
+
     def _build_parameter_values(self) -> list:
         """
         Build and return list of parameter values for the OpenJob. Use YAML parameter names and
@@ -1165,6 +1281,8 @@ class RenderUnrealOpenJob(UnrealOpenJob):
           (see :meth:`deadline.unreal_submitter.unreal_open_job.unreal_open_job.RenderUnrealOpenJob._build_parameter_values_for_ugs()`)
         - Parameters for P4 if P4 is used
           (see :meth:`deadline.unreal_submitter.unreal_open_job.unreal_open_job.RenderUnrealOpenJob._build_parameter_values_for_p4()`)
+        - Frames parameter for dynamic chunking templates
+          (see :meth:`deadline.unreal_submitter.unreal_open_job.unreal_open_job.RenderUnrealOpenJob._build_frames_parameter_value()`)
 
         .. note:: If expected parameter missed, it will be skipped
 
@@ -1251,6 +1369,12 @@ class RenderUnrealOpenJob(UnrealOpenJob):
 
         if self._transfer_files_strategy == TransferProjectFilesStrategy.P4:
             unfilled_parameter_values = self._build_parameter_values_for_p4(
+                parameter_values=unfilled_parameter_values
+            )
+
+        # Populate Frames parameter for dynamic chunking templates
+        if self._is_using_dynamic_chunking():
+            unfilled_parameter_values = self._build_frames_parameter_value(
                 parameter_values=unfilled_parameter_values
             )
 

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -1254,7 +1254,14 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         # integer range expressions are INCLUSIVE on both ends ("10-20" is 11
         # frames) - subtract 1 so the last chunk doesn't render a frame past
         # the end of the sequence.
-        frames_value = f"{start_frame}-{end_frame - 1}"
+        inclusive_end_frame = end_frame - 1
+        if inclusive_end_frame < start_frame:
+            raise exceptions.SubmitterInputValidationError(
+                "Cannot populate Frames parameter from an empty or descending MRQ frame range: "
+                f"[{start_frame}, {end_frame})."
+            )
+
+        frames_value = f"{start_frame}-{inclusive_end_frame}"
 
         parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
             job_parameter_values=parameter_values,

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_dynamic_chunking.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_dynamic_chunking.py
@@ -1,0 +1,214 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import re
+from typing import Optional
+
+from deadline.unreal_logger import get_logger
+from deadline.unreal_submitter.exceptions import SubmitterInputValidationError
+
+logger = get_logger()
+
+
+class DynamicChunkingHelper:
+    """
+    Helper class for TASK_CHUNKING extension.
+
+    Contains all logic related to dynamic chunking:
+    - Template detection (CHUNK[INT] type)
+    - RangeConstraint validation (CONTIGUOUS only; MRQ cannot render non-contiguous ranges)
+    - Frames parameter format validation (IntRangeList/IntRangeExpr)
+    - Single CHUNK[INT] per step constraint
+    """
+
+    @staticmethod
+    def is_chunk_parameter_type(param_type: str) -> bool:
+        """
+        Check if a parameter type is a CHUNK type (e.g., CHUNK[INT]).
+
+        :param param_type: The parameter type string to check
+        :return: True if the type contains "CHUNK", False otherwise
+        """
+        return "CHUNK" in param_type
+
+    @staticmethod
+    def is_using_dynamic_chunking(step_template_object: dict) -> bool:
+        """
+        Detect if a step template uses TASK_CHUNKING extension.
+
+        Checks if any task parameter in the step template has a type containing "CHUNK"
+        (e.g., CHUNK[INT]), which indicates the template uses dynamic chunking.
+
+        :param step_template_object: Parsed YAML step template dictionary
+        :return: True if any task parameter has type containing "CHUNK", False otherwise
+        """
+        try:
+            task_param_definitions = step_template_object.get("parameterSpace", {}).get(
+                "taskParameterDefinitions", []
+            )
+            for param in task_param_definitions:
+                param_type = param.get("type", "")
+                if DynamicChunkingHelper.is_chunk_parameter_type(param_type):
+                    return True
+            return False
+        except (TypeError, AttributeError):
+            logger.warning(
+                "Malformed step_template_object in is_using_dynamic_chunking - "
+                "CHUNK parameters is only expected in step_template_object"
+            )
+            return False
+
+    @staticmethod
+    def _validate_range_constraint(range_constraint: str) -> None:
+        """
+        Validate that RangeConstraint value is CONTIGUOUS.
+
+        Only CONTIGUOUS is supported: Unreal's Movie Render Queue renders frame
+        windows via custom_start_frame/custom_end_frame and cannot render an
+        arbitrary (non-contiguous) frame list, so a NONCONTIGUOUS chunk would
+        fail at render time on the worker. Rejecting it at submission surfaces
+        the error to the user immediately instead.
+
+        :param range_constraint: The RangeConstraint value to validate
+        :type range_constraint: str
+
+        :raises SubmitterInputValidationError: If value is not CONTIGUOUS
+        """
+        if range_constraint != "CONTIGUOUS":
+            raise SubmitterInputValidationError(
+                f'Invalid RangeConstraint value "{range_constraint}". '
+                "Only CONTIGUOUS is supported: Unreal's Movie Render Queue cannot "
+                "render non-contiguous frame lists."
+            )
+
+    @staticmethod
+    def _validate_single_chunk_parameter_per_step(step_template_object: dict) -> None:
+        """
+        Validate that a step template contains at most one CHUNK[INT] task parameter.
+
+        The OpenJobDescription TASK_CHUNKING extension only supports a single CHUNK[INT]
+        parameter per step. This function counts CHUNK[INT] parameters and raises an
+        error if more than one is found.
+
+        :param step_template_object: Parsed YAML step template dictionary
+        :raises SubmitterInputValidationError: If more than one CHUNK[INT] parameter is found
+        """
+        try:
+            task_param_definitions = step_template_object.get("parameterSpace", {}).get(
+                "taskParameterDefinitions", []
+            )
+            chunk_params = []
+            for param in task_param_definitions:
+                param_type = param.get("type", "")
+                if DynamicChunkingHelper.is_chunk_parameter_type(param_type):
+                    chunk_params.append(param.get("name", "unknown"))
+
+            if len(chunk_params) > 1:
+                raise SubmitterInputValidationError(
+                    f"Step template contains {len(chunk_params)} CHUNK[INT] task parameters "
+                    f"({', '.join(chunk_params)}), but only one CHUNK[INT] parameter is allowed per step. "
+                    f"Please remove the extra CHUNK[INT] parameters from the step template."
+                )
+        except (TypeError, AttributeError):
+            logger.warning(
+                "Malformed step_template_object in _validate_single_chunk_parameter_per_step - "
+                "skipping CHUNK parameter count validation"
+            )
+
+    @staticmethod
+    def validate_chunk_parameter(step_template_object: dict, frames: Optional[str] = None) -> None:
+        """
+        Validate all elements of CHUNK[INT] parameters in a step template.
+
+        This method consolidates all CHUNK[INT] validation:
+        1. Validates only one CHUNK[INT] parameter exists per step
+        2. Validates rangeConstraint value if it's a literal (not a template expression)
+        3. Validates frames parameter format if provided
+
+        :param step_template_object: Parsed YAML step template dictionary
+        :param frames: Optional frames parameter value to validate
+        :raises SubmitterInputValidationError: If validation fails
+        """
+        # Validate single CHUNK[INT] per step
+        DynamicChunkingHelper._validate_single_chunk_parameter_per_step(step_template_object)
+
+        # Find and validate CHUNK[INT] parameter's chunks configuration
+        try:
+            task_param_definitions = step_template_object.get("parameterSpace", {}).get(
+                "taskParameterDefinitions", []
+            )
+            for param in task_param_definitions:
+                param_type = param.get("type", "")
+                if DynamicChunkingHelper.is_chunk_parameter_type(param_type):
+                    chunks_config = param.get("chunks", {})
+
+                    # Validate rangeConstraint if it's a literal value (not a template expression)
+                    range_constraint = chunks_config.get("rangeConstraint", "")
+                    if range_constraint and not range_constraint.startswith("{{"):
+                        DynamicChunkingHelper._validate_range_constraint(range_constraint)
+
+        except (TypeError, AttributeError):
+            logger.warning(
+                "Malformed step_template_object in validate_chunk_parameter - "
+                "skipping chunks configuration validation"
+            )
+
+        # Validate frames parameter if provided
+        if frames:
+            DynamicChunkingHelper.validate_frames_parameter(frames)
+
+    @staticmethod
+    def validate_frames_parameter(frames: str) -> None:
+        """
+        Validate that frames parameter conforms to IntRangeList or IntRangeExpr format.
+        Reference: https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md
+
+        Valid formats per OpenJD specification:
+        - Single integer: "5", "100", "-10"
+        - Range: "1-100", "0-50", "-10-49", "-100--76"
+        - Range with step: "1-100:2", "0-100:5"
+        - Comma-separated list (IntRangeList): "1-10,15,20-30", "1,2,3"
+        - Mixed formats: "1-10:2,15,20-30"
+
+        Negative frame numbers are supported, matching Unreal sequences whose
+        playback range starts below zero (the submitter's own auto-population
+        can produce e.g. "-10-49") and the adaptor's chunk parser.
+
+        Note: Empty frames is not valid.
+
+        :param frames: Frame range expression string
+        :raises SubmitterInputValidationError: If frames format is invalid or empty
+        """
+        if not frames or not frames.strip():
+            raise SubmitterInputValidationError(
+                "Frames parameter is required. "
+                "Specify a frame range (e.g., '1-100', '1,5,10-20:2')."
+            )
+
+        frames = frames.strip()
+
+        # Regex pattern for validating Frames parameter format
+        # Supports IntRangeList and IntRangeExpr formats per OpenJD specification:
+        # - Single integer (possibly negative): "5", "0", "-10"
+        # - Range: "1-100", "-10-49", "-100--76"
+        # - Range with step: "1-100:2" (step only valid with range, always positive)
+        # - Comma-separated list: "1,2,3", "1-10,15,20-30"
+        # - Mixed: "1-10:2,15,20-30"
+        #
+        # The range alternation mirrors the adaptor's parse_dynamic_chunked_frames
+        # pattern (r"^(-?\d+)-(-?\d+)$") so submitter and adaptor accept the same
+        # expressions.
+        single_int = r"-?\d+"
+        range_with_optional_step = r"-?\d+--?\d+(?::\d+)?"
+        int_range_element_pattern = rf"(?:{range_with_optional_step}|{single_int})"
+        frames_validation_pattern = re.compile(
+            rf"^{int_range_element_pattern}(?:,{int_range_element_pattern})*$"
+        )
+
+        if not frames_validation_pattern.match(frames):
+            raise SubmitterInputValidationError(
+                f'Invalid Frames parameter value "{frames}". '
+                f"Frames must conform to IntRangeList format (e.g., '1-10,15,20-30') "
+                f"or IntRangeExpr format (e.g., '1-100:2'). "
+                f"Valid formats include: integers ('5', '-10'), ranges ('1-100', '-10-49'), "
+                f"ranges with step ('1-100:2'), or comma-separated combinations."
+            )

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_dynamic_chunking.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_dynamic_chunking.py
@@ -194,9 +194,10 @@ class DynamicChunkingHelper:
         # - Comma-separated list: "1,2,3", "1-10,15,20-30"
         # - Mixed: "1-10:2,15,20-30"
         #
-        # The range alternation mirrors the adaptor's parse_dynamic_chunked_frames
-        # pattern (r"^(-?\d+)-(-?\d+)$") so submitter and adaptor accept the same
-        # expressions.
+        # This validates the job-level OpenJD integer range expression. With
+        # rangeConstraint CONTIGUOUS, the scheduler canonicalizes each dispatched
+        # chunk as "<start>-<end>", including singleton chunks such as "5-5".
+        # The adaptor therefore intentionally accepts a narrower runtime shape.
         single_int = r"-?\d+"
         range_with_optional_step = r"-?\d+--?\d+(?::\d+)?"
         int_range_element_pattern = rf"(?:{range_with_optional_step}|{single_int})"
@@ -212,3 +213,21 @@ class DynamicChunkingHelper:
                 f"Valid formats include: integers ('5', '-10'), ranges ('1-100', '-10-49'), "
                 f"ranges with step ('1-100:2'), or comma-separated combinations."
             )
+
+        range_element_pattern = re.compile(r"^(-?\d+)-(-?\d+)(?::(\d+))?$")
+        for element in frames.split(","):
+            range_match = range_element_pattern.match(element)
+            if not range_match:
+                continue
+
+            start_frame, end_frame, step = range_match.groups()
+            if int(start_frame) > int(end_frame):
+                raise SubmitterInputValidationError(
+                    f'Invalid Frames parameter value "{frames}". '
+                    f'Range start must not exceed range end in "{element}".'
+                )
+            if step is not None and int(step) < 1:
+                raise SubmitterInputValidationError(
+                    f'Invalid Frames parameter value "{frames}". '
+                    f'Range step must be at least 1 in "{element}".'
+                )

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_entity.py
@@ -19,6 +19,7 @@ from openjd.model.v2023_09 import (
     FloatTaskParameterDefinition,
     StringTaskParameterDefinition,
     PathTaskParameterDefinition,
+    ChunkIntTaskParameterDefinition,
 )
 
 from deadline.client.job_bundle.submission import AssetReferences
@@ -211,31 +212,36 @@ class ParameterDefinitionDescriptor:
     """
     Data class for converting C++, OpenJD and generic Python classes between each other
 
-    :cvar type_name: OpenJD type (INT, FLOAT, STRING, PATH)
+    :cvar type_name: OpenJD type (INT, FLOAT, STRING, PATH, CHUNK[INT])
     :cvar job_parameter_openjd_class: OpenJD class for int, float, string, path Job parameter
     :cvar task_parameter_openjd_class: OpenJD class for int, float, string, path Step parameter
     :cvar python_class: Appropriate python class (int, float, string, path)
     """
 
-    type_name: Literal["INT", "FLOAT", "STRING", "PATH"]
-    job_parameter_openjd_class: type[
-        Union[
-            JobIntParameterDefinition,
-            JobFloatParameterDefinition,
-            JobStringParameterDefinition,
-            JobPathParameterDefinition,
+    type_name: Literal["INT", "FLOAT", "STRING", "PATH", "CHUNK[INT]"]
+    job_parameter_openjd_class: Optional[
+        type[
+            Union[
+                JobIntParameterDefinition,
+                JobFloatParameterDefinition,
+                JobStringParameterDefinition,
+                JobPathParameterDefinition,
+            ]
         ]
     ]
-    job_parameter_attribute_name: Literal["int_value", "float_value", "string_value", "path_value"]
+    job_parameter_attribute_name: Optional[
+        Literal["int_value", "float_value", "string_value", "path_value"]
+    ]
     task_parameter_openjd_class: type[
         Union[
             IntTaskParameterDefinition,
             FloatTaskParameterDefinition,
             StringTaskParameterDefinition,
             PathTaskParameterDefinition,
+            ChunkIntTaskParameterDefinition,
         ]
     ]
-    python_class: type[Union[int, float, str]]
+    python_class: Optional[type[Union[int, float, str]]]
 
 
 PARAMETER_DEFINITION_MAPPING = {
@@ -250,6 +256,10 @@ PARAMETER_DEFINITION_MAPPING = {
     ),
     "PATH": ParameterDefinitionDescriptor(
         "PATH", JobPathParameterDefinition, "path_value", PathTaskParameterDefinition, str
+    ),
+    # CHUNK[INT] is a task-only parameter type (no job-level equivalent, no Python conversion)
+    "CHUNK[INT]": ParameterDefinitionDescriptor(
+        "CHUNK[INT]", None, None, ChunkIntTaskParameterDefinition, None
     ),
 }
 
@@ -268,6 +278,10 @@ class OpenJobParameterNames:
     :cvar UNREAL_EXECUTABLE_RELATIVE_PATH: UE executable path relative to P4 workspace root
     :cvar PERFORCE_STREAM_PATH: P4 stream path, e.g. //MyProject/Mainline
     :cvar PERFORCE_CHANGELIST_NUMBER: P4 changelist to sync workspace to
+
+    :cvar FRAMES: Frame range expression for dynamic chunking (e.g., "1-100", "1,3,5-10:2")
+    :cvar TARGET_RUNTIME_SECONDS: Target runtime in seconds per chunk for dynamic chunking
+    :cvar RANGE_CONSTRAINT: Whether frames in a chunk must be CONTIGUOUS or NONCONTIGUOUS
     """
 
     UNREAL_PROJECT_PATH = "ProjectFilePath"
@@ -283,6 +297,11 @@ class OpenJobParameterNames:
     PERFORCE_STREAM_PATH = "PerforceStreamPath"
     PERFORCE_CHANGELIST_NUMBER = "PerforceChangelistNumber"
     PERFORCE_WORKSPACE_SPECIFICATION_TEMPLATE = "PerforceWorkspaceSpecificationTemplate"
+
+    # Dynamic chunking (TASK_CHUNKING extension) job-level parameters
+    FRAMES = "Frames"
+    TARGET_RUNTIME_SECONDS = "TargetRuntimeSeconds"
+    RANGE_CONSTRAINT = "RangeConstraint"
 
 
 class OpenJobStepParameterNames:
@@ -301,6 +320,8 @@ class OpenJobStepParameterNames:
     :cvar FRAMES_PER_TASK: If set, each task will render this number of frames
     :cvar SHOTS_PER_TASK: Count of the shots per OpenJD Step's Task unless FRAMES_PER_TASK set
     :cvar TASK_INDEX: Index of the task (0-based) within the OpenJD Step's parameter space
+
+    :cvar DYNAMIC_CHUNKING: Task parameter name for CHUNK[INT] type in dynamic chunking templates
     """
 
     QUEUE_MANIFEST_PATH = "QueueManifestPath"
@@ -314,3 +335,6 @@ class OpenJobStepParameterNames:
     FRAMES_PER_TASK = "FramesPerTask"
     SHOTS_PER_TASK = "ShotsPerTask"
     TASK_INDEX = "TaskIndex"
+
+    # Dynamic chunking (TASK_CHUNKING extension) step-level task parameter
+    DYNAMIC_CHUNKING = "DynamicChunking"

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_parameters_consistency.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_parameters_consistency.py
@@ -310,8 +310,23 @@ class ParametersConsistencyChecker:
             yaml_parameters=[
                 (p["name"], p["type"])
                 for p in step_template["parameterSpace"]["taskParameterDefinitions"]
+                # CHUNK[INT] (OpenJD TASK_CHUNKING extension) has no equivalent in
+                # Unreal's ValueType enum, so Data Assets cannot hold it by design
+                # (open_job_template_api.py skips it when building the Data Asset).
+                # Excluding it here keeps a valid dynamic-chunking Data Asset from
+                # failing the consistency check.
+                if not p["type"].startswith("CHUNK[")
             ],
-            data_asset_parameters=[(p["name"], p["type"]) for p in step_parameters],
+            # Excluded from the Data Asset side too: a Data Asset can carry a
+            # stale CHUNK[INT] row (e.g. added by the Fix Consistency action of
+            # an older plugin build). The YAML is authoritative for CHUNK
+            # parameters and the submitter never applies Data Asset overrides
+            # to them, so such a row is harmless and must not fail submission.
+            data_asset_parameters=[
+                (p["name"], p["type"])
+                for p in step_parameters
+                if not p["type"].startswith("CHUNK[")
+            ],
         )
 
     @staticmethod
@@ -340,15 +355,31 @@ class ParametersConsistencyChecker:
             left=[
                 (p["name"], p["type"])
                 for p in step_template["parameterSpace"]["taskParameterDefinitions"]
+                # CHUNK[INT] cannot be represented in a Data Asset (see
+                # check_step_parameters_consistency) - never try to "fix" it in,
+                # and never try to "fix" a stale Data Asset CHUNK row out.
+                if not p["type"].startswith("CHUNK[")
             ],
-            right=[(p["name"], p["type"]) for p in step_parameters],
+            right=[
+                (p["name"], p["type"])
+                for p in step_parameters
+                if not p["type"].startswith("CHUNK[")
+            ],
         )
 
         fixed_parameters = ParametersConsistencyChecker.fix_parameters_consistency(
             missed_in_yaml=missed_in_yaml,
             missed_in_data_asset=missed_in_data_asset,
-            yaml_parameters=step_template["parameterSpace"]["taskParameterDefinitions"],
-            data_asset_parameters=step_parameters,
+            yaml_parameters=[
+                p
+                for p in step_template["parameterSpace"]["taskParameterDefinitions"]
+                if not p["type"].startswith("CHUNK[")
+            ],
+            # Stale CHUNK rows are dropped from the Data Asset here, so running
+            # Fix Consistency cleans up Data Assets written by older builds.
+            data_asset_parameters=[
+                p for p in step_parameters if not p["type"].startswith("CHUNK[")
+            ],
         )
 
         logger.info(f"Fixed OpenJobStep parameters: {fixed_parameters}")

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import os
+import copy
 import math
 import unreal
 from enum import IntEnum
@@ -9,6 +10,7 @@ from dataclasses import dataclass, field, asdict
 
 from openjd.model import parse_model
 from openjd.model.v2023_09 import (
+    ExtensionName,
     StepScript,
     StepTemplate,
     TaskParameterType,
@@ -23,6 +25,7 @@ from openjd.model.v2023_09._model import StepDependency
 from deadline.unreal_submitter import common
 from deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity import (
     UnrealOpenJobEntity,
+    OpenJobParameterNames,
     OpenJobStepParameterNames,
     PARAMETER_DEFINITION_MAPPING,
     ParameterDefinitionDescriptor,
@@ -32,6 +35,9 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job_environment impor
 )
 from deadline.unreal_submitter.unreal_open_job.unreal_open_job_parameters_consistency import (
     ParametersConsistencyChecker,
+)
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job_dynamic_chunking import (
+    DynamicChunkingHelper,
 )
 from deadline.unreal_logger import get_logger
 from deadline.unreal_submitter import exceptions, settings
@@ -48,13 +54,15 @@ class UnrealOpenJobStepParameterDefinition:
     Dataclass for storing and managing OpenJob Step Task parameter definitions
 
     :cvar name: Name of the parameter
-    :cvar type: OpenJD Type of the parameter (INT, FLOAT, STRING, PATH)
+    :cvar type: OpenJD Type of the parameter (INT, FLOAT, STRING, PATH, CHUNK[INT])
     :cvar range: List of parameter values
+    :cvar chunks: Chunks configuration for CHUNK[INT] parameters (TASK_CHUNKING extension)
     """
 
     name: str
     type: str
     range: list[Any] = field(default_factory=list)
+    chunks: Optional[dict] = field(default=None)
 
     @classmethod
     def from_unreal_param_definition(cls, u_param: unreal.StepTaskParameterDefinition):
@@ -67,23 +75,35 @@ class UnrealOpenJobStepParameterDefinition:
         """
 
         python_class = PARAMETER_DEFINITION_MAPPING[u_param.type.name].python_class
+        # Unreal's ValueType enum never maps to task-only types such as CHUNK[INT],
+        # so a python_class is always available here.
+        assert python_class is not None
         build_kwargs = dict(
             name=u_param.name,
             type=u_param.type.name,
             range=[python_class(p) for p in list(u_param.range)],
+            chunks=None,
         )
         return cls(**build_kwargs)
 
     @classmethod
     def from_dict(cls, param_dict: dict):
         """
-        Create UnrealOpenJobStepParameterDefinition instance python dict
+        Create UnrealOpenJobStepParameterDefinition instance from python dict.
+
+        Explicitly extracts known fields to handle CHUNK[INT] parameters
+        which have additional fields like 'chunks'.
 
         :return: UnrealOpenJobStepParameterDefinition instance
         :rtype: UnrealOpenJobStepParameterDefinition
         """
-
-        return cls(**param_dict)
+        build_kwargs = dict(
+            name=param_dict["name"],
+            type=param_dict["type"],
+            range=param_dict.get("range", []),
+            chunks=param_dict.get("chunks"),
+        )
+        return cls(**build_kwargs)
 
     def to_dict(self):
         """
@@ -283,6 +303,10 @@ class UnrealOpenJobStep(UnrealOpenJobEntity):
         """
         Build the job parameter definition list from the step template object.
 
+        For CHUNK[INT] parameters, the rangeConstraint field in the chunks configuration
+        must be a literal value (CONTIGUOUS or NONCONTIGUOUS), not a template expression.
+        This method substitutes template expressions with actual values from job parameters.
+
         :return: List of Step parameter definitions
         :rtype: list
         """
@@ -293,22 +317,90 @@ class UnrealOpenJobStep(UnrealOpenJobEntity):
 
         yaml_params = step_template_object["parameterSpace"]["taskParameterDefinitions"]
         for yaml_p in yaml_params:
+            # 1. Apply override from _extra_parameters if exists.
+            # CHUNK[INT] parameters are excluded: their range is a template
+            # expression (e.g. "{{Param.Frames}}") resolved by the scheduler,
+            # so a Data Asset override must never replace it. All other types
+            # keep the original override semantics unchanged.
             override_param = next(
                 (p for p in self._extra_parameters if p.name == yaml_p["name"]), None
             )
-            if override_param:
+            if override_param and not DynamicChunkingHelper.is_chunk_parameter_type(
+                yaml_p.get("type", "")
+            ):
                 yaml_p["range"] = override_param.range
 
+            # 2. For CHUNK[INT], substitute template expressions
+            if DynamicChunkingHelper.is_chunk_parameter_type(yaml_p.get("type", "")):
+                yaml_p = self._substitute_chunk_parameter_values(yaml_p)
+
+            # 3. Parse into OpenJD model
             param_descriptor: ParameterDefinitionDescriptor = PARAMETER_DEFINITION_MAPPING[
                 yaml_p["type"]
             ]
             param_definition_cls = param_descriptor.task_parameter_openjd_class
 
+            # CHUNK[INT] requires TASK_CHUNKING extension to be declared
+            supported_extensions = (
+                [ext.value for ext in ExtensionName]
+                if DynamicChunkingHelper.is_chunk_parameter_type(yaml_p.get("type", ""))
+                else None
+            )
+
             step_parameter_definition_list.append(
-                parse_model(model=param_definition_cls, obj=yaml_p)
+                parse_model(
+                    model=param_definition_cls,
+                    obj=yaml_p,
+                    supported_extensions=supported_extensions,
+                )
             )
 
         return step_parameter_definition_list
+
+    def _substitute_chunk_parameter_values(self, yaml_param: dict) -> dict:
+        """
+        Substitute template expressions in CHUNK[INT] parameter's chunks configuration
+        with actual values from job parameters.
+
+        The OpenJD model requires rangeConstraint to be a literal value, not a
+        template expression. This method resolves the template expression to the
+        actual value from job parameters and validates it (only CONTIGUOUS is
+        supported - Unreal's Movie Render Queue cannot render non-contiguous
+        frame ranges).
+
+        :param yaml_param: YAML parameter dictionary with chunks configuration
+        :return: Modified parameter dictionary with substituted values
+        """
+        yaml_param = copy.deepcopy(yaml_param)
+        chunks_config = yaml_param.get("chunks", {})
+
+        if not chunks_config:
+            return yaml_param
+
+        # Substitute rangeConstraint if it's a template expression
+        range_constraint = chunks_config.get("rangeConstraint", "")
+        if range_constraint and range_constraint.startswith("{{"):
+            # Get actual value from job parameters
+            if self._open_job:
+                range_constraint_param = self._open_job._find_extra_parameter(
+                    parameter_name=OpenJobParameterNames.RANGE_CONSTRAINT, parameter_type="STRING"
+                )
+                if range_constraint_param and range_constraint_param.value:
+                    chunks_config["rangeConstraint"] = range_constraint_param.value
+                else:
+                    # Default to CONTIGUOUS if not specified
+                    chunks_config["rangeConstraint"] = "CONTIGUOUS"
+            else:
+                # Default to CONTIGUOUS if no job context
+                chunks_config["rangeConstraint"] = "CONTIGUOUS"
+
+        # Validate the resolved value. Literal values are also validated by
+        # DynamicChunkingHelper.validate_chunk_parameter() at step build; this
+        # covers values resolved from job parameters, which bypass that check.
+        if chunks_config.get("rangeConstraint"):
+            DynamicChunkingHelper._validate_range_constraint(chunks_config["rangeConstraint"])
+
+        return yaml_param
 
     def _build_template(self) -> StepTemplate:
         """
@@ -441,6 +533,7 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
         self._mrq_job = mrq_job
         self._queue_manifest_path: Optional[str] = None
         self._render_args_type = self._get_render_arguments_type()
+        self._dynamic_chunking_detected: Optional[bool] = None
 
     @property
     def mrq_job(self):
@@ -449,6 +542,25 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
     @mrq_job.setter
     def mrq_job(self, value: unreal.MoviePipelineExecutorJob):
         self._mrq_job = value
+
+    def _is_using_dynamic_chunking(self) -> bool:
+        """
+        Check if this step template uses TASK_CHUNKING extension (CHUNK[INT] type).
+
+        Results are cached to avoid repeated template parsing.
+
+        :return: True if template uses dynamic chunking, False otherwise
+        :rtype: bool
+        """
+        if self._dynamic_chunking_detected is None:
+            try:
+                step_template_object = self.get_template_object()
+                self._dynamic_chunking_detected = DynamicChunkingHelper.is_using_dynamic_chunking(
+                    step_template_object
+                )
+            except FileNotFoundError:
+                self._dynamic_chunking_detected = False
+        return self._dynamic_chunking_detected
 
     def _get_task_count(self) -> int:
         """
@@ -572,6 +684,10 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
             4. Build given Environments
             5. Set up Step dependencies
 
+        For dynamic chunking templates (CHUNK[INT] type):
+            - Skip task index calculation
+            - Frame range expression is passed through unchanged via template references
+
         :return: StepTemplate instance
         :rtype: StepTemplate
         """
@@ -586,12 +702,30 @@ class RenderUnrealOpenJobStep(UnrealOpenJobStep):
                 f"{OpenJobStepParameterNames.MRQ_JOB_CONFIGURATION_PATH})\n"
             )
 
-        task_index_param_definition = UnrealOpenJobStepParameterDefinition(
-            OpenJobStepParameterNames.TASK_INDEX,
-            TaskParameterType.INT.value,
-            [i for i in range(self._get_task_count())],
-        )
-        self._update_extra_parameter(task_index_param_definition)
+        # Skip task index calculation for dynamic chunking templates.
+        # Dynamic chunking uses CHUNK[INT] type with frame range expressions;
+        # chunk boundaries are computed by the scheduler, not the submitter.
+        if self._is_using_dynamic_chunking():
+            # Get frames parameter value from parent job if available
+            frames_value = None
+            if self.open_job:
+                frames_param = self.open_job._find_extra_parameter(
+                    parameter_name=OpenJobParameterNames.FRAMES, parameter_type="STRING"
+                )
+                if frames_param:
+                    frames_value = frames_param.value
+
+            # Validate all CHUNK[INT] elements in the step template
+            DynamicChunkingHelper.validate_chunk_parameter(
+                self.get_template_object(), frames=frames_value
+            )
+        else:
+            task_index_param_definition = UnrealOpenJobStepParameterDefinition(
+                OpenJobStepParameterNames.TASK_INDEX,
+                TaskParameterType.INT.value,
+                [i for i in range(self._get_task_count())],
+            )
+            self._update_extra_parameter(task_index_param_definition)
 
         handler_param_definition = UnrealOpenJobStepParameterDefinition(
             OpenJobStepParameterNames.ADAPTOR_HANDLER, TaskParameterType.STRING.value, ["render"]

--- a/src/unreal_plugin/Content/Python/open_job_template_api.py
+++ b/src/unreal_plugin/Content/Python/open_job_template_api.py
@@ -2,7 +2,7 @@
 
 import yaml
 import unreal
-from typing import Any
+from typing import Any, Optional
 
 from deadline.unreal_submitter.unreal_open_job.unreal_open_job import (
     UnrealOpenJobParameterDefinition,
@@ -76,18 +76,27 @@ class PythonYamlLibraryImplementation(unreal.PythonYamlLibrary):
     @staticmethod
     def step_parameter_to_u_step_task_parameter(
         step_parameter: dict[str, str],
-    ) -> unreal.StepTaskParameterDefinition:
+    ) -> Optional[unreal.StepTaskParameterDefinition]:
         """
         Convert given Step Parameter definition dictionary to unreal.StepTaskParameterDefinition.
+
+        Returns None for parameter types not supported by Unreal's ValueType enum
+        (e.g., CHUNK[INT] from OpenJD TASK_CHUNKING extension).
 
         :param step_parameter: Step Parameter definition dictionary.
         :type step_parameter: dict[str, Any]
 
-        :return: unreal.StepTaskParameterDefinition
+        :return: unreal.StepTaskParameterDefinition or None if type not supported
         """
+        param_type = step_parameter["type"]
+
+        # Skip OpenJD extension types not supported by Unreal's ValueType enum
+        if not hasattr(unreal.ValueType, param_type):
+            return None
+
         u_step_task_parameter_definition = unreal.StepTaskParameterDefinition()
         u_step_task_parameter_definition.name = step_parameter["name"]
-        u_step_task_parameter_definition.type = getattr(unreal.ValueType, step_parameter["type"])
+        u_step_task_parameter_definition.type = getattr(unreal.ValueType, param_type)
         u_step_task_parameter_definition.range = [str(v) for v in step_parameter.get("range", [])]
 
         return u_step_task_parameter_definition
@@ -433,7 +442,9 @@ class PythonYamlLibraryImplementation(unreal.PythonYamlLibrary):
             u_param = PythonYamlLibraryImplementation.step_parameter_to_u_step_task_parameter(
                 param_definition
             )
-            u_step_task_parameter_definitions.append(u_param.copy())
+            # Skip unsupported parameter types (e.g., CHUNK[INT])
+            if u_param is not None:
+                u_step_task_parameter_definitions.append(u_param.copy())
 
         u_step_struct = unreal.StepStruct()
         u_step_struct.name = step_template["name"]

--- a/src/unreal_plugin/Content/Python/openjd_templates/dynamic_chunking/dynamic_chunking_render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/dynamic_chunking/dynamic_chunking_render_job.yml
@@ -1,0 +1,74 @@
+specificationVersion: jobtemplate-2023-09
+extensions:
+  - REDACTED_ENV_VARS
+  - TASK_CHUNKING
+name: RenderJob
+parameterDefinitions:
+- name: ProjectFilePath
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface: 
+   control: HIDDEN
+- name: ExtraCmdArgs
+  type: STRING
+  default: '-log'
+  userInterface: 
+   control: LINE_EDIT
+- name: ExtraCmdArgsFile
+  type: PATH
+  objectType: FILE
+  dataFlow: IN
+  userInterface: 
+   control: HIDDEN
+- name: Executable
+  type: STRING
+  default: 'UnrealEditor-Cmd'
+  userInterface: 
+   control: HIDDEN
+- name: Frames
+  type: STRING
+  description: 'Frame range from MRQ settings. Populated by submitter at submission time.'
+  userInterface: 
+   control: HIDDEN
+- name: ChunkSize
+  type: INT
+  default: 50
+  minValue: 1
+  description: 'Default number of frames to include in a dynamic chunk'
+  userInterface: 
+   control: SPIN_BOX
+   label: Default Dynamic Chunk Size
+- name: TargetRuntimeSeconds
+  type: INT
+  default: 0
+  minValue: 0
+  description: 'Optional target runtime in seconds per chunk. When 0 (default), chunking uses Default Dynamic Chunk Size for all chunks.'
+  userInterface: 
+   control: SPIN_BOX
+   label: Target Runtime Seconds
+- name: CondaPackages
+  type: STRING
+  # Dynamic chunking requires an adaptor that understands the
+  # dynamic_chunked_frames run_data key (ships in the same release as this
+  # template). The 0.7.* glob resolves to the latest 0.7.x in the conda
+  # channel; a pre-release adaptor would silently render the full sequence
+  # per chunk. Do not use this template against a fleet pinned to an older
+  # 0.7.x adaptor.
+  default: unrealengine=5.7 unrealengine-openjd=0.7.*
+  userInterface: 
+   control: LINE_EDIT
+   label: Conda Packages
+- name: CondaChannels
+  type: STRING
+  default: deadline-cloud-v2 deadline-cloud
+  userInterface: 
+   control: LINE_EDIT
+   label: Conda Channels
+- name: MarketplacePluginsDir
+  type: PATH
+  objectType: DIRECTORY
+  dataFlow: IN
+  default: ''
+  userInterface:
+   control: HIDDEN

--- a/src/unreal_plugin/Content/Python/openjd_templates/dynamic_chunking/dynamic_chunking_render_step.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/dynamic_chunking/dynamic_chunking_render_step.yml
@@ -1,0 +1,39 @@
+name: Render
+# NOTE: Only CONTIGUOUS rangeConstraint is supported because Unreal Engine's Movie Render Queue
+# only accepts contiguous frame ranges (custom_start_frame/custom_end_frame).
+parameterSpace:
+  taskParameterDefinitions:
+  - name: DynamicChunking
+    type: CHUNK[INT]
+    range: "{{Param.Frames}}"
+    chunks:
+      defaultTaskCount: "{{Param.ChunkSize}}"
+      targetRuntimeSeconds: "{{Param.TargetRuntimeSeconds}}"
+      rangeConstraint: CONTIGUOUS
+  - name: Handler
+    type: STRING
+    range: []
+  - name: QueueManifestPath
+    type: PATH
+    range: []
+script:
+  embeddedFiles:
+  - name: runData
+    filename: run-data.yaml
+    type: TEXT
+    data: |
+      handler: {{Task.Param.Handler}}
+      queue_manifest_path: {{Task.Param.QueueManifestPath}}
+      dynamic_chunked_frames: {{Task.Param.DynamicChunking}}
+  actions:
+    onRun:
+      command: unreal-engine-openjd
+      args:
+      - daemon
+      - run
+      - --connection-file
+      - '{{Session.WorkingDirectory}}/connection.json'
+      - --run-data
+      - file://{{Task.File.runData}}
+      cancelation:
+        mode: NOTIFY_THEN_TERMINATE

--- a/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_dynamic_chunking.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_dynamic_chunking.py
@@ -1,0 +1,371 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import sys
+import pytest
+from unittest.mock import MagicMock
+
+unreal_mock = MagicMock()
+unreal_mock.log = MagicMock()
+sys.modules["unreal"] = unreal_mock
+
+
+@pytest.fixture()
+def unreal_render_step_handler():
+    from deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler import (
+        UnrealRenderStepHandler,
+    )
+
+    # Clear cached values before each test
+    UnrealRenderStepHandler.cached_frame_range_start = None
+    UnrealRenderStepHandler.cached_frame_range_end = None
+    return UnrealRenderStepHandler()
+
+
+class TestParseDynamicChunkedFrames:
+    """Tests for parse_dynamic_chunked_frames static method.
+
+    Only CONTIGUOUS rangeConstraint is supported because Unreal Engine's Movie Render Queue
+    only accepts contiguous frame ranges (custom_start_frame/custom_end_frame). MRQ does not
+    provide an API to render arbitrary non-contiguous frames in a single job.
+    """
+
+    @pytest.mark.parametrize(
+        "input_value, expected_start, expected_end",
+        [
+            ("1-10", 1, 10),  # Range
+            ("0-100", 0, 100),  # Range starting from zero
+            ("5-5", 5, 5),  # Range with same start and end (single frame)
+            ("0-0", 0, 0),  # Single frame zero as range
+            ("100-100", 100, 100),  # Single frame large number as range
+            ("10-20", 10, 20),  # Range middle values
+            (" 1-10 ", 1, 10),  # Range with whitespace
+            (" 5-5 ", 5, 5),  # Single frame range with extra whitespace
+            # Negative frame support
+            ("-100--76", -100, -76),  # Both negative
+            ("-50-10", -50, 10),  # Negative start, positive end
+            ("-10--10", -10, -10),  # Single negative frame as range
+            ("-1-0", -1, 0),  # Negative to zero
+            (" -100--76 ", -100, -76),  # Negative with whitespace
+        ],
+    )
+    def test_valid_frame_chunk_formats(
+        self, unreal_render_step_handler, input_value, expected_start, expected_end
+    ):
+        """Test that valid frame chunk formats are parsed correctly"""
+        # WHEN
+        start, end = unreal_render_step_handler.parse_dynamic_chunked_frames(input_value)
+
+        # THEN
+        assert start == expected_start
+        assert end == expected_end
+
+    @pytest.mark.parametrize(
+        "input_value, expected_error_substring",
+        [
+            ("", "cannot be empty"),  # Empty string
+            ("   ", "cannot be empty"),  # Whitespace only
+            ("5", "Invalid dynamic_chunked_frames format"),  # Single frame (not range format)
+            ("0", "Invalid dynamic_chunked_frames format"),  # Single frame zero
+            ("100", "Invalid dynamic_chunked_frames format"),  # Single frame large number
+            ("abc", "Invalid dynamic_chunked_frames format"),  # Non-numeric
+            ("1.5", "Invalid dynamic_chunked_frames format"),  # Float
+            ("1-", "Invalid dynamic_chunked_frames format"),  # Incomplete range
+            ("-10", "Invalid dynamic_chunked_frames format"),  # Negative single frame (not range)
+            ("1-10-20", "Invalid dynamic_chunked_frames format"),  # Multiple dashes (ambiguous)
+            (
+                "1,2,3",
+                "Invalid dynamic_chunked_frames format",
+            ),  # Non-contiguous list (unsupported - MRQ limitation)
+            (
+                "1-10:2",
+                "Invalid dynamic_chunked_frames format",
+            ),  # Stepped range (unsupported - MRQ limitation)
+        ],
+    )
+    def test_invalid_frame_chunk_formats(
+        self, unreal_render_step_handler, input_value, expected_error_substring
+    ):
+        """Test that invalid frame chunk formats raise ValueError with descriptive message"""
+        # WHEN/THEN
+        with pytest.raises(ValueError) as exc_info:
+            unreal_render_step_handler.parse_dynamic_chunked_frames(input_value)
+
+        assert expected_error_substring in str(exc_info.value)
+
+    def test_start_greater_than_end_raises_error(self, unreal_render_step_handler):
+        """Test that start > end in range raises ValueError"""
+        # WHEN/THEN
+        with pytest.raises(ValueError) as exc_info:
+            unreal_render_step_handler.parse_dynamic_chunked_frames("10-1")
+
+        assert "start (10) cannot be greater than end (1)" in str(exc_info.value)
+
+    def test_negative_start_greater_than_end_raises_error(self, unreal_render_step_handler):
+        """Test that start > end with negative frames raises ValueError"""
+        # WHEN/THEN
+        with pytest.raises(ValueError) as exc_info:
+            unreal_render_step_handler.parse_dynamic_chunked_frames("-50--100")
+
+        assert "start (-50) cannot be greater than end (-100)" in str(exc_info.value)
+
+
+class TestDynamicChunkingPrecedence:
+    """Tests for chunking mode precedence, exercised through the real run_script()."""
+
+    @pytest.fixture()
+    def run_script_env(self, unreal_render_step_handler):
+        """
+        Patch run_script's collaborators and wire one mock job into the queue.
+
+        Yields (handler, job_mock, output_settings_mock, patches) where patches
+        holds the patched static methods for call assertions.
+        """
+        from unittest.mock import patch
+        import deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler as handler_module
+
+        job = MagicMock()
+        output_settings = MagicMock()
+        job.get_configuration.return_value.find_or_add_setting_by_class.return_value = (
+            output_settings
+        )
+
+        subsystem = MagicMock()
+        subsystem.get_queue.return_value.get_jobs.return_value = [job]
+        unreal_mock.get_editor_subsystem.return_value = subsystem
+
+        # The handler module may already have been imported by another test
+        # module with a different (or absent) `unreal`; patch its globals so
+        # run_script sees the mock regardless of import order. The executor
+        # class only exists when the module was imported with a truthy
+        # `unreal`, hence create=True.
+        with (
+            patch.object(handler_module, "unreal", unreal_mock),
+            patch.object(
+                handler_module,
+                "RemoteRenderMoviePipelineEditorExecutor",
+                MagicMock(),
+                create=True,
+            ),
+            patch.object(
+                handler_module.UnrealRenderStepHandler, "create_queue_from_job_args"
+            ) as create_queue,
+            patch.object(
+                handler_module.UnrealRenderStepHandler, "enable_shots_for_task"
+            ) as enable_shots,
+            patch.object(
+                handler_module.UnrealRenderStepHandler, "_apply_task_index_to_filename"
+            ) as apply_filename,
+            patch.object(
+                handler_module.UnrealRenderStepHandler, "get_frame_range", return_value=(0, 100)
+            ) as get_frame_range,
+        ):
+            patches = {
+                "create_queue": create_queue,
+                "enable_shots": enable_shots,
+                "apply_filename": apply_filename,
+                "get_frame_range": get_frame_range,
+            }
+            yield unreal_render_step_handler, job, output_settings, patches
+
+    def test_dynamic_chunking_takes_precedence_over_frames_per_task(self, run_script_env):
+        """When all three modes' args are present, dynamic chunking wins."""
+        handler, job, output_settings, patches = run_script_env
+
+        # WHEN
+        handler.run_script(
+            {
+                "dynamic_chunked_frames": "1-10",
+                "frames_per_task": 5,
+                "task_index": 0,
+                "shots_per_task": 3,
+            }
+        )
+
+        # THEN - the dynamic branch ran: inclusive "1-10" -> exclusive [1, 11)
+        assert output_settings.use_custom_playback_range is True
+        assert output_settings.custom_start_frame == 1
+        assert output_settings.custom_end_frame == 11
+        # frame-based path not taken
+        patches["get_frame_range"].assert_not_called()
+        # shot-based path not taken
+        patches["enable_shots"].assert_not_called()
+        # filename token substituted with the chunk START FRAME, not task_index
+        patches["apply_filename"].assert_called_once_with(job, 1)
+
+    def test_frames_per_task_used_when_no_dynamic_chunking(self, run_script_env):
+        """Without dynamic_chunked_frames, frames_per_task + task_index wins."""
+        handler, job, output_settings, patches = run_script_env
+
+        # WHEN
+        handler.run_script({"frames_per_task": 5, "task_index": 0, "shots_per_task": 3})
+
+        # THEN - frame window [0, 5) computed from get_frame_range()=(0, 100)
+        assert output_settings.custom_start_frame == 0
+        assert output_settings.custom_end_frame == 5
+        patches["enable_shots"].assert_not_called()
+        patches["apply_filename"].assert_called_once_with(job, 0)
+
+    def test_shots_per_task_used_when_no_dynamic_or_frames_per_task(self, run_script_env):
+        """Without the higher-priority modes, shots_per_task + task_index wins."""
+        handler, job, output_settings, patches = run_script_env
+
+        # WHEN
+        handler.run_script({"shots_per_task": 3, "task_index": 1})
+
+        # THEN
+        patches["enable_shots"].assert_called_once_with(
+            render_job=job, shots_per_task=3, task_index=1
+        )
+        patches["get_frame_range"].assert_not_called()
+        patches["apply_filename"].assert_called_once_with(job, 1)
+
+    def test_no_chunking_when_no_params(self, run_script_env):
+        """With no chunking args, no chunking branch runs."""
+        handler, job, output_settings, patches = run_script_env
+
+        # WHEN
+        handler.run_script({})
+
+        # THEN
+        patches["enable_shots"].assert_not_called()
+        patches["apply_filename"].assert_not_called()
+        patches["get_frame_range"].assert_not_called()
+
+
+class TestStaticMethodBehavior:
+    """Tests for static method behavior"""
+
+    def test_parse_dynamic_chunked_frames_is_static(self, unreal_render_step_handler):
+        """Test that parse_dynamic_chunked_frames can be called as static method"""
+        from deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler import (
+            UnrealRenderStepHandler,
+        )
+
+        # WHEN - Call as static method
+        start, end = UnrealRenderStepHandler.parse_dynamic_chunked_frames("1-10")
+
+        # THEN
+        assert start == 1
+        assert end == 10
+
+    def test_parse_dynamic_chunked_frames_across_instances(self, unreal_render_step_handler):
+        """Test that parse_dynamic_chunked_frames works consistently across instances"""
+        from deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler import (
+            UnrealRenderStepHandler,
+        )
+
+        handler1 = UnrealRenderStepHandler()
+        handler2 = UnrealRenderStepHandler()
+
+        # WHEN
+        start1, end1 = handler1.parse_dynamic_chunked_frames("5-15")
+        start2, end2 = handler2.parse_dynamic_chunked_frames("5-15")
+
+        # THEN
+        assert start1 == start2 == 5
+        assert end1 == end2 == 15
+
+
+class TestDynamicChunkingInclusiveToExclusiveConversion:
+    """Tests for inclusive-to-exclusive frame range conversion.
+
+    The scheduler returns inclusive frame ranges (e.g., "150-150" means render frame 150,
+    which is 1 frame), but Unreal Engine's custom_end_frame is exclusive. The adaptor
+    must add 1 to the end frame to correctly render the expected number of frames.
+    """
+
+    @pytest.mark.parametrize(
+        "dynamic_chunked_frames, expected_start, expected_ue_end, expected_frame_count",
+        [
+            ("150-150", 150, 151, 1),  # Single frame - the bug case
+            ("0-0", 0, 1, 1),  # Single frame at zero
+            ("1-10", 1, 11, 10),  # Range of 10 frames
+            ("0-99", 0, 100, 100),  # 100 frames starting from 0
+            ("50-74", 50, 75, 25),  # Mid-range chunk
+        ],
+    )
+    def test_dynamic_chunking_converts_inclusive_to_exclusive_end_frame(
+        self,
+        unreal_render_step_handler,
+        dynamic_chunked_frames,
+        expected_start,
+        expected_ue_end,
+        expected_frame_count,
+    ):
+        """Test that dynamic chunking adds 1 to end frame for Unreal's exclusive end frame.
+
+        The scheduler returns inclusive ranges (e.g., "150-150" = 1 frame), but Unreal's
+        custom_end_frame is exclusive. Without the +1 adjustment, "150-150" would result
+        in custom_start_frame=150, custom_end_frame=150, which Unreal interprets as 0 frames,
+        causing "Cannot render the Queue with frame range of zero length" error.
+        """
+        # GIVEN - Parse the dynamic_chunked_frames as run_script does
+        start_frame, end_frame = unreal_render_step_handler.parse_dynamic_chunked_frames(
+            dynamic_chunked_frames
+        )
+
+        # WHEN - Apply the +1 conversion as run_script does for dynamic chunking
+        # This simulates the logic in run_script:
+        #   end_frame = end_frame + 1  # Convert inclusive to exclusive
+        ue_end_frame = end_frame + 1
+
+        # THEN - Verify the converted values match expected Unreal settings
+        assert start_frame == expected_start
+        assert ue_end_frame == expected_ue_end
+
+        # Verify the frame count Unreal will calculate (end - start)
+        actual_frame_count = ue_end_frame - start_frame
+        assert actual_frame_count == expected_frame_count
+
+    def test_single_frame_chunk_does_not_cause_zero_length_error(self, unreal_render_step_handler):
+        """Test that single frame chunk "150-150" results in 1 frame, not 0.
+
+        This is the specific bug case: scheduler sends "150-150" meaning render frame 150.
+        Without the fix, Unreal would get start=150, end=150, calculate 0 frames, and error.
+        With the fix, Unreal gets start=150, end=151, correctly rendering 1 frame.
+        """
+        # GIVEN - The bug case input
+        dynamic_chunked_frames = "150-150"
+
+        # WHEN - Parse and apply the conversion
+        start_frame, end_frame = unreal_render_step_handler.parse_dynamic_chunked_frames(
+            dynamic_chunked_frames
+        )
+        ue_end_frame = end_frame + 1  # The fix: convert inclusive to exclusive
+
+        # THEN - Frame range should be 150-151 (1 frame), not 150-150 (0 frames)
+        assert start_frame == 150
+        assert ue_end_frame == 151  # +1 for exclusive end
+
+        # The frame count Unreal will calculate: 151 - 150 = 1 frame
+        frame_count = ue_end_frame - start_frame
+        assert frame_count == 1, "Single frame chunk should result in exactly 1 frame"
+
+        # Without the fix, this would be 0 frames:
+        frame_count_without_fix = end_frame - start_frame
+        assert frame_count_without_fix == 0, "Without fix, single frame chunk would be 0 frames"
+
+    def test_inclusive_range_semantics(self, unreal_render_step_handler):
+        """Test that the scheduler's inclusive range semantics are correctly understood.
+
+        Scheduler range "10-20" means frames 10, 11, 12, ..., 19, 20 = 11 frames total.
+        Unreal's exclusive end means custom_end_frame=21 to render those 11 frames.
+        """
+        # GIVEN
+        dynamic_chunked_frames = "10-20"
+
+        # WHEN
+        start_frame, end_frame = unreal_render_step_handler.parse_dynamic_chunked_frames(
+            dynamic_chunked_frames
+        )
+        ue_end_frame = end_frame + 1
+
+        # THEN
+        # Scheduler says "10-20" = frames 10 through 20 inclusive = 11 frames
+        scheduler_frame_count = end_frame - start_frame + 1  # Inclusive count
+        assert scheduler_frame_count == 11
+
+        # Unreal needs end=21 to render 11 frames (21 - 10 = 11)
+        assert ue_end_frame == 21
+        ue_frame_count = ue_end_frame - start_frame  # Exclusive count
+        assert ue_frame_count == 11

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_dynamic_chunking_validator.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_dynamic_chunking_validator.py
@@ -242,6 +242,23 @@ class TestValidateFramesParameter:
         assert "IntRangeList" in str(exc_info.value)
         assert "IntRangeExpr" in str(exc_info.value)
 
+    @pytest.mark.parametrize(
+        ("invalid_frames", "expected_reason"),
+        [
+            ("10-9", "Range start must not exceed range end"),
+            ("1-10:0", "Range step must be at least 1"),
+        ],
+    )
+    def test_validate_frames_parameter_rejects_invalid_range_values(
+        self, invalid_frames, expected_reason
+    ):
+        """Reject syntactically valid ranges that OpenJD cannot instantiate."""
+        with pytest.raises(SubmitterInputValidationError) as exc_info:
+            DynamicChunkingHelper.validate_frames_parameter(invalid_frames)
+
+        assert f'Invalid Frames parameter value "{invalid_frames}"' in str(exc_info.value)
+        assert expected_reason in str(exc_info.value)
+
 
 class TestSubstituteChunkParameterValues:
     """Tests for the _substitute_chunk_parameter_values method in UnrealOpenJobStep."""

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_dynamic_chunking_validator.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_dynamic_chunking_validator.py
@@ -1,0 +1,367 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import sys
+import pytest
+from unittest.mock import MagicMock
+
+# Mock unreal module before importing deadline modules
+unreal_mock = MagicMock()
+sys.modules["unreal"] = unreal_mock
+
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job_dynamic_chunking import (  # noqa: E402
+    DynamicChunkingHelper,
+)
+from deadline.unreal_submitter.exceptions import SubmitterInputValidationError  # noqa: E402
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job_step import (  # noqa: E402
+    UnrealOpenJobStep,
+)
+
+
+class TestDynamicChunkingHelper:
+    """Tests for the DynamicChunkingHelper class."""
+
+    def test_validate_range_constraint_valid_values(self):
+        """Test that CONTIGUOUS passes validation."""
+        # WHEN / THEN - should not raise
+        DynamicChunkingHelper._validate_range_constraint("CONTIGUOUS")
+
+    def test_validate_range_constraint_rejects_noncontiguous(self):
+        """
+        NONCONTIGUOUS is valid OpenJD but unsupported by this integration:
+        Unreal's Movie Render Queue cannot render non-contiguous frame lists,
+        so it must be rejected at submission rather than failing at render time.
+        """
+        # WHEN / THEN
+        with pytest.raises(SubmitterInputValidationError) as exc_info:
+            DynamicChunkingHelper._validate_range_constraint("NONCONTIGUOUS")
+
+        assert "Only CONTIGUOUS is supported" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "invalid_value",
+        [
+            "contiguous",  # lowercase
+            "CONTIGOUS",  # typo
+            "noncontiguous",  # lowercase
+            "INVALID",
+            "",
+            "BOTH",
+            "RANDOM",
+        ],
+    )
+    def test_validate_range_constraint_invalid_values(self, invalid_value):
+        """Test that invalid RangeConstraint values raise SubmitterInputValidationError."""
+        # WHEN / THEN
+        with pytest.raises(SubmitterInputValidationError) as exc_info:
+            DynamicChunkingHelper._validate_range_constraint(invalid_value)
+
+        # Verify error message contains helpful information
+        assert f'Invalid RangeConstraint value "{invalid_value}"' in str(exc_info.value)
+        assert "Only CONTIGUOUS is supported" in str(exc_info.value)
+
+
+class TestValidateSingleChunkParameter:
+    """Tests for the validate_single_chunk_parameter_per_step function."""
+
+    def test_validate_single_chunk_parameter_per_step_no_chunk_params(self):
+        """Test that templates with no CHUNK[INT] parameters pass validation."""
+        # GIVEN - template with no CHUNK parameters
+        step_template = {
+            "parameterSpace": {
+                "taskParameterDefinitions": [
+                    {"name": "TaskIndex", "type": "INT", "range": [0, 1, 2]},
+                    {"name": "OutputPath", "type": "PATH", "range": ["/output"]},
+                ]
+            }
+        }
+
+        # WHEN / THEN - should not raise
+        DynamicChunkingHelper._validate_single_chunk_parameter_per_step(step_template)
+
+    def test_validate_single_chunk_parameter_per_step_one_chunk_param(self):
+        """Test that templates with exactly one CHUNK[INT] parameter pass validation."""
+        # GIVEN - template with one CHUNK[INT] parameter
+        step_template = {
+            "parameterSpace": {
+                "taskParameterDefinitions": [
+                    {
+                        "name": "DynamicChunking",
+                        "type": "CHUNK[INT]",
+                        "range": "{{Param.Frames}}",
+                        "chunks": {"defaultTaskCount": "{{Param.ChunkSize}}"},
+                    },
+                    {"name": "OutputPath", "type": "PATH", "range": ["/output"]},
+                ]
+            }
+        }
+
+        # WHEN / THEN - should not raise
+        DynamicChunkingHelper._validate_single_chunk_parameter_per_step(step_template)
+
+    def test_validate_single_chunk_parameter_per_step_multiple_chunk_params(self):
+        """Test that templates with multiple CHUNK[INT] parameters raise error."""
+        # GIVEN - template with multiple CHUNK[INT] parameters
+        step_template = {
+            "parameterSpace": {
+                "taskParameterDefinitions": [
+                    {
+                        "name": "DynamicChunking1",
+                        "type": "CHUNK[INT]",
+                        "range": "{{Param.Frames}}",
+                    },
+                    {
+                        "name": "DynamicChunking2",
+                        "type": "CHUNK[INT]",
+                        "range": "{{Param.Frames2}}",
+                    },
+                    {"name": "OutputPath", "type": "PATH", "range": ["/output"]},
+                ]
+            }
+        }
+
+        # WHEN / THEN
+        with pytest.raises(SubmitterInputValidationError) as exc_info:
+            DynamicChunkingHelper._validate_single_chunk_parameter_per_step(step_template)
+
+        # Verify error message contains helpful information
+        assert "2 CHUNK[INT] task parameters" in str(exc_info.value)
+        assert "DynamicChunking1" in str(exc_info.value)
+        assert "DynamicChunking2" in str(exc_info.value)
+        assert "only one CHUNK[INT] parameter is allowed per step" in str(exc_info.value)
+
+    def test_validate_single_chunk_parameter_per_step_empty_template(self):
+        """Test that empty templates pass validation."""
+        # GIVEN - empty template
+        step_template: dict = {}
+
+        # WHEN / THEN - should not raise
+        DynamicChunkingHelper._validate_single_chunk_parameter_per_step(step_template)
+
+    def test_validate_single_chunk_parameter_per_step_malformed_template(self):
+        """Test that malformed templates are handled gracefully."""
+        # GIVEN - malformed template (None)
+        step_template = None
+
+        # WHEN / THEN - should not raise (graceful handling)
+        DynamicChunkingHelper._validate_single_chunk_parameter_per_step(
+            step_template  # type: ignore[arg-type]
+        )
+
+
+class TestValidateFramesParameter:
+    """Tests for the validate_frames_parameter function."""
+
+    @pytest.mark.parametrize(
+        "valid_frames",
+        [
+            # Single non-negative integers
+            "1",
+            "0",
+            "100",
+            "999",
+            # Simple ranges
+            "1-100",
+            "0-50",
+            "10-20",
+            "0-0",  # single frame as range
+            # Ranges with step
+            "1-100:2",
+            "0-50:5",
+            "1-1000:10",
+            "0-100:1",
+            # Comma-separated lists (IntRangeList)
+            "1,2,3",
+            "1,5,10,15",
+            "1-10,15,20-30",
+            "1-10:2,15,20-30:5",
+            # Complex mixed formats
+            "1-10,15,20-30,35,40-50:2",
+            "0,5-10,15,20-30:2",
+            "1,2,3,4,5",
+            # Negative frames - Unreal sequences can start below zero; the
+            # submitter's auto-population can emit e.g. "-10-49" and the
+            # adaptor's chunk parser accepts negatives
+            "-1",
+            "-100",
+            "-10-10",
+            "-100--50",
+            "-10-10:2",
+            "-10-49",
+        ],
+    )
+    def test_validate_frames_parameter_valid_values(self, valid_frames):
+        """Test that valid Frames parameter values pass validation."""
+        # WHEN / THEN - should not raise
+        DynamicChunkingHelper.validate_frames_parameter(valid_frames)
+
+    @pytest.mark.parametrize(
+        "empty_frames",
+        [
+            "",
+            "   ",
+            None,
+        ],
+    )
+    def test_validate_frames_parameter_empty_values_raise_error(self, empty_frames):
+        """Test that empty Frames parameter values raise SubmitterInputValidationError."""
+        # WHEN / THEN - should raise (empty is not valid)
+        with pytest.raises(SubmitterInputValidationError) as exc_info:
+            DynamicChunkingHelper.validate_frames_parameter(empty_frames)
+
+        assert "Frames parameter is required" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "invalid_frames",
+        [
+            "abc",  # non-numeric
+            "1-",  # incomplete range
+            "-",  # just a dash
+            "1--",  # double dash at end
+            "1-10-20",  # invalid triple range
+            "1:2",  # step without range
+            "1-10:",  # step without value
+            "1-10:abc",  # non-numeric step
+            ",1,2",  # leading comma
+            "1,2,",  # trailing comma
+            "1,,2",  # double comma
+            "1 2 3",  # spaces instead of commas
+            "1..10",  # double dots
+            "1-10;20-30",  # semicolon instead of comma
+            "a-z",  # letters
+            "1.5-10.5",  # floats
+        ],
+    )
+    def test_validate_frames_parameter_invalid_values(self, invalid_frames):
+        """Test that invalid Frames parameter values raise SubmitterInputValidationError."""
+        # WHEN / THEN
+        with pytest.raises(SubmitterInputValidationError) as exc_info:
+            DynamicChunkingHelper.validate_frames_parameter(invalid_frames)
+
+        # Verify error message contains helpful information
+        assert f'Invalid Frames parameter value "{invalid_frames}"' in str(exc_info.value)
+        assert "IntRangeList" in str(exc_info.value)
+        assert "IntRangeExpr" in str(exc_info.value)
+
+
+class TestSubstituteChunkParameterValues:
+    """Tests for the _substitute_chunk_parameter_values method in UnrealOpenJobStep."""
+
+    def test_substitute_range_constraint_from_job_parameter(self):
+        """Test that rangeConstraint template expression is substituted with job parameter value."""
+        # GIVEN - a step with a job that has RangeConstraint parameter
+        mock_job = MagicMock()
+        mock_range_constraint_param = MagicMock()
+        mock_range_constraint_param.value = "CONTIGUOUS"
+        mock_job._find_extra_parameter.return_value = mock_range_constraint_param
+
+        step = UnrealOpenJobStep(file_path="")
+        step.open_job = mock_job
+
+        yaml_param: dict = {
+            "name": "DynamicChunking",
+            "type": "CHUNK[INT]",
+            "range": "{{Param.Frames}}",
+            "chunks": {
+                "defaultTaskCount": "{{Param.ChunkSize}}",
+                "targetRuntimeSeconds": "{{Param.TargetRuntimeSeconds}}",
+                "rangeConstraint": "{{Param.RangeConstraint}}",
+            },
+        }
+
+        # WHEN
+        result = step._substitute_chunk_parameter_values(yaml_param)
+
+        # THEN
+        assert result["chunks"]["rangeConstraint"] == "CONTIGUOUS"
+        # Verify template expressions for other fields are preserved
+        assert result["chunks"]["defaultTaskCount"] == "{{Param.ChunkSize}}"
+        assert result["chunks"]["targetRuntimeSeconds"] == "{{Param.TargetRuntimeSeconds}}"
+        # Verify original dict is not modified
+        assert yaml_param["chunks"]["rangeConstraint"] == "{{Param.RangeConstraint}}"
+
+    def test_substitute_range_constraint_defaults_to_contiguous_when_no_job(self):
+        """Test that rangeConstraint defaults to CONTIGUOUS when no job is available."""
+        # GIVEN - a step without a job
+        step = UnrealOpenJobStep(file_path="")
+        step._open_job = None
+
+        yaml_param: dict = {
+            "name": "DynamicChunking",
+            "type": "CHUNK[INT]",
+            "range": "{{Param.Frames}}",
+            "chunks": {
+                "defaultTaskCount": "{{Param.ChunkSize}}",
+                "rangeConstraint": "{{Param.RangeConstraint}}",
+            },
+        }
+
+        # WHEN
+        result = step._substitute_chunk_parameter_values(yaml_param)
+
+        # THEN
+        assert result["chunks"]["rangeConstraint"] == "CONTIGUOUS"
+
+    def test_substitute_range_constraint_preserves_literal_value(self):
+        """Test that a literal CONTIGUOUS rangeConstraint is preserved."""
+        # GIVEN - a step with literal rangeConstraint
+        step = UnrealOpenJobStep(file_path="")
+        step._open_job = None
+
+        yaml_param: dict = {
+            "name": "DynamicChunking",
+            "type": "CHUNK[INT]",
+            "range": "{{Param.Frames}}",
+            "chunks": {
+                "defaultTaskCount": "{{Param.ChunkSize}}",
+                "rangeConstraint": "CONTIGUOUS",  # literal value
+            },
+        }
+
+        # WHEN
+        result = step._substitute_chunk_parameter_values(yaml_param)
+
+        # THEN - literal value should be preserved
+        assert result["chunks"]["rangeConstraint"] == "CONTIGUOUS"
+
+    def test_substitute_range_constraint_rejects_noncontiguous_from_job_parameter(self):
+        """A NONCONTIGUOUS value resolved from a job parameter must be rejected."""
+        # GIVEN - a step with a job whose RangeConstraint parameter is NONCONTIGUOUS
+        mock_job = MagicMock()
+        mock_range_constraint_param = MagicMock()
+        mock_range_constraint_param.value = "NONCONTIGUOUS"
+        mock_job._find_extra_parameter.return_value = mock_range_constraint_param
+
+        step = UnrealOpenJobStep(file_path="")
+        step.open_job = mock_job
+
+        yaml_param: dict = {
+            "name": "DynamicChunking",
+            "type": "CHUNK[INT]",
+            "range": "{{Param.Frames}}",
+            "chunks": {
+                "defaultTaskCount": "{{Param.ChunkSize}}",
+                "rangeConstraint": "{{Param.RangeConstraint}}",
+            },
+        }
+
+        # WHEN / THEN
+        with pytest.raises(SubmitterInputValidationError):
+            step._substitute_chunk_parameter_values(yaml_param)
+
+    def test_substitute_handles_missing_chunks_config(self):
+        """Test that parameters without chunks config are handled gracefully."""
+        # GIVEN - a parameter without chunks config
+        step = UnrealOpenJobStep(file_path="")
+        step._open_job = None
+
+        yaml_param: dict = {
+            "name": "TaskIndex",
+            "type": "INT",
+            "range": [0, 1, 2],
+        }
+
+        # WHEN
+        result = step._substitute_chunk_parameter_values(yaml_param)
+
+        # THEN - parameter should be returned unchanged
+        assert result == yaml_param

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_integration_template_verification.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_integration_template_verification.py
@@ -1,0 +1,470 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+Integration verification tests for dynamic chunking and legacy templates.
+
+These tests verify that:
+1. Dynamic chunking templates (TASK_CHUNKING extension) work end-to-end
+2. Legacy templates remain unchanged and continue to work correctly
+"""
+
+import sys
+import os
+import pytest
+import yaml
+from unittest.mock import MagicMock
+from pathlib import Path
+
+# Mock unreal module before importing deadline modules
+unreal_mock = MagicMock()
+sys.modules["unreal"] = unreal_mock
+
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job_dynamic_chunking import (  # noqa: E402
+    DynamicChunkingHelper,
+)
+
+
+def get_templates_base_path() -> str:
+    """Get the base path for OpenJD templates."""
+    # Navigate from test directory to src/unreal_plugin/Content/Python/openjd_templates
+    # The test file is at: test/deadline_submitter_for_unreal/unit/test_unreal_open_job/
+    # We need to go up 4 levels to reach the workspace root
+    current_dir = Path(__file__).resolve().parent
+    workspace_root = current_dir.parent.parent.parent.parent
+    templates_path = (
+        workspace_root / "src" / "unreal_plugin" / "Content" / "Python" / "openjd_templates"
+    )
+    return str(templates_path)
+
+
+class TestDynamicChunkingTemplateIntegration:
+    """
+    Integration tests for dynamic chunking templates.
+    """
+
+    @pytest.fixture
+    def templates_base_path(self):
+        """Fixture providing the base path for templates."""
+        return get_templates_base_path()
+
+    def test_dynamic_chunking_job_template_has_task_chunking_extension(self, templates_base_path):
+        """
+        Verify dynamic chunking job template includes TASK_CHUNKING extension.
+        """
+        # GIVEN - the dynamic chunking job template
+        job_template_path = os.path.join(
+            templates_base_path, "dynamic_chunking", "dynamic_chunking_render_job.yml"
+        )
+
+        # WHEN - we load the template
+        with open(job_template_path, "r") as f:
+            job_template = yaml.safe_load(f)
+
+        # THEN - it should have TASK_CHUNKING extension
+        assert "extensions" in job_template, "Job template should have extensions field"
+        assert (
+            "TASK_CHUNKING" in job_template["extensions"]
+        ), "Job template should include TASK_CHUNKING extension"
+        assert (
+            "REDACTED_ENV_VARS" in job_template["extensions"]
+        ), "Job template should also include REDACTED_ENV_VARS extension"
+
+    def test_dynamic_chunking_job_template_has_frames_parameter(self, templates_base_path):
+        """
+        Verify dynamic chunking job template includes Frames parameter.
+        """
+        # GIVEN - the dynamic chunking job template
+        job_template_path = os.path.join(
+            templates_base_path, "dynamic_chunking", "dynamic_chunking_render_job.yml"
+        )
+
+        # WHEN - we load the template
+        with open(job_template_path, "r") as f:
+            job_template = yaml.safe_load(f)
+
+        # THEN - it should have Frames parameter
+        param_names = [p["name"] for p in job_template["parameterDefinitions"]]
+        assert "Frames" in param_names, "Job template should have Frames parameter"
+
+        # Verify Frames parameter is STRING type for expression passthrough
+        frames_param = next(
+            p for p in job_template["parameterDefinitions"] if p["name"] == "Frames"
+        )
+        assert frames_param["type"] == "STRING", "Frames parameter should be STRING type"
+
+    def test_dynamic_chunking_job_template_has_chunking_parameters(self, templates_base_path):
+        """
+        Verify dynamic chunking job template includes chunking configuration parameters
+        (ChunkSize, TargetRuntimeSeconds).
+        """
+        # GIVEN - the dynamic chunking job template
+        job_template_path = os.path.join(
+            templates_base_path, "dynamic_chunking", "dynamic_chunking_render_job.yml"
+        )
+
+        # WHEN - we load the template
+        with open(job_template_path, "r") as f:
+            job_template = yaml.safe_load(f)
+
+        # THEN - it should have all chunking parameters
+        param_names = [p["name"] for p in job_template["parameterDefinitions"]]
+
+        assert "ChunkSize" in param_names, "Job template should have ChunkSize parameter"
+        assert (
+            "TargetRuntimeSeconds" in param_names
+        ), "Job template should have TargetRuntimeSeconds parameter"
+
+        # Verify ChunkSize has correct constraints
+        chunk_size_param = next(
+            p for p in job_template["parameterDefinitions"] if p["name"] == "ChunkSize"
+        )
+        assert chunk_size_param["type"] == "INT", "ChunkSize should be INT type"
+        assert chunk_size_param.get("minValue", 0) >= 1 or chunk_size_param.get("default", 0) >= 1
+
+        # Verify TargetRuntimeSeconds
+        target_runtime_param = next(
+            p for p in job_template["parameterDefinitions"] if p["name"] == "TargetRuntimeSeconds"
+        )
+        assert target_runtime_param["type"] == "INT", "TargetRuntimeSeconds should be INT type"
+        assert target_runtime_param.get("default") == 0, "TargetRuntimeSeconds should default to 0"
+        assert (
+            target_runtime_param.get("minValue", 0) >= 0
+        ), "TargetRuntimeSeconds minValue should be >= 0"
+
+    def test_dynamic_chunking_job_template_uses_current_conda_defaults(self, templates_base_path):
+        """
+        Verify dynamic chunking job template uses the current CondaPackages pin and
+        CondaChannels defaults. Dynamic chunking requires an adaptor that understands
+        the dynamic_chunked_frames run_data key, so the pin must be at least 0.7.*.
+        """
+        # GIVEN - the dynamic chunking job template
+        job_template_path = os.path.join(
+            templates_base_path, "dynamic_chunking", "dynamic_chunking_render_job.yml"
+        )
+
+        # WHEN - we load the template
+        with open(job_template_path, "r") as f:
+            job_template = yaml.safe_load(f)
+
+        # THEN - CondaPackages pin should reference the 0.7.* adaptor line
+        conda_packages_param = next(
+            p for p in job_template["parameterDefinitions"] if p["name"] == "CondaPackages"
+        )
+        assert "unrealengine-openjd=0.7.*" in conda_packages_param["default"]
+        assert "unrealengine-openjd=0.6.*" not in conda_packages_param["default"]
+
+        # AND - CondaChannels should include the current deadline-cloud-v2 channel
+        conda_channels_param = next(
+            p for p in job_template["parameterDefinitions"] if p["name"] == "CondaChannels"
+        )
+        assert "deadline-cloud-v2" in conda_channels_param["default"]
+
+    def test_dynamic_chunking_step_template_has_chunk_int_parameter(self, templates_base_path):
+        """
+        Verify dynamic chunking step template contains CHUNK[INT] task parameter
+        with the chunks configuration structure preserved.
+        """
+        # GIVEN - the dynamic chunking step template
+        step_template_path = os.path.join(
+            templates_base_path, "dynamic_chunking", "dynamic_chunking_render_step.yml"
+        )
+
+        # WHEN - we load the template
+        with open(step_template_path, "r") as f:
+            step_template = yaml.safe_load(f)
+
+        # THEN - it should have CHUNK[INT] task parameter
+        task_params = step_template["parameterSpace"]["taskParameterDefinitions"]
+        chunk_params = [p for p in task_params if p.get("type") == "CHUNK[INT]"]
+
+        assert len(chunk_params) == 1, "Step template should have exactly one CHUNK[INT] parameter"
+
+        chunk_param = chunk_params[0]
+        assert (
+            chunk_param["name"] == "DynamicChunking"
+        ), "CHUNK[INT] parameter should be named DynamicChunking"
+
+        # Verify chunks configuration exists with all required fields
+        assert "chunks" in chunk_param, "CHUNK[INT] parameter should have chunks configuration"
+        chunks_config = chunk_param["chunks"]
+
+        assert "defaultTaskCount" in chunks_config, "chunks config should have defaultTaskCount"
+        assert (
+            "targetRuntimeSeconds" in chunks_config
+        ), "chunks config should have targetRuntimeSeconds"
+        assert "rangeConstraint" in chunks_config, "chunks config should have rangeConstraint"
+
+    def test_dynamic_chunking_detection_works_on_step_template(self, templates_base_path):
+        """
+        Verify DynamicChunkingHelper correctly detects CHUNK[INT] in step template.
+        """
+        # GIVEN - the dynamic chunking step template
+        step_template_path = os.path.join(
+            templates_base_path, "dynamic_chunking", "dynamic_chunking_render_step.yml"
+        )
+
+        with open(step_template_path, "r") as f:
+            step_template = yaml.safe_load(f)
+
+        # WHEN - we check if it uses dynamic chunking
+        uses_dynamic_chunking = DynamicChunkingHelper.is_using_dynamic_chunking(step_template)
+
+        # THEN - it should be detected as using dynamic chunking
+        assert (
+            uses_dynamic_chunking is True
+        ), "Dynamic chunking step template should be detected as using dynamic chunking"
+
+    def test_dynamic_chunking_step_template_uses_template_references(self, templates_base_path):
+        """
+        Verify dynamic chunking step template uses template references for parameter values.
+
+        This ensures frame range expressions and chunking parameters are passed through
+        from job parameters to the step template.
+        """
+        # GIVEN - the dynamic chunking step template
+        step_template_path = os.path.join(
+            templates_base_path, "dynamic_chunking", "dynamic_chunking_render_step.yml"
+        )
+
+        with open(step_template_path, "r") as f:
+            step_template = yaml.safe_load(f)
+
+        # WHEN - we examine the CHUNK[INT] parameter
+        task_params = step_template["parameterSpace"]["taskParameterDefinitions"]
+        chunk_param = next(p for p in task_params if p.get("type") == "CHUNK[INT]")
+
+        # THEN - it should use template references
+        assert (
+            chunk_param["range"] == "{{Param.Frames}}"
+        ), "CHUNK[INT] range should reference Frames parameter"
+
+        chunks_config = chunk_param["chunks"]
+        assert (
+            chunks_config["defaultTaskCount"] == "{{Param.ChunkSize}}"
+        ), "defaultTaskCount should reference ChunkSize parameter"
+        assert (
+            chunks_config["targetRuntimeSeconds"] == "{{Param.TargetRuntimeSeconds}}"
+        ), "targetRuntimeSeconds should reference TargetRuntimeSeconds parameter"
+        # rangeConstraint is hardcoded to CONTIGUOUS (not a template reference)
+        assert (
+            chunks_config["rangeConstraint"] == "CONTIGUOUS"
+        ), "rangeConstraint should be hardcoded to CONTIGUOUS"
+
+    def test_dynamic_chunking_step_template_uses_current_run_data_wiring(self, templates_base_path):
+        """
+        Verify dynamic chunking step template wires Handler/QueueManifestPath and
+        dynamic_chunked_frames into run data using the current conventions.
+        """
+        # GIVEN - the dynamic chunking step template
+        step_template_path = os.path.join(
+            templates_base_path, "dynamic_chunking", "dynamic_chunking_render_step.yml"
+        )
+
+        with open(step_template_path, "r") as f:
+            step_template = yaml.safe_load(f)
+
+        # WHEN - we examine the script's embedded files
+        embedded_files = step_template["script"]["embeddedFiles"]
+        run_data_file = next(f for f in embedded_files if f["name"] == "runData")
+
+        # THEN - run data should reference the current keys
+        assert "handler: {{Task.Param.Handler}}" in run_data_file["data"]
+        assert "queue_manifest_path: {{Task.Param.QueueManifestPath}}" in run_data_file["data"]
+        assert "dynamic_chunked_frames: {{Task.Param.DynamicChunking}}" in run_data_file["data"]
+        # AND - it should NOT carry the legacy/static chunking keys
+        assert "task_index:" not in run_data_file["data"]
+        assert "shots_per_task:" not in run_data_file["data"]
+        assert "frames_per_task:" not in run_data_file["data"]
+
+
+class TestLegacyTemplateIntegration:
+    """
+    Integration tests for legacy (non-dynamic-chunking) templates.
+    """
+
+    @pytest.fixture
+    def templates_base_path(self):
+        """Fixture providing the base path for templates."""
+        return get_templates_base_path()
+
+    def test_legacy_job_template_does_not_have_task_chunking_extension(self, templates_base_path):
+        """
+        Verify legacy job template does NOT include TASK_CHUNKING extension.
+        """
+        # GIVEN - the legacy render job template
+        job_template_path = os.path.join(templates_base_path, "render_job.yml")
+
+        # WHEN - we load the template
+        with open(job_template_path, "r") as f:
+            job_template = yaml.safe_load(f)
+
+        # THEN - it should NOT have TASK_CHUNKING extension
+        extensions = job_template.get("extensions", [])
+        assert (
+            "TASK_CHUNKING" not in extensions
+        ), "Legacy job template should NOT include TASK_CHUNKING extension"
+
+    def test_legacy_step_template_has_task_index_parameter(self, templates_base_path):
+        """
+        Verify legacy step template uses TaskIndex INT parameter (not CHUNK[INT]).
+        """
+        # GIVEN - the legacy render step template
+        step_template_path = os.path.join(templates_base_path, "render_step.yml")
+
+        # WHEN - we load the template
+        with open(step_template_path, "r") as f:
+            step_template = yaml.safe_load(f)
+
+        # THEN - it should have TaskIndex INT parameter (not CHUNK[INT])
+        task_params = step_template["parameterSpace"]["taskParameterDefinitions"]
+
+        # Should have TaskIndex parameter
+        task_index_params = [p for p in task_params if p["name"] == "TaskIndex"]
+        assert len(task_index_params) == 1, "Legacy template should have TaskIndex parameter"
+
+        task_index_param = task_index_params[0]
+        assert task_index_param["type"] == "INT", "TaskIndex should be INT type (not CHUNK[INT])"
+
+        # Should NOT have any CHUNK[INT] parameters
+        chunk_int_params = [p for p in task_params if p.get("type") == "CHUNK[INT]"]
+        assert (
+            len(chunk_int_params) == 0
+        ), "Legacy template should NOT have any CHUNK[INT] parameters"
+
+    def test_legacy_step_template_not_detected_as_dynamic_chunking(self, templates_base_path):
+        """
+        Verify DynamicChunkingHelper correctly identifies legacy template as NOT using
+        dynamic chunking.
+        """
+        # GIVEN - the legacy render step template
+        step_template_path = os.path.join(templates_base_path, "render_step.yml")
+
+        with open(step_template_path, "r") as f:
+            step_template = yaml.safe_load(f)
+
+        # WHEN - we check if it uses dynamic chunking
+        uses_dynamic_chunking = DynamicChunkingHelper.is_using_dynamic_chunking(step_template)
+
+        # THEN - it should NOT be detected as using dynamic chunking
+        assert (
+            uses_dynamic_chunking is False
+        ), "Legacy step template should NOT be detected as using dynamic chunking"
+
+    def test_legacy_job_template_has_shots_per_task_parameter(self, templates_base_path):
+        """
+        Verify legacy job template has ShotsPerTask parameter for shot-based chunking.
+        """
+        # GIVEN - the legacy render job template
+        job_template_path = os.path.join(templates_base_path, "render_job.yml")
+
+        # WHEN - we load the template
+        with open(job_template_path, "r") as f:
+            job_template = yaml.safe_load(f)
+
+        # THEN - it should have ShotsPerTask parameter
+        param_names = [p["name"] for p in job_template["parameterDefinitions"]]
+        assert (
+            "ShotsPerTask" in param_names
+        ), "Legacy job template should have ShotsPerTask parameter for shot-based chunking"
+
+    def test_legacy_step_template_uses_task_index_in_run_data(self, templates_base_path):
+        """
+        Verify legacy step template references task_index in run data.
+
+        This confirms the legacy template structure is preserved for backward compatibility.
+        """
+        # GIVEN - the legacy render step template
+        step_template_path = os.path.join(templates_base_path, "render_step.yml")
+
+        with open(step_template_path, "r") as f:
+            step_template = yaml.safe_load(f)
+
+        # WHEN - we examine the script's embedded files
+        embedded_files = step_template["script"]["embeddedFiles"]
+        run_data_file = next(f for f in embedded_files if f["name"] == "runData")
+
+        # THEN - run data should reference task_index
+        assert (
+            "task_index: {{Task.Param.TaskIndex}}" in run_data_file["data"]
+        ), "Legacy template run data should reference TaskIndex task parameter"
+        assert (
+            "shots_per_task: {{Param.ShotsPerTask}}" in run_data_file["data"]
+        ), "Legacy template run data should reference ShotsPerTask job parameter"
+
+
+class TestTemplateStructureComparison:
+    """
+    Tests comparing dynamic chunking and legacy template structures.
+
+    Ensures both template types maintain their distinct characteristics.
+    """
+
+    @pytest.fixture
+    def templates_base_path(self):
+        """Fixture providing the base path for templates."""
+        return get_templates_base_path()
+
+    def test_both_templates_have_same_base_structure(self, templates_base_path):
+        """
+        Verify both template types share common base structure elements.
+        """
+        # Load both step templates
+        dynamic_step_path = os.path.join(
+            templates_base_path, "dynamic_chunking", "dynamic_chunking_render_step.yml"
+        )
+        legacy_step_path = os.path.join(templates_base_path, "render_step.yml")
+
+        with open(dynamic_step_path, "r") as f:
+            dynamic_template = yaml.safe_load(f)
+        with open(legacy_step_path, "r") as f:
+            legacy_template = yaml.safe_load(f)
+
+        # Both should have same base structure
+        assert "name" in dynamic_template and "name" in legacy_template
+        assert "parameterSpace" in dynamic_template and "parameterSpace" in legacy_template
+        assert "script" in dynamic_template and "script" in legacy_template
+
+        # Both should have Handler and QueueManifestPath parameters
+        dynamic_param_names = [
+            p["name"] for p in dynamic_template["parameterSpace"]["taskParameterDefinitions"]
+        ]
+        legacy_param_names = [
+            p["name"] for p in legacy_template["parameterSpace"]["taskParameterDefinitions"]
+        ]
+
+        assert "Handler" in dynamic_param_names and "Handler" in legacy_param_names
+        assert (
+            "QueueManifestPath" in dynamic_param_names and "QueueManifestPath" in legacy_param_names
+        )
+
+    def test_templates_differ_in_chunking_approach(self, templates_base_path):
+        """
+        Verify templates use different chunking approaches.
+        """
+        # Load both step templates
+        dynamic_step_path = os.path.join(
+            templates_base_path, "dynamic_chunking", "dynamic_chunking_render_step.yml"
+        )
+        legacy_step_path = os.path.join(templates_base_path, "render_step.yml")
+
+        with open(dynamic_step_path, "r") as f:
+            dynamic_template = yaml.safe_load(f)
+        with open(legacy_step_path, "r") as f:
+            legacy_template = yaml.safe_load(f)
+
+        dynamic_params = dynamic_template["parameterSpace"]["taskParameterDefinitions"]
+        legacy_params = legacy_template["parameterSpace"]["taskParameterDefinitions"]
+
+        # Dynamic template should have CHUNK[INT], legacy should have INT TaskIndex
+        dynamic_types = {p["name"]: p["type"] for p in dynamic_params}
+        legacy_types = {p["name"]: p["type"] for p in legacy_params}
+
+        assert "DynamicChunking" in dynamic_types
+        assert dynamic_types["DynamicChunking"] == "CHUNK[INT]"
+
+        assert "TaskIndex" in legacy_types
+        assert legacy_types["TaskIndex"] == "INT"
+
+        # Dynamic should NOT have TaskIndex, legacy should NOT have DynamicChunking
+        assert "TaskIndex" not in dynamic_types
+        assert "DynamicChunking" not in legacy_types

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_parameters_consistency.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_parameters_consistency.py
@@ -289,3 +289,111 @@ class TestParametersConsistencyChecker:
 
         # THEN
         assert fixed == fixtures.f_environment_template_default()["variables"]
+
+    def _f_dynamic_chunking_step_template(self) -> dict:
+        """Step template with a CHUNK[INT] task parameter (TASK_CHUNKING extension)."""
+        template = fixtures.f_step_template_default()
+        template["parameterSpace"]["taskParameterDefinitions"] = list(
+            template["parameterSpace"]["taskParameterDefinitions"]
+        ) + [
+            {
+                "name": "DynamicChunking",
+                "type": "CHUNK[INT]",
+                "range": "{{Param.Frames}}",
+                "chunks": {
+                    "defaultTaskCount": "{{Param.ChunkSize}}",
+                    "rangeConstraint": "CONTIGUOUS",
+                },
+            }
+        ]
+        return template
+
+    def test_check_step_parameters_consistency_ignores_chunk_int(self):
+        """
+        A Data Asset can never hold a CHUNK[INT] parameter (Unreal's ValueType
+        enum has no such type; open_job_template_api.py skips it), so the
+        consistency check must not report it as missing from the Data Asset.
+        """
+        # GIVEN
+        checker = ParametersConsistencyChecker()
+        template = self._f_dynamic_chunking_step_template()
+        data_asset_parameters = [
+            {"name": p["name"], "type": p["type"]}
+            for p in fixtures.f_step_template_default()["parameterSpace"][
+                "taskParameterDefinitions"
+            ]
+        ]
+
+        # WHEN
+        with patch("yaml.safe_load", MagicMock(side_effect=[template])):
+            with patch("builtins.open", MagicMock()):
+                result = checker.check_step_parameters_consistency("", data_asset_parameters)
+
+        # THEN
+        assert result.passed, result.reason
+
+    def test_fix_step_parameters_consistency_does_not_add_chunk_int(self):
+        """The fix path must never inject a CHUNK[INT] parameter into a Data Asset."""
+        # GIVEN
+        checker = ParametersConsistencyChecker()
+        template = self._f_dynamic_chunking_step_template()
+
+        # WHEN
+        with patch("yaml.safe_load", MagicMock(side_effect=[template])):
+            with patch("builtins.open", MagicMock()):
+                fixed = checker.fix_step_parameters_consistency("", [])
+
+        # THEN
+        assert all(not p["type"].startswith("CHUNK[") for p in fixed)
+        assert [p["name"] for p in fixed] == [
+            p["name"]
+            for p in fixtures.f_step_template_default()["parameterSpace"][
+                "taskParameterDefinitions"
+            ]
+        ]
+
+    def test_check_step_parameters_consistency_ignores_stale_chunk_int_in_data_asset(self):
+        """
+        A Data Asset written by an older plugin build can carry a stale
+        CHUNK[INT] row (e.g. inserted by that build's Fix Consistency action).
+        The YAML is authoritative for CHUNK parameters and Data Asset
+        overrides are never applied to them, so the row must not fail the
+        consistency check.
+        """
+        # GIVEN
+        checker = ParametersConsistencyChecker()
+        template = self._f_dynamic_chunking_step_template()
+        data_asset_parameters = [
+            {"name": p["name"], "type": p["type"]}
+            for p in fixtures.f_step_template_default()["parameterSpace"][
+                "taskParameterDefinitions"
+            ]
+        ] + [{"name": "DynamicChunking", "type": "CHUNK[INT]"}]
+
+        # WHEN
+        with patch("yaml.safe_load", MagicMock(side_effect=[template])):
+            with patch("builtins.open", MagicMock()):
+                result = checker.check_step_parameters_consistency("", data_asset_parameters)
+
+        # THEN
+        assert result.passed, result.reason
+
+    def test_fix_step_parameters_consistency_drops_stale_chunk_int_from_data_asset(self):
+        """Fix Consistency must clean a stale CHUNK[INT] row out of the Data Asset."""
+        # GIVEN
+        checker = ParametersConsistencyChecker()
+        template = self._f_dynamic_chunking_step_template()
+        data_asset_parameters = [
+            {"name": p["name"], "type": p["type"]}
+            for p in fixtures.f_step_template_default()["parameterSpace"][
+                "taskParameterDefinitions"
+            ]
+        ] + [{"name": "DynamicChunking", "type": "CHUNK[INT]"}]
+
+        # WHEN
+        with patch("yaml.safe_load", MagicMock(side_effect=[template])):
+            with patch("builtins.open", MagicMock()):
+                fixed = checker.fix_step_parameters_consistency("", data_asset_parameters)
+
+        # THEN
+        assert all(not p["type"].startswith("CHUNK[") for p in fixed)

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_render_unreal_open_job_dynamic_chunking.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_render_unreal_open_job_dynamic_chunking.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import sys
+import pytest
 from unittest.mock import patch, MagicMock
 
 # Mock external modules before importing
@@ -11,6 +12,7 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job import (  # noqa:
     RenderUnrealOpenJob,
     OpenJobParameterNames,
 )
+from deadline.unreal_submitter.exceptions import SubmitterInputValidationError  # noqa: E402
 
 
 class TestRenderUnrealOpenJobIsUsingDynamicChunking:
@@ -227,6 +229,42 @@ class TestRenderUnrealOpenJobBuildFramesParameterValue:
         # THEN - MRQ end frames are exclusive; the OpenJD Frames expression is
         # inclusive, so custom range [10, 50) becomes "10-49" (40 frames)
         assert result[0]["value"] == "10-49"
+
+    @pytest.mark.parametrize(("start_frame", "end_frame"), [(0, 0), (10, 5)])
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={"parameterDefinitions": []},
+    )
+    def test_rejects_empty_or_descending_custom_playback_range(
+        self, get_template_object_mock, start_frame, end_frame
+    ):
+        """Fail in the submitter instead of emitting an invalid OpenJD range."""
+        output_settings_mock = MagicMock()
+        output_settings_mock.use_custom_playback_range = True
+        output_settings_mock.custom_start_frame = start_frame
+        output_settings_mock.custom_end_frame = end_frame
+
+        config_mock = MagicMock()
+        config_mock.find_setting_by_class.return_value = output_settings_mock
+
+        mrq_job_mock = MagicMock()
+        mrq_job_mock.get_configuration.return_value = config_mock
+        mrq_job_mock.sequence = MagicMock()
+
+        render_job = RenderUnrealOpenJob(file_path="", name="TestJob")
+        render_job._mrq_job = mrq_job_mock  # type: ignore[assignment]
+
+        parameter_values = [{"name": OpenJobParameterNames.FRAMES, "value": None}]
+
+        with patch(
+            "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.EditorAssetLibrary.load_asset",
+            return_value=MagicMock(),
+        ):
+            with pytest.raises(SubmitterInputValidationError) as exc_info:
+                render_job._build_frames_parameter_value(parameter_values)
+
+        assert f"[{start_frame}, {end_frame})" in str(exc_info.value)
 
     @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_render_unreal_open_job_dynamic_chunking.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_render_unreal_open_job_dynamic_chunking.py
@@ -1,0 +1,336 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import sys
+from unittest.mock import patch, MagicMock
+
+# Mock external modules before importing
+unreal_mock = MagicMock()
+sys.modules["unreal"] = unreal_mock
+
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job import (  # noqa: E402
+    RenderUnrealOpenJob,
+    OpenJobParameterNames,
+)
+
+
+class TestRenderUnrealOpenJobIsUsingDynamicChunking:
+    """Tests for RenderUnrealOpenJob._is_using_dynamic_chunking method."""
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={"parameterDefinitions": []},
+    )
+    def test_returns_true_when_step_uses_chunk_int(self, get_template_object_mock):
+        """Test that _is_using_dynamic_chunking returns True when a step has CHUNK[INT] parameter."""
+        # GIVEN
+        step_mock = MagicMock()
+        step_mock.get_template_object.return_value = {
+            "parameterSpace": {
+                "taskParameterDefinitions": [
+                    {"name": "DynamicChunking", "type": "CHUNK[INT]", "range": "{{Param.Frames}}"}
+                ]
+            }
+        }
+
+        render_job = RenderUnrealOpenJob(file_path="", name="TestJob", steps=[step_mock])
+
+        # WHEN
+        result = render_job._is_using_dynamic_chunking()
+
+        # THEN
+        assert result is True
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={"parameterDefinitions": []},
+    )
+    def test_returns_false_when_step_uses_int_type(self, get_template_object_mock):
+        """Test that _is_using_dynamic_chunking returns False when step uses regular INT type."""
+        # GIVEN
+        step_mock = MagicMock()
+        step_mock.get_template_object.return_value = {
+            "parameterSpace": {
+                "taskParameterDefinitions": [
+                    {"name": "TaskIndex", "type": "INT", "range": [0, 1, 2]}
+                ]
+            }
+        }
+
+        render_job = RenderUnrealOpenJob(file_path="", name="TestJob", steps=[step_mock])
+
+        # WHEN
+        result = render_job._is_using_dynamic_chunking()
+
+        # THEN
+        assert result is False
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={"parameterDefinitions": []},
+    )
+    def test_returns_false_when_no_steps(self, get_template_object_mock):
+        """Test that _is_using_dynamic_chunking returns False when there are no steps."""
+        # GIVEN
+        render_job = RenderUnrealOpenJob(file_path="", name="TestJob", steps=[])
+
+        # WHEN
+        result = render_job._is_using_dynamic_chunking()
+
+        # THEN
+        assert result is False
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={"parameterDefinitions": []},
+    )
+    def test_returns_true_when_any_step_uses_dynamic_chunking(self, get_template_object_mock):
+        """Test that _is_using_dynamic_chunking returns True if any step uses CHUNK[INT]."""
+        # GIVEN
+        step_regular = MagicMock()
+        step_regular.get_template_object.return_value = {
+            "parameterSpace": {
+                "taskParameterDefinitions": [{"name": "TaskIndex", "type": "INT", "range": [0, 1]}]
+            }
+        }
+
+        step_dynamic = MagicMock()
+        step_dynamic.get_template_object.return_value = {
+            "parameterSpace": {
+                "taskParameterDefinitions": [
+                    {"name": "DynamicChunking", "type": "CHUNK[INT]", "range": "{{Param.Frames}}"}
+                ]
+            }
+        }
+
+        render_job = RenderUnrealOpenJob(
+            file_path="", name="TestJob", steps=[step_regular, step_dynamic]
+        )
+
+        # WHEN
+        result = render_job._is_using_dynamic_chunking()
+
+        # THEN
+        assert result is True
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={"parameterDefinitions": []},
+    )
+    def test_handles_step_template_file_not_found(self, get_template_object_mock):
+        """Test that _is_using_dynamic_chunking handles FileNotFoundError gracefully."""
+        # GIVEN
+        step_mock = MagicMock()
+        step_mock.get_template_object.side_effect = FileNotFoundError("Template not found")
+
+        render_job = RenderUnrealOpenJob(file_path="", name="TestJob", steps=[step_mock])
+
+        # WHEN
+        result = render_job._is_using_dynamic_chunking()
+
+        # THEN
+        assert result is False
+
+
+class TestRenderUnrealOpenJobBuildFramesParameterValue:
+    """Tests for RenderUnrealOpenJob._build_frames_parameter_value method."""
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={"parameterDefinitions": []},
+    )
+    def test_returns_unchanged_when_no_frames_parameter(self, get_template_object_mock):
+        """Test that parameter values are unchanged when Frames parameter doesn't exist."""
+        # GIVEN
+        render_job = RenderUnrealOpenJob(file_path="", name="TestJob")
+        parameter_values = [{"name": "OtherParam", "value": "test"}]
+
+        # WHEN
+        result = render_job._build_frames_parameter_value(parameter_values)
+
+        # THEN
+        assert result == parameter_values
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={"parameterDefinitions": []},
+    )
+    def test_returns_unchanged_when_frames_already_has_value(self, get_template_object_mock):
+        """Test that parameter values are unchanged when Frames already has a value."""
+        # GIVEN
+        render_job = RenderUnrealOpenJob(file_path="", name="TestJob")
+        parameter_values = [{"name": OpenJobParameterNames.FRAMES, "value": "1-100"}]
+
+        # WHEN
+        result = render_job._build_frames_parameter_value(parameter_values)
+
+        # THEN
+        assert result[0]["value"] == "1-100"
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={"parameterDefinitions": []},
+    )
+    def test_returns_unchanged_when_no_mrq_job(self, get_template_object_mock):
+        """Test that parameter values are unchanged when MRQ job is not set."""
+        # GIVEN
+        render_job = RenderUnrealOpenJob(file_path="", name="TestJob")
+        parameter_values = [{"name": OpenJobParameterNames.FRAMES, "value": None}]
+
+        # WHEN
+        result = render_job._build_frames_parameter_value(parameter_values)
+
+        # THEN
+        assert result[0]["value"] is None
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={"parameterDefinitions": []},
+    )
+    def test_populates_frames_from_custom_playback_range(self, get_template_object_mock):
+        """Test that Frames is populated from custom playback range when enabled."""
+        # GIVEN
+        output_settings_mock = MagicMock()
+        output_settings_mock.use_custom_playback_range = True
+        output_settings_mock.custom_start_frame = 10
+        output_settings_mock.custom_end_frame = 50
+
+        config_mock = MagicMock()
+        config_mock.find_setting_by_class.return_value = output_settings_mock
+
+        mrq_job_mock = MagicMock()
+        mrq_job_mock.get_configuration.return_value = config_mock
+        mrq_job_mock.sequence = MagicMock()
+
+        level_sequence_mock = MagicMock()
+
+        render_job = RenderUnrealOpenJob(file_path="", name="TestJob")
+        render_job._mrq_job = mrq_job_mock  # type: ignore[assignment]
+
+        parameter_values = [{"name": OpenJobParameterNames.FRAMES, "value": None}]
+
+        with patch(
+            "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.EditorAssetLibrary.load_asset",
+            return_value=level_sequence_mock,
+        ):
+            # WHEN
+            result = render_job._build_frames_parameter_value(parameter_values)
+
+        # THEN - MRQ end frames are exclusive; the OpenJD Frames expression is
+        # inclusive, so custom range [10, 50) becomes "10-49" (40 frames)
+        assert result[0]["value"] == "10-49"
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={"parameterDefinitions": []},
+    )
+    def test_populates_frames_from_level_sequence_playback_range(self, get_template_object_mock):
+        """Test that Frames is populated from level sequence when custom range is disabled."""
+        # GIVEN
+        output_settings_mock = MagicMock()
+        output_settings_mock.use_custom_playback_range = False
+
+        config_mock = MagicMock()
+        config_mock.find_setting_by_class.return_value = output_settings_mock
+
+        mrq_job_mock = MagicMock()
+        mrq_job_mock.get_configuration.return_value = config_mock
+        mrq_job_mock.sequence = MagicMock()
+
+        playback_range_mock = MagicMock()
+        playback_range_mock.get_start_frame.return_value = 0
+        playback_range_mock.get_end_frame.return_value = 100
+
+        level_sequence_mock = MagicMock()
+        level_sequence_mock.get_playback_range.return_value = playback_range_mock
+
+        render_job = RenderUnrealOpenJob(file_path="", name="TestJob")
+        render_job._mrq_job = mrq_job_mock  # type: ignore[assignment]
+
+        parameter_values = [{"name": OpenJobParameterNames.FRAMES, "value": None}]
+
+        with patch(
+            "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.EditorAssetLibrary.load_asset",
+            return_value=level_sequence_mock,
+        ):
+            # WHEN
+            result = render_job._build_frames_parameter_value(parameter_values)
+
+        # THEN - playback range [0, 100) becomes inclusive "0-99" (100 frames)
+        assert result[0]["value"] == "0-99"
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={"parameterDefinitions": []},
+    )
+    def test_returns_unchanged_when_level_sequence_not_found(self, get_template_object_mock):
+        """Test that parameter values are unchanged when level sequence cannot be loaded."""
+        # GIVEN
+        config_mock = MagicMock()
+        config_mock.find_setting_by_class.return_value = MagicMock()
+
+        mrq_job_mock = MagicMock()
+        mrq_job_mock.get_configuration.return_value = config_mock
+        mrq_job_mock.sequence = MagicMock()
+
+        render_job = RenderUnrealOpenJob(file_path="", name="TestJob")
+        render_job._mrq_job = mrq_job_mock  # type: ignore[assignment]
+
+        parameter_values = [{"name": OpenJobParameterNames.FRAMES, "value": None}]
+
+        with patch(
+            "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.EditorAssetLibrary.load_asset",
+            return_value=None,
+        ):
+            # WHEN
+            result = render_job._build_frames_parameter_value(parameter_values)
+
+        # THEN
+        assert result[0]["value"] is None
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={"parameterDefinitions": []},
+    )
+    def test_handles_negative_frame_numbers(self, get_template_object_mock):
+        """Test that negative frame numbers are handled correctly."""
+        # GIVEN
+        output_settings_mock = MagicMock()
+        output_settings_mock.use_custom_playback_range = True
+        output_settings_mock.custom_start_frame = -10
+        output_settings_mock.custom_end_frame = 50
+
+        config_mock = MagicMock()
+        config_mock.find_setting_by_class.return_value = output_settings_mock
+
+        mrq_job_mock = MagicMock()
+        mrq_job_mock.get_configuration.return_value = config_mock
+        mrq_job_mock.sequence = MagicMock()
+
+        level_sequence_mock = MagicMock()
+
+        render_job = RenderUnrealOpenJob(file_path="", name="TestJob")
+        render_job._mrq_job = mrq_job_mock  # type: ignore[assignment]
+
+        parameter_values = [{"name": OpenJobParameterNames.FRAMES, "value": None}]
+
+        with patch(
+            "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.EditorAssetLibrary.load_asset",
+            return_value=level_sequence_mock,
+        ):
+            # WHEN
+            result = render_job._build_frames_parameter_value(parameter_values)
+
+        # THEN - custom range [-10, 50) becomes inclusive "-10-49" (60 frames)
+        assert result[0]["value"] == "-10-49"

--- a/test/end_to_end/test_dynamic_chunking_job.py
+++ b/test/end_to_end/test_dynamic_chunking_job.py
@@ -1,0 +1,265 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""
+End-to-end test for the bundled dynamic-chunking template pair
+(``dynamic_chunking_render_job.yml`` + ``dynamic_chunking_render_step.yml``).
+
+The test composes those shipped templates into one job, submits it to a real
+worker, and verifies both scheduler chunking and adaptor rendering. Service-side
+acceptance of the required ``Frames`` parameter and ``TASK_CHUNKING`` extension
+is implicit in successful job creation.
+
+The in-editor submission path and missing/empty ``Frames`` validation are
+covered by submitter unit tests.
+"""
+
+import json
+import logging
+import os
+from typing import Any
+
+import yaml
+
+from conftest import (
+    cancel_job,
+    extract_job_info_from_test_output,
+    get_source_root,
+    wait_for_job_state,
+)
+
+logger = logging.getLogger(__name__)
+
+TEMPLATES_DIR = os.path.join(
+    get_source_root(),
+    "src",
+    "unreal_plugin",
+    "Content",
+    "Python",
+    "openjd_templates",
+    "dynamic_chunking",
+)
+
+
+def _compose_dynamic_chunking_job_template(job_name: str, queue_manifest_path: str) -> dict:
+    """
+    Compose a submittable OpenJD job template from the bundled dynamic-chunking
+    job and step templates, the same way the submitter assembles them:
+    the step template is attached under ``steps`` and the task parameter
+    ranges the submitter would populate (Handler, QueueManifestPath) are
+    filled in.
+
+    Args:
+        job_name: Name for the Deadline Cloud job. Following the repo's e2e
+            convention (see ``run_unreal_test`` in conftest), each submitted
+            job is named after the pytest test that created it so it can be
+            traced back. Deadline Cloud job names are capped at 128 chars.
+        queue_manifest_path: Donor job's serialized MRQ manifest path.
+
+    Returns:
+        The composed job template as a dict.
+    """
+    with open(os.path.join(TEMPLATES_DIR, "dynamic_chunking_render_job.yml")) as f:
+        job_template = yaml.safe_load(f)
+    with open(os.path.join(TEMPLATES_DIR, "dynamic_chunking_render_step.yml")) as f:
+        step_template = yaml.safe_load(f)
+
+    job_template["name"] = job_name[:128]
+
+    # Fill the task parameter ranges that the submitter populates at
+    # submission time. The DynamicChunking CHUNK[INT] parameter keeps its
+    # "{{Param.Frames}}" range reference - that is resolved by the service.
+    for task_param in step_template["parameterSpace"]["taskParameterDefinitions"]:
+        if task_param["name"] == "Handler":
+            task_param["range"] = ["render"]
+        elif task_param["name"] == "QueueManifestPath":
+            task_param["range"] = [queue_manifest_path]
+
+    job_template["steps"] = [step_template]
+    return job_template
+
+
+def _load_launch_environment_template() -> dict:
+    """
+    Load the LaunchUnrealEditor job environment from the source tree.
+
+    The dynamic-chunking job template has no ``jobEnvironments`` section (the
+    in-editor flow attaches the environment from a separate Data Asset), so a
+    direct-API submission must compose the environment in - without it there
+    is no adaptor daemon for the render step's ``daemon run`` to talk to.
+    """
+    launch_env_path = os.path.join(
+        get_source_root(),
+        "src",
+        "unreal_plugin",
+        "Content",
+        "Python",
+        "openjd_templates",
+        "launch_ue_environment.yml",
+    )
+    with open(launch_env_path) as f:
+        return yaml.safe_load(f)
+
+
+def test_dynamic_chunking_render_job_succeeds(
+    deadline_client,
+    build_plugin,
+    create_readonly_test_project,
+    run_unreal_test,
+    reusable_queue_fleet_association,
+    deadline_worker_agent,
+    request,
+):
+    """
+    Render a dynamic-chunking job end to end on a real worker, exercising the
+    adaptor side of the change (dynamic_chunked_frames parsing and MRQ frame
+    windows).
+
+    The dynamic-chunking templates cannot yet be submitted from the editor
+    (no Data Assets reference them), so this test uses a donor job:
+
+    1. Submit a normal job through the editor's MRQ flow. This uploads the
+       real Unreal project and serialized MRQ manifest as job attachments.
+    2. Cancel the donor before a worker picks it up, and harvest its job
+       attachments, parameter values, and the QueueManifestPath task value.
+    3. Resubmit under the dynamic-chunking template pair with Frames="1-10"
+       and ChunkSize=5, so the scheduler forms 2 chunks.
+    4. Wait for SUCCEEDED and assert 10 tasks (one per frame - chunking is a
+       dispatch-time grouping, not a task-count reduction) ran via exactly 2
+       taskRun session actions - proof the scheduler chunked the range and
+       the adaptor rendered each dynamic_chunked_frames window.
+    """
+    _, uproject_file = create_readonly_test_project
+
+    # --- 1. Donor job: real attachments + manifest via the editor flow ---
+    logger.info(f"Submitting donor job from project {uproject_file}")
+    success, output_lines = run_unreal_test(
+        "DeadlineCloud.Integration.CreateJob",
+        uproject_file,
+        job_name=f"{request.node.name}_donor",
+    )
+    assert success, "Donor job submission failed"
+
+    donor_job_id, farm_id, queue_id = extract_job_info_from_test_output(output_lines)
+    assert donor_job_id and farm_id and queue_id, "Could not extract donor job information"
+
+    # Cancel the donor immediately - only its attachments/parameters are
+    # needed, and the fixture's worker agent must not waste time rendering it.
+    cancel_job(deadline_client, farm_id, queue_id, donor_job_id)
+
+    donor_job = deadline_client.get_job(farmId=farm_id, queueId=queue_id, jobId=donor_job_id)
+    donor_parameters = donor_job.get("parameters", {})
+    donor_attachments = donor_job.get("attachments")
+    assert donor_attachments, "Donor job has no job attachments to reuse"
+
+    # QueueManifestPath is a task-level parameter on the donor's Render step.
+    donor_steps = deadline_client.list_steps(
+        farmId=farm_id, queueId=queue_id, jobId=donor_job_id
+    ).get("steps", [])
+    render_steps = [s for s in donor_steps if s.get("name") == "Render"]
+    assert render_steps, f"Donor job has no Render step: {[s.get('name') for s in donor_steps]}"
+    donor_tasks = deadline_client.list_tasks(
+        farmId=farm_id, queueId=queue_id, jobId=donor_job_id, stepId=render_steps[0]["stepId"]
+    ).get("tasks", [])
+    assert donor_tasks, "Donor Render step has no tasks"
+    queue_manifest_path = donor_tasks[0]["parameters"]["QueueManifestPath"]["path"]
+
+    # --- 2. Compose the dynamic-chunking job ---
+    job_template = _compose_dynamic_chunking_job_template(
+        job_name=request.node.name, queue_manifest_path=queue_manifest_path
+    )
+    job_template["jobEnvironments"] = [_load_launch_environment_template()]
+
+    # Carry over the donor's values for the parameters the two templates
+    # share, so the render environment matches the known-good standard flow.
+    dynamic_param_names = {p["name"] for p in job_template["parameterDefinitions"]}
+    parameters = {
+        name: value for name, value in donor_parameters.items() if name in dynamic_param_names
+    }
+    # Frames="1-10" with ChunkSize=5: per the TASK_CHUNKING RFC the parameter
+    # space is the same as for a plain INT parameter - 10 frames = 10 tasks.
+    # Chunking happens at DISPATCH time: the scheduler groups the tasks into
+    # 2 contiguous chunks ("1-5", "6-10") and runs each chunk as a single
+    # session action. Small range keeps the render short while still
+    # exercising multi-chunk dispatch.
+    parameters["Frames"] = {"string": "1-10"}
+    parameters["ChunkSize"] = {"int": "5"}
+    parameters["TargetRuntimeSeconds"] = {"int": "0"}
+    expected_task_count = 10  # one task per frame; chunking does NOT reduce task count
+    expected_chunk_count = 2  # ceil(10 frames / ChunkSize 5) dispatch chunks
+
+    create_job_kwargs = dict(
+        farmId=farm_id,
+        queueId=queue_id,
+        template=json.dumps(job_template),
+        templateType="JSON",
+        priority=50,
+        parameters=parameters,
+        attachments=donor_attachments,
+    )
+    if donor_job.get("storageProfileId"):
+        create_job_kwargs["storageProfileId"] = donor_job["storageProfileId"]
+
+    response = deadline_client.create_job(**create_job_kwargs)
+    job_id = response.get("jobId")
+    assert job_id, "CreateJob did not return a jobId"
+    logger.info(f"Dynamic chunking render job created: {job_id}")
+
+    try:
+        # --- 3. Render on the fixture's worker agent ---
+        success, status, message = wait_for_job_state(
+            deadline_client=deadline_client,
+            farm_id=farm_id,
+            job_id=job_id,
+            queue_id=queue_id,
+            expected_states=["SUCCEEDED"],
+            max_wait_time=900,
+            wait_interval=10,
+        )
+        assert success, f"Dynamic chunking render job did not succeed: {message}"
+        logger.info(f"Dynamic chunking render job {job_id} SUCCEEDED")
+
+        # --- 4. Verify the scheduler actually chunked the frame range ---
+        # The parameter space still has one task per frame (chunking is a
+        # dispatch-time grouping, not a task-count reduction) ...
+        steps = deadline_client.list_steps(farmId=farm_id, queueId=queue_id, jobId=job_id).get(
+            "steps", []
+        )
+        render_step = next((s for s in steps if s.get("name") == "Render"), None)
+        assert render_step, f"No Render step on the job: {[s.get('name') for s in steps]}"
+        tasks = deadline_client.list_tasks(
+            farmId=farm_id, queueId=queue_id, jobId=job_id, stepId=render_step["stepId"]
+        ).get("tasks", [])
+        assert len(tasks) == expected_task_count, (
+            f"Expected {expected_task_count} tasks - one per frame in Frames=1-10 "
+            f"(chunking does not reduce the task count) - got {len(tasks)}"
+        )
+        unsucceeded = [t["taskId"] for t in tasks if t.get("runStatus") != "SUCCEEDED"]
+        assert not unsucceeded, f"Tasks did not succeed: {unsucceeded}"
+
+        # ... while each chunk runs as a single taskRun session action, so a
+        # 10-frame range with ChunkSize=5 dispatches exactly 2 taskRun actions.
+        task_run_actions: list[dict[str, Any]] = []
+        sessions = deadline_client.list_sessions(
+            farmId=farm_id, queueId=queue_id, jobId=job_id
+        ).get("sessions", [])
+        for session in sessions:
+            actions = deadline_client.list_session_actions(
+                farmId=farm_id,
+                queueId=queue_id,
+                jobId=job_id,
+                sessionId=session["sessionId"],
+            ).get("sessionActions", [])
+            task_run_actions.extend(a for a in actions if a.get("definition", {}).get("taskRun"))
+        for action in task_run_actions:
+            logger.info(
+                "Chunk taskRun action %s parameters: %s",
+                action["sessionActionId"],
+                action["definition"]["taskRun"].get("parameters"),
+            )
+        assert len(task_run_actions) == expected_chunk_count, (
+            f"Expected {expected_chunk_count} chunk dispatches (taskRun session actions) "
+            f"for Frames=1-10 with ChunkSize=5, got {len(task_run_actions)}"
+        )
+    finally:
+        logger.info(f"Cleaning up: canceling job {job_id}")
+        cancel_job(deadline_client, farm_id, queue_id, job_id)

--- a/test/end_to_end/test_dynamic_chunking_job.py
+++ b/test/end_to_end/test_dynamic_chunking_job.py
@@ -260,6 +260,19 @@ def test_dynamic_chunking_render_job_succeeds(
             f"Expected {expected_chunk_count} chunk dispatches (taskRun session actions) "
             f"for Frames=1-10 with ChunkSize=5, got {len(task_run_actions)}"
         )
+
+        actual_chunk_windows = {
+            action["definition"]["taskRun"]
+            .get("parameters", {})
+            .get("DynamicChunking", {})
+            .get("chunkInt")
+            for action in task_run_actions
+        }
+        expected_chunk_windows = {"1-5", "6-10"}
+        assert actual_chunk_windows == expected_chunk_windows, (
+            f"Expected dispatched DynamicChunking windows {expected_chunk_windows}, "
+            f"got {actual_chunk_windows}"
+        )
     finally:
         logger.info(f"Cleaning up: canceling job {job_id}")
         cancel_job(deadline_client, farm_id, queue_id, job_id)


### PR DESCRIPTION
feat: add OpenJD TASK_CHUNKING dynamic chunking support

### What was the problem/requirement? (What/Why)

Deadline Cloud’s existing Unreal Engine render partitioning modes determine task boundaries when a job is submitted. This prevents the scheduler from dynamically grouping frames based on current worker availability and target runtime, limiting load balancing for workloads whose per-frame render times vary.

This change adds an opt-in third partitioning mode using OpenJD’s native `TASK_CHUNKING` extension and `CHUNK[INT]` task parameter type. Deadline Cloud determines contiguous frame chunks at dispatch time from the submitted frame range.

### What was the solution? (How)

Added dedicated dynamic-chunking job and step templates that:

- Declare the OpenJD `TASK_CHUNKING` extension.
- Define a `CHUNK[INT]` task parameter.
- Expose `Frames`, `TargetRuntimeSeconds`, and `RangeConstraint` job parameters.
- Require contiguous ranges because Unreal Engine’s Movie Render Queue cannot render non-contiguous frame lists.

Updated the submitter to:

- Detect and validate dynamically chunked steps.
- Populate `Frames` from the MRQ frame range, converting MRQ’s exclusive end frame to an inclusive OpenJD range.
- Support negative frame numbers.
- Reject missing or empty frame ranges, non-contiguous constraints, and multiple `CHUNK[INT]` parameters in one step.
- Skip fixed `TaskIndex` range generation when the scheduler will form the chunks.
- Handle `CHUNK[INT]` consistently when Unreal Data Assets cannot represent that OpenJD parameter type.

Updated the adaptor to:

- Parse scheduler-provided contiguous frame ranges.
- Convert OpenJD’s inclusive end frame to MRQ’s exclusive end frame.
- Use the chunk’s starting frame for `{task_index}` filename substitution, preventing output collisions when dynamic chunks do not have a task index.

The render partitioning design and migration plan were also updated, including diagrams for all three partitioning modes.

### What is the impact of this change?

Dynamic chunking is opt-in through the dedicated templates under `openjd_templates/dynamic_chunking`. The default submission path remains unchanged and continues to use the existing shots-per-task behavior.

Existing jobs and templates are unaffected. The new `dynamic_chunked_frames` run-data property is optional.

The dynamic templates require an adaptor release containing this new parsing and MRQ configuration logic. The templates specify `unrealengine-openjd=0.7.*` because this feature is intended for a 0.7.x patch release; the currently released `0.7.0` package predates this feature and cannot execute these templates successfully.

### How was this change tested?

- Full unit suite: `677 passed, 2 skipped`
- Dynamic validator suite: `63 passed`
- E2E test ran with all tests passing in CMF setup

### Have you run a render job successfully with these changes?

Yes, rendered test jobs in CMF

### Was this change documented?

Yes, but I am also working a new user guide which will be merged in a different PR

### Is this a breaking change?

No.

The feature is additive and opt-in. Existing templates, submitted jobs, and the default submission path retain their current behavior. The new adaptor run-data property is optional.

Users selecting the dedicated dynamic-chunking templates must use an adaptor release containing this feature; released `unrealengine-openjd=0.7.0` does not yet include the required adaptor logic.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*