### PR TITLE
test: fetch dynamic chunk action details

### DIFF
--- a/test/end_to_end/test_dynamic_chunking_job.py
+++ b/test/end_to_end/test_dynamic_chunking_job.py
@@ -250,23 +250,35 @@ def test_dynamic_chunking_render_job_succeeds(
                 sessionId=session["sessionId"],
             ).get("sessionActions", [])
             task_run_actions.extend(a for a in actions if a.get("definition", {}).get("taskRun"))
-        for action in task_run_actions:
+        assert len(task_run_actions) == expected_chunk_count, (
+            f"Expected {expected_chunk_count} chunk dispatches (taskRun session actions) "
+            f"for Frames=1-10 with ChunkSize=5, got {len(task_run_actions)}"
+        )
+
+        # ListSessionActions returns summary definitions that omit taskRun parameters.
+        # Fetch each action's details before validating the dispatched chunk windows.
+        task_run_action_details = [
+            deadline_client.get_session_action(
+                farmId=farm_id,
+                queueId=queue_id,
+                jobId=job_id,
+                sessionActionId=action["sessionActionId"],
+            )
+            for action in task_run_actions
+        ]
+        for action in task_run_action_details:
             logger.info(
                 "Chunk taskRun action %s parameters: %s",
                 action["sessionActionId"],
                 action["definition"]["taskRun"].get("parameters"),
             )
-        assert len(task_run_actions) == expected_chunk_count, (
-            f"Expected {expected_chunk_count} chunk dispatches (taskRun session actions) "
-            f"for Frames=1-10 with ChunkSize=5, got {len(task_run_actions)}"
-        )
 
         actual_chunk_windows = {
             action["definition"]["taskRun"]
             .get("parameters", {})
             .get("DynamicChunking", {})
             .get("chunkInt")
-            for action in task_run_actions
+            for action in task_run_action_details
         }
         expected_chunk_windows = {"1-5", "6-10"}
         assert actual_chunk_windows == expected_chunk_windows, (


### PR DESCRIPTION
test: fetch dynamic chunk action details

### What was the problem/requirement? (What/Why)

The dynamic-chunking E2E test failed while validating the dispatched chunk windows. It expected `{"1-5", "6-10"}` but received `{None}`, even though the render job succeeded and all 10 frame tasks completed successfully.

The test attempted to read `DynamicChunking.chunkInt` directly from the results of `ListSessionActions`. That API returns summary action definitions and omits `taskRun.parameters`. The complete parameters are available from `GetSessionAction`.

### What was the solution? (How)

After identifying the task-run actions with `ListSessionActions`, the test now fetches each action's complete definition using `GetSessionAction`.

The test still verifies both of its original invariants:

- Exactly two task-run session actions were dispatched.
- The exact dispatched chunk windows are `1-5` and `6-10`.

### What is the impact of this change?

This is a test-only change with no impact on submitter, adaptor, or rendering behavior.

The E2E test now retrieves session-action data from the API that provides the complete task-run parameters. It makes one additional `GetSessionAction` request for each dispatched chunk; this test creates two chunks.

### How was this change tested?

Yes, the unit tests were run.

- `hatch run test` — 681 passed, 2 skipped
- `hatch run lint` — Ruff, Black, and mypy passed
- `hatch build` — source and wheel distributions built successfully
- `hatch run e2e --collect-only test/end_to_end/test_dynamic_chunking_job.py` — the modified E2E test was collected successfully
- `git diff --check` — passed

Read-only API calls against a successful dynamic-chunking job also confirmed that:

- `ListSessionActions` omits `taskRun.parameters`.
- `GetSessionAction` returns `DynamicChunking.chunkInt` values `1-5` and `6-10`.

### Have you run a render job successfully with these changes?

Yes. I also ran e2e tests and they are all passing 

### Was this change documented?

The test includes an inline comment explaining why `GetSessionAction` is required after listing the action summaries.

No user-facing documentation, public interfaces, schemas, or Python function docstrings are affected.

### Is this a breaking change?

No. This only changes how an E2E test retrieves session-action details and does not modify any public contract or application behavior.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*