### PR TITLE
fix: Restore Unreal Engine 5.7 build default

### DIFF
--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -48,8 +48,8 @@ def find_unreal_engine(folder: str, version: Optional[str] = None) -> str:
     if version:
         check_version = version
     else:
-        # Default to 5.8 if no other versions are found
-        check_version = "5.8"
+        # Default to 5.7 if no other versions are found
+        check_version = "5.7"
         for subfolder in os.listdir(folder):
             if subfolder.startswith("UE_"):
                 version = subfolder.split("_")[1]


### PR DESCRIPTION
fix: Restore Unreal Engine 5.7 build default

### What was the problem/requirement? (What/Why)

Bumping to 5.8 is causing issue in tests. Reverting this to 5.7 while we fixing the root cause of setting up the test env

### What was the solution? (How)

Temp solution to revert to run test in 5.7 while we get the test env set up to run all supported version

### What is the impact of this change?

Test will pass while we working the over all solution for setting up test env

### How was this change tested?

hatch run test: 681 passed, 2 skipped; 72.33% coverage
hatch run lint: Ruff, Black, and mypy passed
hatch build: sdist and wheel built successfully

- Have you run the unit tests?
Yes

### Have you run a render job successfully with these changes?
No. This is a revert of the installation script, not affecting submitter or adaptor

### Was this change documented?
No, and it is okay

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*