### PR TITLE
feat: Add Unreal Engine 5.8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For instructions on installing and using this integration, visit the [user guide
 
 This library requires:
 
-1. Python 3.9 or higher; and Unreal Engine 5.4 - 5.7.
+1. Python 3.9 or higher; and Unreal Engine 5.4 through 5.8.
 2. Windows operating system.
 
 ## Submitter

--- a/docs/user_guide/setup-submitter.md
+++ b/docs/user_guide/setup-submitter.md
@@ -18,7 +18,7 @@ Select the appropriate branch for your deployment:
 If you’re setting up on a brand new Windows EC2 Instance as your submitter, a g5.2xlarge instance with 200 GB of storage will likely be reasonable minimum:
 
 1. Launch EC2 instance with a valid Instance Profile. This is required to download NVIDIA GRID drivers as instructed below.
-1. Download the Epic Installer and install a supported version of Unreal (5.4 - 5.7).
+1. Download the Epic Installer and install a supported version of Unreal Engine (5.4 through 5.8).
     - UE 5.5 has a known crash bug when running with the DirectX 11 plugin, see UI issue #UE-276282. If you need DirectX support on UE 5.5, use DirectX 12+.
 1. NVIDIA GRID drivers - Follow Windows instructions - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html#nvidia-GRID-driver
 

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -48,8 +48,8 @@ def find_unreal_engine(folder: str, version: Optional[str] = None) -> str:
     if version:
         check_version = version
     else:
-        # Default to 5.7 if no other versions are found
-        check_version = "5.7"
+        # Default to 5.8 if no other versions are found
+        check_version = "5.8"
         for subfolder in os.listdir(folder):
             if subfolder.startswith("UE_"):
                 version = subfolder.split("_")[1]

--- a/skills/ue-dev-setup/SKILL.md
+++ b/skills/ue-dev-setup/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when:
 
 ## Core Concepts
 
-**Platform:** Windows only. UE 5.4–5.7, Python 3.9+.
+**Platform:** Windows only. UE 5.4–5.8, Python 3.9+.
 
 **Build system:** Hatch (Python), Unreal Build Tool (C++)
 

--- a/src/unreal_plugin/Content/Python/openjd_templates/dynamic_chunking/dynamic_chunking_render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/dynamic_chunking/dynamic_chunking_render_job.yml
@@ -55,7 +55,7 @@ parameterDefinitions:
   # channel; a pre-release adaptor would silently render the full sequence
   # per chunk. Do not use this template against a fleet pinned to an older
   # 0.7.x adaptor.
-  default: unrealengine=5.7 unrealengine-openjd=0.7.*
+  default: unrealengine=5.8 unrealengine-openjd=0.7.*
   userInterface: 
    control: LINE_EDIT
    label: Conda Packages

--- a/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/p4/p4_render_job.yml
@@ -32,7 +32,7 @@ parameterDefinitions:
   default: 0
 - name: CondaPackages
   type: STRING
-  default: unrealengine=5.7 unrealengine-openjd=0.7.*
+  default: unrealengine=5.8 unrealengine-openjd=0.7.*
   userInterface: 
    control: LINE_EDIT
 - name: CondaChannels

--- a/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/render_job.yml
@@ -30,7 +30,7 @@ parameterDefinitions:
   default: 0
 - name: CondaPackages
   type: STRING
-  default: unrealengine=5.7 unrealengine-openjd=0.7.*
+  default: unrealengine=5.8 unrealengine-openjd=0.7.*
   userInterface: 
    control: LINE_EDIT
 - name: CondaChannels


### PR DESCRIPTION
feat: Add Unreal Engine 5.8 support

### What was the problem/requirement? (What/Why)

Add Unreal Engine 5.8 support while retaining support for Unreal Engine 5.4 through 5.7.

The integration’s documentation, default build version, development setup guidance, and OpenJD render job templates still referenced Unreal Engine 5.7 as the latest supported version.

### What was the solution? (How)

- Extended the documented support range through Unreal Engine 5.8.
- Changed the plugin build helper’s default Unreal Engine version from 5.7 to 5.8.
- Updated the standard, Perforce, and dynamic-chunking OpenJD templates to use `unrealengine=5.8` by default.
- Updated the Unreal Engine development setup skill to identify UE 5.8 as supported.

The integration and end-to-end CI matrices remain on UE 5.7, and no CodeBuild runner configuration was changed.

### What is the impact of this change?

New render job submissions use the Unreal Engine 5.8 Conda package by default. Developers who do not specify an Unreal Engine version when running the build helper are directed to a UE 5.8 installation.

Earlier supported Unreal Engine versions remain available when explicitly selected.

### How was this change tested?

- `hatch run test`
  - 681 passed
  - 2 skipped
  - 72.33% coverage
- `hatch run lint`
  - Ruff passed
  - Black passed
  - mypy passed
- `hatch build`
  - Source distribution and wheel built successfully
- Validated all three modified OpenJD template fragments with `openjd-cli==0.7.5` after composing each fragment with a minimal validation-only `steps` section.
- Ran the development skill validator successfully.

### Have you run a render job successfully with these changes?

No. Unreal Engine C++/Automation and render-job validation require a Windows environment with UE 5.8 installed and were not available in the Linux development environment.

### Was this change documented?

Yes. The supported-version range was updated in:

- `README.md`
- `docs/user_guide/setup-submitter.md`
- `skills/ue-dev-setup/SKILL.md`

The OpenJD defaults were updated in the standard, Perforce, and dynamic-chunking render job templates.

### Is this a breaking change?

No. Existing supported Unreal Engine versions can still be selected explicitly. This change updates the default version for new builds and render job submissions to UE 5.8 without changing the adaptor’s public init-data or run-data contracts.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*