### PR TITLE
fix: Reject unresolved dynamic frame ranges

### DIFF
--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -1212,11 +1212,10 @@ class RenderUnrealOpenJob(UnrealOpenJob):
 
         # Need MRQ job to extract frame range
         if not self._mrq_job:
-            logger.warning(
+            raise exceptions.SubmitterInputValidationError(
                 "Cannot populate Frames parameter: MRQ job is not set. "
                 "Dynamic chunking requires frame range from MRQ settings."
             )
-            return parameter_values
 
         # Load output settings and level sequence from MRQ job
         output_settings = self._mrq_job.get_configuration().find_setting_by_class(
@@ -1229,11 +1228,10 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         )
 
         if not level_sequence:
-            logger.warning(
-                "Cannot populate Frames parameter: Level sequence not found. "
-                "Dynamic chunking requires frame range from level sequence."
+            raise exceptions.SubmitterInputValidationError(
+                "Cannot populate Frames parameter: Level sequence could not be loaded. "
+                "Dynamic chunking requires frame range from a valid MRQ level sequence."
             )
-            return parameter_values
 
         # Extract frame range from MRQ settings
         if output_settings and output_settings.use_custom_playback_range:

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_render_unreal_open_job_dynamic_chunking.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_render_unreal_open_job_dynamic_chunking.py
@@ -180,17 +180,18 @@ class TestRenderUnrealOpenJobBuildFramesParameterValue:
         "UnrealOpenJobEntity.get_template_object",
         return_value={"parameterDefinitions": []},
     )
-    def test_returns_unchanged_when_no_mrq_job(self, get_template_object_mock):
-        """Test that parameter values are unchanged when MRQ job is not set."""
-        # GIVEN
+    def test_rejects_dynamic_template_without_mrq_job(self, get_template_object_mock):
+        """Reject a dynamic job template when its Frames value cannot be derived."""
+        # GIVEN - an unresolved Frames parameter identifies the selected dynamic template
         render_job = RenderUnrealOpenJob(file_path="", name="TestJob")
         parameter_values = [{"name": OpenJobParameterNames.FRAMES, "value": None}]
 
-        # WHEN
-        result = render_job._build_frames_parameter_value(parameter_values)
+        # WHEN / THEN
+        with pytest.raises(SubmitterInputValidationError) as exc_info:
+            render_job._build_frames_parameter_value(parameter_values)
 
-        # THEN
-        assert result[0]["value"] is None
+        assert "MRQ job is not set" in str(exc_info.value)
+        assert "Dynamic chunking requires frame range" in str(exc_info.value)
 
     @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
@@ -311,9 +312,11 @@ class TestRenderUnrealOpenJobBuildFramesParameterValue:
         "UnrealOpenJobEntity.get_template_object",
         return_value={"parameterDefinitions": []},
     )
-    def test_returns_unchanged_when_level_sequence_not_found(self, get_template_object_mock):
-        """Test that parameter values are unchanged when level sequence cannot be loaded."""
-        # GIVEN
+    def test_rejects_dynamic_template_when_level_sequence_cannot_be_loaded(
+        self, get_template_object_mock
+    ):
+        """Reject a dynamic job template that cannot supply an MRQ frame range."""
+        # GIVEN - the dynamic template has unresolved Frames and an invalid sequence reference
         config_mock = MagicMock()
         config_mock.find_setting_by_class.return_value = MagicMock()
 
@@ -330,11 +333,12 @@ class TestRenderUnrealOpenJobBuildFramesParameterValue:
             "deadline.unreal_submitter.unreal_open_job.unreal_open_job.unreal.EditorAssetLibrary.load_asset",
             return_value=None,
         ):
-            # WHEN
-            result = render_job._build_frames_parameter_value(parameter_values)
+            # WHEN / THEN
+            with pytest.raises(SubmitterInputValidationError) as exc_info:
+                render_job._build_frames_parameter_value(parameter_values)
 
-        # THEN
-        assert result[0]["value"] is None
+        assert "Level sequence could not be loaded" in str(exc_info.value)
+        assert "valid MRQ level sequence" in str(exc_info.value)
 
     @patch(
         "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."


### PR DESCRIPTION
fix: Reject unresolved dynamic frame ranges

### What was the problem/requirement? (What/Why)

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

When a dynamic chunking template had an unresolved `Frames` parameter, the submitter logged a warning and continued if either:
- No MRQ job was attached.
- The MRQ job’s level sequence could not be loaded.
Both conditions prevent the submitter from deriving the required frame range. Continuing left Frames unresolved and deferred the failure to downstream OpenJD validation, producing a less useful error later in submission.

- Have you run the unit tests?
Yes

### Have you run a render job successfully with these changes?
Yes

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*