### PR TITLE
feat: add Unreal profiling output support

### DIFF
--- a/docs/source/docs_usage/use_cases/submit_job.rst
+++ b/docs/source/docs_usage/use_cases/submit_job.rst
@@ -31,4 +31,11 @@ To submit DeadlineCloud Job from Movie Render Queue, follow next steps:
       .. image:: ../../images/submit_job_5.png
 
 #. Update parameters in Preset Overrides if needed
+
+   a. Use **Profiling Settings** to enable Unreal Insights CPU, GPU, or Memory tracing.
+   #. Enable **CSV Profiler** to capture CSV output and adjust **CSV Capture Frames** if needed.
+   #. Enable **MemReport** to request ``MemReport -full`` after render completion.
+   #. The submitter automatically adds the required Unreal launch arguments and profiling output directories for these options.
+   #. Remote profiling artifacts are uploaded with the job outputs through Job Attachments. Unreal Insights traces are written under ``Saved/Profiling``, CSV output under ``Saved/Profiling/CSV``, and MemReport output under ``Saved/Profiling/MemReports`` on the worker.
+
 #. Click “Render (Remote)” button

--- a/docs/source/docs_usage/use_cases/submit_job.rst
+++ b/docs/source/docs_usage/use_cases/submit_job.rst
@@ -37,5 +37,6 @@ To submit DeadlineCloud Job from Movie Render Queue, follow next steps:
    #. Enable **MemReport** to request ``MemReport -full`` after render completion.
    #. The submitter automatically adds the required Unreal launch arguments and profiling output directories for these options.
    #. Remote profiling artifacts are uploaded with the job outputs through Job Attachments. Unreal Insights traces are written under ``Saved/Profiling``, CSV output under ``Saved/Profiling/CSV``, and MemReport output under ``Saved/Profiling/MemReports`` on the worker.
+   #. Memory Insights instrumentation remains active for the Unreal process, while each task trace contains only events recorded during that task.
 
 #. Click “Render (Remote)” button

--- a/docs/user_guide/setup-submitter.md
+++ b/docs/user_guide/setup-submitter.md
@@ -198,12 +198,28 @@ This example will use the Meerkat Demo from the Unreal Marketplace:
 			1. Expand "Job Attachments":
 				1. Under "Input Files", select "Show Auto-Detected" 
 				1. Verify that the list of Auto Detected Files populates correctly
+			1. Expand "Profiling Settings" if you want Unreal profiling artifacts:
+				1. Enable "Insights CPU", "Insights GPU", or "Insights Memory" to capture Unreal Insights traces
+				1. Enable "CSV Profiler" to capture CSV profiler output
+				1. Adjust "CSV Capture Frames" if you need more or fewer than the default `300` frames
+				1. Enable "MemReport" to request `MemReport -full` after render completion
 		1. Under "Job Template Overrides":
 			1. Update the Unreal Engine version in "CondaPackages" if you are using a different version than 5.6
 				1. Note: Unreal Engine version autodetection is coming in a future release
 		
 	1. Ready to Go! Hit "Render (Remote)". 
 1. You can go to Deadline Cloud Monitor and watch the progress of your job. 
+
+### Profiling output locations
+
+If you enable profiling settings on a remote render:
+
+- Unreal Insights traces are written under `Saved/Profiling`
+- CSV profiler output is written under `Saved/Profiling/CSV`
+- MemReport output is written under `Saved/Profiling/MemReports`
+- these artifacts are uploaded with the job outputs through Job Attachments
+
+When the remote job finishes, download the profiling artifacts from Deadline Cloud Monitor or your configured output storage. They are not copied back into your local Unreal project directory automatically.
 
 
 # Update Notifications

--- a/docs/user_guide/setup-submitter.md
+++ b/docs/user_guide/setup-submitter.md
@@ -219,6 +219,8 @@ If you enable profiling settings on a remote render:
 - MemReport output is written under `Saved/Profiling/MemReports`
 - these artifacts are uploaded with the job outputs through Job Attachments
 
+Memory Insights instrumentation remains active for the Unreal process, while each task trace contains only events recorded during that task.
+
 When the remote job finishes, download the profiling artifacts from Deadline Cloud Monitor or your configured output storage. They are not copied back into your local Unreal project directory automatically.
 
 

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
@@ -8,6 +8,7 @@ import sys
 import time
 import logging
 import threading
+import uuid
 import jsonschema
 from typing import Callable, Optional
 
@@ -67,6 +68,9 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
         super().__init__(*args, **kwargs)
 
         self.data_validation = DataValidation()
+        self._csv_capture_frames: Optional[int] = None
+        self._memreport_enabled: bool = False
+        self._insights_categories: Optional[str] = None
 
     @property
     def integration_data_interface_version(self) -> SemanticVersion:
@@ -342,7 +346,6 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
 
         # Remove the -execcmds argument from the extra_cmd_args
         extra_cmd_str = re.sub(r'(-execcmds=["\'][^"\']*["\'])', "", extra_cmd_str)
-
         client_path = self.unreal_client_path.replace("\\", "/")
         log_args = ["-log", "-unattended", "-stdout", "-allowstdoutlogverbosity", "-nozen"]
 
@@ -351,10 +354,26 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
             log_args += ["-NoLoadingScreen", "-NoScreenMessages", "-RenderOffscreen", "-nozen"]
 
         extra_cmd_args = extra_cmd_str.split(" ")
+        extra_cmd_args, self._csv_capture_frames = self._extract_csv_capture_frames_arg(
+            extra_cmd_args
+        )
+        extra_cmd_args, self._memreport_enabled = self._extract_memreport_arg(extra_cmd_args)
+        extra_cmd_args, self._insights_categories = self._extract_insights_arg(extra_cmd_args)
+        if self._insights_categories and any(
+            re.match(r"^-trace(?:=|$)", arg, flags=re.IGNORECASE) for arg in extra_cmd_args
+        ):
+            logger.warning(
+                "Raw -trace arguments take precedence over task-scoped Deadline Cloud "
+                "Insights profiling"
+            )
+            self._insights_categories = None
+        trace_file_arg = self._get_tracefile_arg(unreal_project_path, " ".join(extra_cmd_args))
 
         args = [unreal_exe, unreal_project_path]
         args.extend(log_args)
         args.extend(extra_cmd_args)
+        if trace_file_arg:
+            args.append(trace_file_arg)
         args = [arg for arg in args if arg]  # Remove empty strings
         args = list(dict.fromkeys(args))  # Remove duplicates
 
@@ -382,6 +401,148 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
             stdout_handler=regexhandler,
             stderr_handler=regexhandler,
         )
+
+    @staticmethod
+    def _extract_csv_capture_frames_arg(
+        extra_cmd_args: list[str],
+    ) -> tuple[list[str], Optional[int]]:
+        """
+        Remove launch-time CSV frame capture so render steps can start CSV only
+        after MRQ reports that rendering has actually begun.
+        """
+
+        filtered_args: list[str] = []
+        csv_capture_frames: Optional[int] = None
+        index = 0
+
+        while index < len(extra_cmd_args):
+            token = extra_cmd_args[index]
+            match = re.match(r"^-csvCaptureFrames(?:=(.+))?$", token, flags=re.IGNORECASE)
+            if not match:
+                filtered_args.append(token)
+                index += 1
+                continue
+
+            raw_value = match.group(1)
+            if raw_value is None:
+                next_index = index + 1
+                if next_index < len(extra_cmd_args) and not str(
+                    extra_cmd_args[next_index]
+                ).startswith("-"):
+                    raw_value = extra_cmd_args[next_index]
+                    index = next_index
+
+            if raw_value is None or str(raw_value).startswith("-"):
+                logger.warning("Ignoring -csvCaptureFrames without a numeric value")
+                index += 1
+                continue
+
+            try:
+                csv_capture_frames = max(1, int(str(raw_value).strip()))
+                logger.info(
+                    "Deferring CSV capture until render begins: %s frame(s)",
+                    csv_capture_frames,
+                )
+            except ValueError:
+                logger.warning("Ignoring invalid -csvCaptureFrames value: %s", raw_value)
+
+            index += 1
+
+        return filtered_args, csv_capture_frames
+
+    @staticmethod
+    def _extract_memreport_arg(extra_cmd_args: list[str]) -> tuple[list[str], bool]:
+        """
+        Remove the MemReport transport flag from launch args so the render step
+        can request MemReport -full after MRQ has completed.
+        """
+
+        filtered_args: list[str] = []
+        memreport_enabled = False
+
+        for token in extra_cmd_args:
+            if re.match(r"^-MemReport(?:=.*)?$", token, flags=re.IGNORECASE):
+                if not memreport_enabled:
+                    logger.info("Deferring MemReport generation until render completion")
+                memreport_enabled = True
+                continue
+
+            filtered_args.append(token)
+
+        return filtered_args, memreport_enabled
+
+    @staticmethod
+    def _extract_insights_arg(extra_cmd_args: list[str]) -> tuple[list[str], Optional[str]]:
+        filtered_args: list[str] = []
+        insights_categories: Optional[str] = None
+
+        for token in extra_cmd_args:
+            match = re.match(r"^-DeadlineCloudInsights=(.+)$", token, flags=re.IGNORECASE)
+            if not match:
+                filtered_args.append(token)
+                continue
+
+            raw_value = match.group(1).strip().strip("\"'")
+            categories = [category.strip() for category in raw_value.split(",") if category.strip()]
+            if categories and all(
+                re.fullmatch(r"[A-Za-z0-9_.-]+", category) for category in categories
+            ):
+                insights_categories = ",".join(dict.fromkeys(categories))
+                logger.info(
+                    "Deferring Unreal Insights capture until each render task: %s",
+                    insights_categories,
+                )
+            else:
+                logger.warning("Ignoring invalid -DeadlineCloudInsights value: %s", raw_value)
+
+        return filtered_args, insights_categories
+
+    @staticmethod
+    def _get_tracefile_arg(unreal_project_path: str, extra_cmd_str: str) -> Optional[str]:
+        """
+        If tracing is enabled without an explicit tracefile, write traces under the
+        runtime project's Saved/Profiling directory so artifacts are produced on the worker.
+        """
+
+        if not unreal_project_path:
+            return None
+
+        if not re.search(r"(^|\s)-trace=", extra_cmd_str, flags=re.IGNORECASE):
+            return None
+
+        if re.search(r"(^|\s)-tracefile=", extra_cmd_str, flags=re.IGNORECASE):
+            return None
+
+        project_dir = os.path.dirname(unreal_project_path).replace("\\", "/").rstrip("/")
+        trace_dir = f"{project_dir}/Saved/Profiling/DeadlineCloud"
+        try:
+            os.makedirs(trace_dir, exist_ok=True)
+        except OSError as exc:
+            logger.warning(
+                "Unable to create Unreal Insights trace directory %s: %s", trace_dir, exc
+            )
+            return None
+        trace_name = time.strftime("deadline-cloud-insights-%Y%m%d-%H%M%S.utrace")
+        return f"-tracefile={trace_dir}/{trace_name}"
+
+    @staticmethod
+    def _get_task_trace_file(unreal_project_path: str, run_data: dict) -> Optional[str]:
+        if not unreal_project_path:
+            return None
+
+        project_dir = os.path.dirname(unreal_project_path).replace("\\", "/").rstrip("/")
+        trace_dir = f"{project_dir}/Saved/Profiling/DeadlineCloud"
+        try:
+            os.makedirs(trace_dir, exist_ok=True)
+        except OSError as exc:
+            logger.warning(
+                "Unable to create Unreal Insights trace directory %s: %s", trace_dir, exc
+            )
+            return None
+
+        task_label = run_data.get("task_index", run_data.get("chunk_id", "task"))
+        trace_name = f"deadline-cloud-insights-task-{task_label}-{uuid.uuid4().hex}.utrace"
+        return f"{trace_dir}/{trace_name}"
 
     def _populate_client_loaded_action(self) -> None:
         """
@@ -481,6 +642,21 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
             self.data_validation.validate_run_data(run_data)
         except (jsonschema.exceptions.ValidationError, jsonschema.exceptions.SchemaError) as e:
             self._record_error_and_raise(exc=e, exception_scope="on_run")
+
+        if run_data.get("handler", "base") == "render":
+            if self._csv_capture_frames or self._memreport_enabled or self._insights_categories:
+                run_data = dict(run_data)
+                if self._csv_capture_frames:
+                    run_data["csv_capture_frames"] = self._csv_capture_frames
+                if self._memreport_enabled:
+                    run_data["memreport"] = True
+                if self._insights_categories:
+                    trace_file = self._get_task_trace_file(
+                        os.path.expandvars(self.init_data.get("project_path", "")), run_data
+                    )
+                    if trace_file:
+                        run_data["insights_categories"] = self._insights_categories
+                        run_data["insights_trace_file"] = trace_file
 
         # Set up the step handler
         self._action_queue.enqueue_action(

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
@@ -368,12 +368,17 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
             )
             self._insights_categories = None
         trace_file_arg = self._get_tracefile_arg(unreal_project_path, " ".join(extra_cmd_args))
+        memory_insights_enabled = self._insights_categories and any(
+            category.lower() == "memory" for category in self._insights_categories.split(",")
+        )
 
         args = [unreal_exe, unreal_project_path]
         args.extend(log_args)
         args.extend(extra_cmd_args)
         if trace_file_arg:
             args.append(trace_file_arg)
+        if memory_insights_enabled:
+            args.append("-trace=memory")
         args = [arg for arg in args if arg]  # Remove empty strings
         args = list(dict.fromkeys(args))  # Remove duplicates
 

--- a/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/run_data.schema.json
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/schemas/run_data.schema.json
@@ -19,6 +19,22 @@
             "description": "Contiguous frame range chunk '<start>-<end>' (inclusive) computed by the OpenJD TASK_CHUNKING extension. Mutually exclusive with frames_per_task/shots_per_task."
         },
         "output_path": { "type":  "string" },
+        "csv_capture_frames": {
+            "type": "integer",
+            "description": "Number of render frames to capture with the CSV profiler."
+        },
+        "memreport": {
+            "type": "boolean",
+            "description": "Generate a full MemReport after this render task."
+        },
+        "insights_categories": {
+            "type": "string",
+            "description": "Comma-separated Unreal Insights channels enabled for this render task."
+        },
+        "insights_trace_file": {
+            "type": "string",
+            "description": "Worker-local .utrace path for this render task."
+        },
         "submit_mode": {
             "type": "string",
             "enum": ["", "submit", "shelve"],

--- a/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
+++ b/src/deadline/unreal_adaptor/UnrealClient/step_handlers/unreal_render_step_handler.py
@@ -3,6 +3,8 @@
 import os
 import re
 import shutil
+import tempfile
+import time
 from pathlib import Path
 
 try:
@@ -21,12 +23,275 @@ from deadline.unreal_logger import get_logger
 logger = get_logger()
 
 
+def _get_command_world():
+    """Resolve the best available world for console commands during MRQ/PIE."""
+
+    if unreal is None:
+        return None
+
+    editor_level_library = getattr(unreal, "EditorLevelLibrary", None)
+    if editor_level_library is not None:
+        get_pie_worlds = getattr(editor_level_library, "get_pie_worlds", None)
+        if callable(get_pie_worlds):
+            try:
+                pie_worlds = get_pie_worlds(False)
+            except TypeError:
+                pie_worlds = get_pie_worlds()
+            if pie_worlds:
+                return pie_worlds[0]
+
+        get_game_world = getattr(editor_level_library, "get_game_world", None)
+        if callable(get_game_world):
+            game_world = get_game_world()
+            if game_world is not None:
+                return game_world
+
+    unreal_editor_subsystem_cls = getattr(unreal, "UnrealEditorSubsystem", None)
+    get_editor_subsystem = getattr(unreal, "get_editor_subsystem", None)
+    if unreal_editor_subsystem_cls is not None and callable(get_editor_subsystem):
+        subsystem = get_editor_subsystem(unreal_editor_subsystem_cls)
+        if subsystem is not None:
+            get_game_world = getattr(subsystem, "get_game_world", None)
+            if callable(get_game_world):
+                game_world = get_game_world()
+                if game_world is not None:
+                    return game_world
+
+            get_editor_world = getattr(subsystem, "get_editor_world", None)
+            if callable(get_editor_world):
+                editor_world = get_editor_world()
+                if editor_world is not None:
+                    return editor_world
+
+    if editor_level_library is not None:
+        get_editor_world = getattr(editor_level_library, "get_editor_world", None)
+        if callable(get_editor_world):
+            return get_editor_world()
+
+    return None
+
+
+def _execute_editor_console_command(command: str) -> bool:
+    """Execute a console command against the active PIE/game world."""
+
+    if unreal is None:
+        return False
+
+    try:
+        command_world = _get_command_world()
+    except Exception as exc:
+        logger.warning(
+            "Render Executor: Unable to resolve a world for console command '%s': %s",
+            command,
+            exc,
+        )
+        return False
+
+    if command_world is None:
+        logger.warning(
+            "Render Executor: Unable to execute console command '%s' because no active "
+            "editor or PIE world is available",
+            command,
+        )
+        return False
+
+    try:
+        unreal.SystemLibrary.execute_console_command(command_world, command)
+    except Exception as exc:
+        logger.warning(
+            "Render Executor: Console command '%s' failed: %s",
+            command,
+            exc,
+        )
+        return False
+
+    logger.info(f"Render Executor: Executed console command: {command}")
+    return True
+
+
+def _initialize_executor_profiling_state(executor) -> None:
+    executor.csvCaptureFrames = 0
+    executor.csvFramesObserved = 0
+    executor.csvStartAttempted = False
+    executor.csvStarted = False
+    executor.csvFinished = False
+    executor.renderStarted = False
+    executor.renderCompletionHandled = False
+    executor.memreportEnabled = False
+    executor.memreportGenerated = False
+    executor.insightsCategories = ""
+    executor.insightsTraceFile = ""
+    executor.insightsWorkingTraceFile = ""
+    executor.insightsStarted = False
+    executor.insightsFinished = False
+
+
+def _start_executor_csv_capture(executor) -> None:
+    if executor.csvCaptureFrames <= 0 or executor.csvStartAttempted or executor.csvFinished:
+        return
+
+    executor.csvStartAttempted = True
+    if not _execute_editor_console_command("CsvProfile Start"):
+        executor.csvFinished = True
+        return
+
+    executor.csvStarted = True
+    executor.csvFramesObserved = 0
+    logger.info(
+        f"Render Executor: Started CSV capture for {executor.csvCaptureFrames} render frame(s)"
+    )
+
+
+def _stop_executor_csv_capture(executor, reason: str) -> None:
+    if executor.csvFinished:
+        return
+
+    if executor.csvStarted:
+        if _execute_editor_console_command("CsvProfile Stop"):
+            logger.info(f"Render Executor: Stopped CSV capture ({reason})")
+
+    executor.csvStarted = False
+    executor.csvFinished = True
+
+
+def _observe_executor_csv_frame(executor) -> None:
+    _start_executor_csv_capture(executor)
+    if not executor.csvStarted or executor.csvFinished:
+        return
+
+    executor.csvFramesObserved += 1
+    if executor.csvFramesObserved >= executor.csvCaptureFrames:
+        _stop_executor_csv_capture(executor, "captured requested frame count")
+
+
+def _generate_executor_memreport(executor) -> None:
+    if not executor.memreportEnabled or executor.memreportGenerated:
+        return
+
+    executor.memreportGenerated = True
+    if _execute_editor_console_command("MemReport -full"):
+        logger.info("Render Executor: Requested MemReport -full")
+    else:
+        logger.warning("Render Executor: Unable to request MemReport -full")
+
+
+def _start_executor_insights_trace(executor) -> None:
+    if (
+        not executor.insightsCategories
+        or not executor.insightsTraceFile
+        or executor.insightsStarted
+        or executor.insightsFinished
+    ):
+        return
+
+    trace_directory = os.path.dirname(executor.insightsTraceFile)
+    if trace_directory:
+        try:
+            os.makedirs(trace_directory, exist_ok=True)
+        except OSError as exc:
+            logger.warning(
+                "Render Executor: Unable to create Insights trace directory '%s': %s",
+                trace_directory,
+                exc,
+            )
+            executor.insightsFinished = True
+            return
+
+    trace_filename = os.path.basename(executor.insightsTraceFile)
+    working_trace_file = os.path.join(tempfile.gettempdir(), trace_filename)
+    command_trace_file = working_trace_file
+    if any(character.isspace() for character in command_trace_file):
+        command_trace_file = trace_filename
+        working_trace_file = unreal.Paths.convert_relative_path_to_full(trace_filename)
+
+    command_trace_file = command_trace_file.replace("\\", "/")
+    command = f"Trace.File {command_trace_file} {executor.insightsCategories}"
+    if not _execute_editor_console_command(command):
+        executor.insightsFinished = True
+        return
+
+    executor.insightsWorkingTraceFile = working_trace_file
+    executor.insightsStarted = True
+    logger.info(f"Render Executor: Started Insights trace: {executor.insightsTraceFile}")
+
+
+def _move_finalized_insights_trace(source: str, destination: str) -> bool:
+    last_error = None
+    for attempt in range(50):
+        try:
+            shutil.move(source, destination)
+            return True
+        except OSError as exc:
+            last_error = exc
+            if attempt < 49:
+                time.sleep(0.1)
+
+    logger.warning(
+        "Render Executor: Unable to move finalized Insights trace from '%s' to '%s': %s",
+        source,
+        destination,
+        last_error,
+    )
+    return False
+
+
+def _stop_executor_insights_trace(executor, reason: str) -> None:
+    if executor.insightsFinished:
+        return
+
+    if executor.insightsStarted:
+        if _execute_editor_console_command("Trace.Stop"):
+            if _move_finalized_insights_trace(
+                executor.insightsWorkingTraceFile, executor.insightsTraceFile
+            ):
+                logger.info(f"Render Executor: Stopped Insights trace ({reason})")
+
+    executor.insightsStarted = False
+    executor.insightsFinished = True
+
+
+def _handle_executor_render_completion(executor) -> None:
+    if executor.renderCompletionHandled:
+        return
+
+    executor.renderCompletionHandled = True
+    for operation, description in (
+        (lambda: _stop_executor_csv_capture(executor, "render completed"), "stop CSV capture"),
+        (lambda: _generate_executor_memreport(executor), "generate MemReport"),
+        (
+            lambda: _stop_executor_insights_trace(executor, "render completed"),
+            "stop Insights trace",
+        ),
+    ):
+        try:
+            operation()
+        except Exception:
+            logger.exception("Render Executor: Failed to %s", description)
+
+    # Completion must not depend on optional profiling operations succeeding.
+    logger.info("Render Executor: Rendering is complete")
+
+
 if unreal:
 
     @unreal.uclass()
     class RemoteRenderMoviePipelineEditorExecutor(unreal.MoviePipelinePIEExecutor):
         totalFrameRange = unreal.uproperty(int)  # Total frame range of the job's level sequence
         currentFrame = unreal.uproperty(int)  # Current frame handler that will be updating later
+        csvCaptureFrames = unreal.uproperty(int)
+        csvFramesObserved = unreal.uproperty(int)
+        csvStartAttempted = unreal.uproperty(bool)
+        csvStarted = unreal.uproperty(bool)
+        csvFinished = unreal.uproperty(bool)
+        renderStarted = unreal.uproperty(bool)
+        renderCompletionHandled = unreal.uproperty(bool)
+        memreportEnabled = unreal.uproperty(bool)
+        memreportGenerated = unreal.uproperty(bool)
+        insightsCategories = unreal.uproperty(str)
+        insightsTraceFile = unreal.uproperty(str)
+        insightsWorkingTraceFile = unreal.uproperty(str)
+        insightsStarted = unreal.uproperty(bool)
+        insightsFinished = unreal.uproperty(bool)
 
         def _post_init(self):
             """
@@ -35,6 +300,25 @@ if unreal:
             """
             self.totalFrameRange = 0
             self.currentFrame = 0
+            _initialize_executor_profiling_state(self)
+
+        def _start_csv_capture(self):
+            _start_executor_csv_capture(self)
+
+        def _stop_csv_capture(self, reason: str):
+            _stop_executor_csv_capture(self, reason)
+
+        def _generate_memreport(self):
+            _generate_executor_memreport(self)
+
+        def _start_insights_trace(self):
+            _start_executor_insights_trace(self)
+
+        def _stop_insights_trace(self, reason: str):
+            _stop_executor_insights_trace(self, reason)
+
+        def _handle_render_completion(self):
+            _handle_executor_render_completion(self)
 
         @unreal.ufunction(override=True)
         def execute(self, queue: unreal.MoviePipelineQueue):
@@ -124,6 +408,8 @@ if unreal:
             # Since PIEExecutor launching Play in Editor before mrq is rendering, we should ensure, that
             # executor actually rendering the sequence.
             if self.is_rendering():
+                self.renderStarted = True
+                _observe_executor_csv_frame(self)
                 self.currentFrame += 1
                 progress = self.currentFrame / self.totalFrameRange * 100
 
@@ -136,6 +422,77 @@ if unreal:
 class UnrealRenderStepHandler(BaseStepHandler):
     cached_frame_range_start = None
     cached_frame_range_end = None
+    active_executor = None
+    render_wait_started = False
+
+    def __init__(self):
+        super().__init__()
+
+    @staticmethod
+    def _get_csv_capture_frames(args: dict) -> int:
+        value = args.get("csv_capture_frames")
+        if value is None:
+            return 0
+
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            logger.warning("Ignoring invalid csv_capture_frames value: %s", value)
+            return 0
+
+    @staticmethod
+    def _stop_executor_csv_capture(executor, reason: str) -> None:
+        stop_csv_capture = getattr(executor, "_stop_csv_capture", None)
+        if callable(stop_csv_capture):
+            stop_csv_capture(reason)
+
+    @staticmethod
+    def _get_memreport_enabled(args: dict) -> bool:
+        value = args.get("memreport")
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value != 0
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "on"}:
+                return True
+            if normalized in {"", "0", "false", "no", "off"}:
+                return False
+
+        if value is not None:
+            logger.warning("Ignoring invalid memreport value: %s", value)
+        return False
+
+    @staticmethod
+    def _generate_executor_memreport(executor) -> None:
+        generate_memreport = getattr(executor, "_generate_memreport", None)
+        if callable(generate_memreport):
+            generate_memreport()
+
+    @staticmethod
+    def _start_executor_insights_trace(executor) -> None:
+        start_insights_trace = getattr(executor, "_start_insights_trace", None)
+        if callable(start_insights_trace):
+            start_insights_trace()
+
+    @staticmethod
+    def _stop_executor_insights_trace(executor, reason: str) -> None:
+        stop_insights_trace = getattr(executor, "_stop_insights_trace", None)
+        if callable(stop_insights_trace):
+            stop_insights_trace(reason)
+
+    @staticmethod
+    def _handle_executor_completion(executor) -> None:
+        handle_render_completion = getattr(executor, "_handle_render_completion", None)
+        if callable(handle_render_completion):
+            handle_render_completion()
+            return
+
+        UnrealRenderStepHandler._stop_executor_csv_capture(executor, "render completed")
+        UnrealRenderStepHandler._generate_executor_memreport(executor)
+        UnrealRenderStepHandler._stop_executor_insights_trace(executor, "render completed")
+        logger.info("Render Executor: Rendering is complete")
 
     @staticmethod
     def regex_pattern_progress() -> list[re.Pattern]:
@@ -155,10 +512,7 @@ class UnrealRenderStepHandler(BaseStepHandler):
         :return: A list of regular expression patterns
         :rtype: list[re.Pattern]
         """
-        return [
-            re.compile(".*Render Executor: Rendering is complete"),
-            re.compile(".* finished ([0-9]+) jobs in .*"),
-        ]
+        return [re.compile(".*Render Executor: Rendering is complete")]
 
     @staticmethod
     def regex_pattern_error() -> list[re.Pattern]:
@@ -180,6 +534,9 @@ class UnrealRenderStepHandler(BaseStepHandler):
         :param is_fatal: Whether the error is fatal or not
         :param error: The error message
         """
+        executor = executor or UnrealRenderStepHandler.active_executor
+        UnrealRenderStepHandler._stop_executor_csv_capture(executor, "render error")
+        UnrealRenderStepHandler._stop_executor_insights_trace(executor, "render error")
         logger.error(f"Render Executor: Error: {error}")
 
     @staticmethod
@@ -190,7 +547,8 @@ class UnrealRenderStepHandler(BaseStepHandler):
         :param pipeline_executor: The RemoteRenderMoviePipelineEditorExecutor instance
         :param success: Whether finished successfully or not
         """
-        logger.info("Render Executor: Rendering is complete")
+        executor = pipeline_executor or UnrealRenderStepHandler.active_executor
+        UnrealRenderStepHandler._handle_executor_completion(executor)
 
     @staticmethod
     def copy_pipeline_queue_from_manifest_file(
@@ -639,6 +997,23 @@ class UnrealRenderStepHandler(BaseStepHandler):
 
         # Initialize Render executor
         executor = RemoteRenderMoviePipelineEditorExecutor()
+        executor.csvCaptureFrames = self._get_csv_capture_frames(args)
+        if executor.csvCaptureFrames > 0:
+            logger.info(
+                "Render Executor: CSV capture will start when rendering begins for "
+                f"{executor.csvCaptureFrames} frame(s)"
+            )
+        executor.memreportEnabled = self._get_memreport_enabled(args)
+        if executor.memreportEnabled:
+            logger.info("Render Executor: MemReport -full will run after render completion")
+        executor.insightsCategories = str(args.get("insights_categories", ""))
+        executor.insightsTraceFile = str(args.get("insights_trace_file", ""))
+        if executor.insightsCategories and executor.insightsTraceFile:
+            logger.info(
+                f"Render Executor: Insights trace will capture this render task: "
+                f"{executor.insightsTraceFile}"
+            )
+            executor._start_insights_trace()
 
         # Add callbacks on complete and error actions to handle it and
         # provide output to the Deadline Adaptor
@@ -650,6 +1025,8 @@ class UnrealRenderStepHandler(BaseStepHandler):
         )
 
         # Render queue with the given executor
+        type(self).active_executor = executor
+        type(self).render_wait_started = False
         subsystem.render_queue_with_executor_instance(executor)
 
         return True
@@ -662,5 +1039,23 @@ class UnrealRenderStepHandler(BaseStepHandler):
         It is responsible for waiting result of the
         :meth:`deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler.UnrealRenderStepHandler.run_script()`.
         """
-        logger.info("Render wait start")
-        logger.info("Render wait finish")
+        handler_cls = type(self)
+
+        if not handler_cls.render_wait_started:
+            logger.info("Render wait start")
+            handler_cls.render_wait_started = True
+
+        executor = handler_cls.active_executor
+        if executor is None:
+            handler_cls.render_wait_started = False
+            logger.info("Render wait finish")
+            return
+
+        if getattr(executor, "renderCompletionHandled", False):
+            handler_cls.active_executor = None
+            handler_cls.render_wait_started = False
+            logger.info("Render wait finish")
+            return
+
+        # The finished delegate is authoritative. is_rendering() may briefly be false
+        # between queued jobs and before MRQ has flushed all render output.

--- a/src/deadline/unreal_cmd_utils/cmd_utils.py
+++ b/src/deadline/unreal_cmd_utils/cmd_utils.py
@@ -7,7 +7,7 @@ import shlex
 
 logger = get_logger()
 
-SPECIAL_KEYS = {"dpcvars", "execcmds"}
+SPECIAL_KEYS = {"dpcvars", "execcmds", "trace"}
 NEED_QUOTE_CHARS = set(" ,;")
 
 
@@ -74,6 +74,12 @@ def merge_cmd_args_with_priority(higher_priority_args: str, lower_priority_args:
             merged[norm] = (name, val)
         return ",".join(f"{name}={val}" for _, (name, val) in merged.items())
 
+    def _merge_trace(v1, v2):
+        merged: OrderedDict[str, str] = OrderedDict()
+        for category in _parse_list(v1) + _parse_list(v2):
+            merged.setdefault(category.lower(), category)
+        return ",".join(merged.values())
+
     def _quote_if_needed(val: str):
         if any(c in NEED_QUOTE_CHARS for c in val):
             escaped = val.replace('"', r"\"")
@@ -111,7 +117,12 @@ def merge_cmd_args_with_priority(higher_priority_args: str, lower_priority_args:
     for k, v in kv2.items():
         lk = k.lower()
         if lk in SPECIAL_KEYS and lk in out:
-            v = _merge_dpcvars(out[lk][1], v) if lk == "dpcvars" else _merge_execcmds(out[lk][1], v)
+            if lk == "dpcvars":
+                v = _merge_dpcvars(out[lk][1], v)
+            elif lk == "trace":
+                v = _merge_trace(out[lk][1], v)
+            else:
+                v = _merge_execcmds(out[lk][1], v)
         out[lk] = (k, v)
     key_vals = {orig: val for orig, val in out.values()}
 

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job.py
@@ -132,6 +132,127 @@ class UnrealOpenJobParameterDefinition:
         return asdict(self)
 
 
+@dataclass
+class ProfilingSettings:
+    insights_cpu: bool = False
+    insights_gpu: bool = False
+    insights_memory: bool = False
+    csv_profiler: bool = False
+    csv_capture_frames: int = 300
+    memreport: bool = False
+
+    @staticmethod
+    def _read_unreal_property(source: Any, *property_names: str):
+        getter = getattr(source, "get_editor_property", None)
+        for property_name in property_names:
+            if hasattr(source, property_name):
+                return getattr(source, property_name)
+            if getter:
+                try:
+                    return getter(property_name)
+                except Exception:
+                    continue
+        return None
+
+    @staticmethod
+    def _coerce_bool(value: Any, default: bool = False) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int) and not isinstance(value, bool):
+            return bool(value)
+        return default
+
+    @staticmethod
+    def _coerce_int(value: Any, default: int) -> int:
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+        return default
+
+    @classmethod
+    def from_u_deadline_cloud_profiling_settings(
+        cls, profiling_settings: Optional[unreal.DeadlineCloudProfilingSettingsStruct]
+    ) -> "ProfilingSettings":
+        if profiling_settings is None:
+            return cls()
+
+        return cls(
+            insights_cpu=cls._coerce_bool(
+                cls._read_unreal_property(
+                    profiling_settings, "insights_cpu", "b_insights_cpu", "bInsightsCpu"
+                )
+            ),
+            insights_gpu=cls._coerce_bool(
+                cls._read_unreal_property(
+                    profiling_settings, "insights_gpu", "b_insights_gpu", "bInsightsGpu"
+                )
+            ),
+            insights_memory=cls._coerce_bool(
+                cls._read_unreal_property(
+                    profiling_settings,
+                    "insights_memory",
+                    "b_insights_memory",
+                    "bInsightsMemory",
+                )
+            ),
+            csv_profiler=cls._coerce_bool(
+                cls._read_unreal_property(
+                    profiling_settings, "csv_profiler", "b_csv_profiler", "bCsvProfiler"
+                )
+            ),
+            csv_capture_frames=max(
+                1,
+                cls._coerce_int(
+                    cls._read_unreal_property(
+                        profiling_settings, "csv_capture_frames", "CsvCaptureFrames"
+                    ),
+                    300,
+                ),
+            ),
+            memreport=cls._coerce_bool(
+                cls._read_unreal_property(
+                    profiling_settings, "memreport", "mem_report", "bMemReport"
+                )
+            ),
+        )
+
+    def is_insights_enabled(self) -> bool:
+        return self.insights_cpu or self.insights_gpu or self.insights_memory
+
+    def build_cmd_args(self) -> str:
+        trace_categories: OrderedDict[str, str] = OrderedDict()
+        if self.insights_cpu:
+            for category in ("cpu", "frame", "bookmark", "loadtime"):
+                trace_categories.setdefault(category, category)
+        if self.insights_gpu:
+            trace_categories.setdefault("gpu", "gpu")
+        if self.insights_memory:
+            trace_categories.setdefault("memory", "memory")
+
+        cmd_args = []
+        if trace_categories:
+            cmd_args.append(f'-DeadlineCloudInsights={",".join(trace_categories.values())}')
+        if self.csv_profiler:
+            cmd_args.append("-csvGpuStats")
+            if self.csv_capture_frames > 0:
+                cmd_args.append(f"-csvCaptureFrames={self.csv_capture_frames}")
+        if self.memreport:
+            cmd_args.append("-MemReport")
+
+        return " ".join(cmd_args)
+
+    def get_output_directories(self, project_directory: str) -> list[str]:
+        profiling_root = f"{project_directory.rstrip('/')}/Saved/Profiling"
+        if self.is_insights_enabled():
+            return [profiling_root]
+
+        output_directories = []
+        if self.csv_profiler:
+            output_directories.append(f"{profiling_root}/CSV")
+        if self.memreport:
+            output_directories.append(f"{profiling_root}/MemReports")
+        return output_directories
+
+
 # Base Open Job implementation
 class UnrealOpenJob(UnrealOpenJobEntity):
     """
@@ -657,6 +778,7 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         environments: Optional[list[UnrealOpenJobEnvironment]] = None,
         extra_parameters: Optional[list[UnrealOpenJobParameterDefinition]] = None,
         job_shared_settings: Optional[JobSharedSettings] = None,
+        profiling_settings: Optional[ProfilingSettings] = None,
         asset_references: Optional[AssetReferences] = None,
         mrq_job: Optional[unreal.MoviePipelineExecutorJob] = None,
     ):
@@ -681,6 +803,9 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         :param job_shared_settings: JobSharedSettings instance
         :type job_shared_settings: JobSharedSettings
 
+        :param profiling_settings: ProfilingSettings instance
+        :type profiling_settings: ProfilingSettings
+
         :param asset_references: AssetReferences object
         :type asset_references: AssetReferences
 
@@ -696,6 +821,7 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             job_shared_settings,
             asset_references,
         )
+        self._profiling_settings = profiling_settings or ProfilingSettings()
 
         self._mrq_job = None
         if mrq_job:
@@ -719,6 +845,14 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             self._transfer_files_strategy = TransferProjectFilesStrategy.UGS
         elif p4_envs:
             self._transfer_files_strategy = TransferProjectFilesStrategy.P4
+
+    @property
+    def profiling_settings(self) -> ProfilingSettings:
+        return getattr(self, "_profiling_settings", ProfilingSettings())
+
+    @profiling_settings.setter
+    def profiling_settings(self, value: ProfilingSettings):
+        self._profiling_settings = value or ProfilingSettings()
 
     @property
     def mrq_job(self):
@@ -768,6 +902,13 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             self.job_shared_settings = JobSharedSettings.from_u_deadline_cloud_job_shared_settings(
                 self._mrq_job.preset_overrides.job_shared_settings
             )
+
+        if self._mrq_job is not None and self._mrq_job.preset_overrides is not None:
+            profiling_settings = getattr(self._mrq_job.preset_overrides, "profiling_settings", None)
+            if profiling_settings is not None:
+                self.profiling_settings = (
+                    ProfilingSettings.from_u_deadline_cloud_profiling_settings(profiling_settings)
+                )
 
         # Job name set order:
         #   0. Job preset override (high priority)
@@ -822,6 +963,7 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             environments.append(job_env)
 
         shared_settings = data_asset.job_preset_struct.job_shared_settings
+        profiling_settings = getattr(data_asset.job_preset_struct, "profiling_settings", None)
 
         result_job = cls(
             file_path=data_asset.path_to_template.file_path,
@@ -834,6 +976,9 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             ],
             job_shared_settings=JobSharedSettings.from_u_deadline_cloud_job_shared_settings(
                 shared_settings
+            ),
+            profiling_settings=ProfilingSettings.from_u_deadline_cloud_profiling_settings(
+                profiling_settings
             ),
         )
 
@@ -1330,8 +1475,11 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         if args_from_file:
             user_extra_cmd_args = merge_cmd_args_with_priority(user_extra_cmd_args, args_from_file)
         executor_cmd_args = self.get_executor_cmd_args()
+        profiling_cmd_args = self.get_profiling_cmd_args()
 
         merged_cmd_args = merge_cmd_args_with_priority(user_extra_cmd_args, executor_cmd_args)
+        if profiling_cmd_args:
+            merged_cmd_args = merge_cmd_args_with_priority(merged_cmd_args, profiling_cmd_args)
         merged_cmd_args = self.clear_cmd_args(merged_cmd_args)
 
         unfilled_parameter_values = RenderUnrealOpenJob.update_job_parameter_values(
@@ -1396,6 +1544,9 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             cmd_args.extend(common.get_mrq_job_cmd_args(self._mrq_job))
 
         return " ".join(a for a in cmd_args)
+
+    def get_profiling_cmd_args(self) -> str:
+        return self.profiling_settings.build_cmd_args()
 
     def get_user_extra_cmd_args(self) -> str:
         """
@@ -1603,6 +1754,9 @@ class RenderUnrealOpenJob(UnrealOpenJob):
 
         return output_directories
 
+    def _get_profiling_output_directories(self) -> list[str]:
+        return self.profiling_settings.get_output_directories(common.get_project_directory())
+
     def _get_mrq_job_output_directory(self) -> str:
         """
         Get the output directory path from  MRQ Job Configuration, resolve all possible tokens
@@ -1665,6 +1819,9 @@ class RenderUnrealOpenJob(UnrealOpenJob):
             # Render output path
             asset_references.output_directories.add(self._get_mrq_job_output_directory())
 
+        profiling_output_directories = set(self._get_profiling_output_directories())
+        asset_references.output_directories.update(profiling_output_directories)
+
         # When SubmitMode is set on a Perforce job template, render outputs are
         # delivered to Perforce and MUST NOT be re-uploaded to S3 as Job
         # Attachments. But we can't just drop the output paths: OpenJD derives
@@ -1677,8 +1834,11 @@ class RenderUnrealOpenJob(UnrealOpenJob):
         # Gate on the SubmitMode parameter existing + being non-empty so non-P4
         # templates (which don't declare SubmitMode) are unaffected.
         if self._submit_mode_active():
-            asset_references.referenced_paths.update(asset_references.output_directories)
-            asset_references.output_directories.clear()
+            render_output_directories = (
+                asset_references.output_directories - profiling_output_directories
+            )
+            asset_references.referenced_paths.update(render_output_directories)
+            asset_references.output_directories.difference_update(render_output_directories)
 
         return asset_references
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/MovieRenderPipeline/MoviePipelineDeadlineCloudExecutorJob.cpp
@@ -231,6 +231,12 @@ FDeadlineCloudJobPresetStruct UMoviePipelineDeadlineCloudExecutorJob::GetDeadlin
 		&PresetOverrides.JobAttachments.OutputDirectories,
 		&ReturnValue.JobAttachments.OutputDirectories
 	);
+
+	GetPresetStructWithOverrides(
+		FDeadlineCloudProfilingSettingsStruct::StaticStruct(),
+		&PresetOverrides.ProfilingSettings,
+		&ReturnValue.ProfilingSettings
+	);
 	return ReturnValue;
 }
 
@@ -440,6 +446,9 @@ void UMoviePipelineDeadlineCloudExecutorJob::ReloadDataFromJobPreset()
 	PresetOverrides.JobAttachments.OutputDirectories.Directories =
 		JobPreset->JobPresetStruct.JobAttachments.OutputDirectories.Directories;
 
+	PresetOverrides.ProfilingSettings =
+		JobPreset->JobPresetStruct.ProfilingSettings;
+
 	JobTemplateOverrides.Parameters = JobPreset->GetParametersDataToOverride();
 	JobTemplateOverrides.StepsOverrides = GetStepsToOverride(JobPreset);
 	JobTemplateOverrides.EnvironmentsOverrides = GetEnvironmentsToOverride(JobPreset);
@@ -635,6 +644,7 @@ void UMoviePipelineDeadlineCloudExecutorJob::CopyJobOverrides(UDeadlineCloudRend
 	Job->JobPresetStruct.JobAttachments.InputFiles = PresetOverrides.JobAttachments.InputFiles;
 	Job->JobPresetStruct.JobAttachments.InputDirectories = PresetOverrides.JobAttachments.InputDirectories;
 	Job->JobPresetStruct.JobAttachments.OutputDirectories = PresetOverrides.JobAttachments.OutputDirectories;
+	Job->JobPresetStruct.ProfilingSettings = PresetOverrides.ProfilingSettings;
 	Job->ParameterDefinition.Parameters = JobTemplateOverrides.Parameters;
 }
 

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/Tests/Integration/DeadlinePluginTest_CreateJobTest.cpp
@@ -547,10 +547,8 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMovieQueueCreateJobTest, "DeadlineCloud.Integr
     NewJob->SetSequence(Sequence);
     NewJob->JobName = NewJob->Sequence.GetAssetName();
 
-    // Optionally override the submitted job name via '-testparams=...;job_name=<name>'
-    // so each automation/E2E test can be identified by its Deadline Cloud job name.
-    // The preset override name has the highest priority in the Python submitter's
-    // job name resolution, so it wins over the job template's default name.
+    bool bEnableAllProfiling = false;
+    int32 CsvCaptureFrames = 10;
     FString TestParamsString;
     if (FParse::Value(FCommandLine::Get(), TEXT("testparams="), TestParamsString))
     {
@@ -565,7 +563,31 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMovieQueueCreateJobTest, "DeadlineCloud.Integr
                 NewJob->JobName = Value;
                 NewJob->PresetOverrides.JobSharedSettings.Name = Value;
             }
+            else if (Key == TEXT("profiling") && Value.Equals(TEXT("all"), ESearchCase::IgnoreCase))
+            {
+                bEnableAllProfiling = true;
+            }
+            else if (Key == TEXT("csv_capture_frames"))
+            {
+                const int32 ParsedCaptureFrames = FCString::Atoi(*Value);
+                if (ParsedCaptureFrames > 0)
+                {
+                    CsvCaptureFrames = ParsedCaptureFrames;
+                }
+            }
         }
+    }
+
+    if (bEnableAllProfiling)
+    {
+        FDeadlineCloudProfilingSettingsStruct& ProfilingSettings = NewJob->PresetOverrides.ProfilingSettings;
+        ProfilingSettings.bInsightsCpu = true;
+        ProfilingSettings.bInsightsGpu = true;
+        ProfilingSettings.bInsightsMemory = true;
+        ProfilingSettings.bCsvProfiler = true;
+        ProfilingSettings.CsvCaptureFrames = CsvCaptureFrames;
+        ProfilingSettings.bMemReport = true;
+        UE_LOG(LogCreateJobTest, Display, TEXT("Enabled all profiling settings with %d CSV capture frames"), CsvCaptureFrames);
     }
 
     UMoviePipelineExecutorJob* QueueJob = ActiveQueue->DuplicateJob(NewJob);

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Private/UnrealDeadlineCloudServiceModule.cpp
@@ -71,6 +71,10 @@ void FUnrealDeadlineCloudServiceModule::StartupModule()
 		FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FDeadlineCloudJobPresetDetailsCustomization::MakeInstance));
 
 	PropertyModule.RegisterCustomPropertyTypeLayout(
+		FDeadlineCloudProfilingSettingsStruct::StaticStruct()->GetFName(),
+		FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FDeadlineCloudJobPresetDetailsCustomization::MakeInstance));
+
+	PropertyModule.RegisterCustomPropertyTypeLayout(
 		FDeadlineCloudJobParametersArray::StaticStruct()->GetFName(),
 		FOnGetPropertyTypeCustomizationInstance::CreateStatic(&FDeadlineCloudJobParametersArrayCustomization::MakeInstance));
 	

--- a/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudJob.h
+++ b/src/unreal_plugin/Source/UnrealDeadlineCloudService/Public/DeadlineCloudJobSettings/DeadlineCloudJob.h
@@ -158,6 +158,39 @@ struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudAttachmentsStruct
 };
 
 /**
+ * Profiling settings container struct
+ */
+USTRUCT(BlueprintType)
+struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudProfilingSettingsStruct
+{
+	GENERATED_BODY()
+
+	/** Enable Unreal Insights CPU tracing */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Profiling Settings", meta = (DisplayPriority = 0))
+	bool bInsightsCpu = false;
+
+	/** Enable Unreal Insights GPU tracing */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Profiling Settings", meta = (DisplayPriority = 1))
+	bool bInsightsGpu = false;
+
+	/** Enable Unreal Insights Memory tracing */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Profiling Settings", meta = (DisplayPriority = 2))
+	bool bInsightsMemory = false;
+
+	/** Enable Unreal CSV profiler capture */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Profiling Settings", meta = (DisplayPriority = 3))
+	bool bCsvProfiler = false;
+
+	/** Number of frames to capture for CSV profiler */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Profiling Settings", meta = (ClampMin = 1, DisplayPriority = 4))
+	int32 CsvCaptureFrames = 300;
+
+	/** Generate a MemReport -full after render completion */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Profiling Settings", meta = (DisplayPriority = 5))
+	bool bMemReport = false;
+};
+
+/**
  * All Deadline Cloud job settings container struct
  */
 USTRUCT(BlueprintType)
@@ -172,6 +205,10 @@ struct UNREALDEADLINECLOUDSERVICE_API FDeadlineCloudJobPresetStruct
 	/** Job attachments */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Job Preset")
 	FDeadlineCloudAttachmentsStruct JobAttachments;
+
+	/** Profiling settings */
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Job Preset")
+	FDeadlineCloudProfilingSettingsStruct ProfilingSettings;
 
 };
 

--- a/test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py
@@ -506,6 +506,13 @@ class TestUnrealAdaptor_on_start:
     )
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.logger")
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
+    @pytest.mark.parametrize(
+        ("insights_categories", "expected_trace_args"),
+        [
+            ("cpu,frame", []),
+            ("cpu,frame,memory", ["-trace=memory"]),
+        ],
+    )
     def test__start_unreal_client_defers_feature_insights(
         self,
         mock_subprocess: Mock,
@@ -515,6 +522,8 @@ class TestUnrealAdaptor_on_start:
         mock_os_path_exists: Mock,
         mock_os_makedirs: Mock,
         init_data: dict,
+        insights_categories: str,
+        expected_trace_args: list[str],
     ):
         mock_unreal_client_path.side_effect = ["UnrealClient.py"]
         init_data["extra_cmd_args_file"] = "path/to/args/file.txt"
@@ -523,7 +532,7 @@ class TestUnrealAdaptor_on_start:
         with patch(
             "builtins.open",
             new_callable=mock_open,
-            read_data="-DeadlineCloudInsights=cpu,frame -stdout",
+            read_data=f"-DeadlineCloudInsights={insights_categories} -stdout",
         ):
             adaptor._start_unreal_client()
 
@@ -534,9 +543,11 @@ class TestUnrealAdaptor_on_start:
         )
         launch_args = ast.literal_eval(launch_ue_with_message)
 
-        assert not any(arg.lower().startswith("-trace") for arg in launch_args)
+        assert [arg for arg in launch_args if arg.lower().startswith("-trace")] == (
+            expected_trace_args
+        )
         assert not any(arg.lower().startswith("-deadlinecloudinsights") for arg in launch_args)
-        assert adaptor._insights_categories == "cpu,frame"
+        assert adaptor._insights_categories == insights_categories
         mock_os_makedirs.assert_not_called()
 
     @patch("os.path.exists", return_value=True)

--- a/test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py
@@ -49,6 +49,52 @@ def run_data() -> dict:
 
 
 class TestUnrealAdaptor_on_start:
+    def test_extract_csv_capture_frames_arg(self):
+        filtered_args, csv_capture_frames = UnrealAdaptor._extract_csv_capture_frames_arg(
+            ["-csvGpuStats", "-csvCaptureFrames=120", "-trace=cpu,frame"]
+        )
+
+        assert filtered_args == ["-csvGpuStats", "-trace=cpu,frame"]
+        assert csv_capture_frames == 120
+
+    def test_extract_csv_capture_frames_preserves_following_switch(self):
+        filtered_args, csv_capture_frames = UnrealAdaptor._extract_csv_capture_frames_arg(
+            ["-csvCaptureFrames", "-unattended", "-trace=cpu,frame"]
+        )
+
+        assert filtered_args == ["-unattended", "-trace=cpu,frame"]
+        assert csv_capture_frames is None
+
+    def test_extract_memreport_arg(self):
+        filtered_args, memreport_enabled = UnrealAdaptor._extract_memreport_arg(
+            ["-stdout", "-MemReport", "-trace=cpu,frame"]
+        )
+
+        assert filtered_args == ["-stdout", "-trace=cpu,frame"]
+        assert memreport_enabled is True
+
+    def test_extract_insights_arg(self):
+        filtered_args, insights_categories = UnrealAdaptor._extract_insights_arg(
+            [
+                "-stdout",
+                "-DeadlineCloudInsights=cpu,frame,bookmark",
+                "-trace=gpu",
+            ]
+        )
+
+        assert filtered_args == ["-stdout", "-trace=gpu"]
+        assert insights_categories == "cpu,frame,bookmark"
+
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.logger")
+    def test_extract_insights_arg_rejects_console_command_injection(self, mock_logger: Mock):
+        filtered_args, insights_categories = UnrealAdaptor._extract_insights_arg(
+            ["-DeadlineCloudInsights=cpu;quit"]
+        )
+
+        assert filtered_args == []
+        assert insights_categories is None
+        mock_logger.warning.assert_called_once()
+
     @patch(
         "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor.telemetry_client",
         new_callable=PropertyMock,
@@ -324,6 +370,250 @@ class TestUnrealAdaptor_on_start:
     )
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.logger")
     @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
+    def test__start_unreal_client_defers_csv_capture_frames(
+        self,
+        mock_subprocess: Mock,
+        mock_logger: Mock,
+        mock_get_regex_callbacks: Mock,
+        mock_unreal_client_path: Mock,
+        os_path_exists: Mock,
+        init_data: dict,
+    ):
+        init_data["extra_cmd_args_file"] = "path/to/args/file.txt"
+
+        unreal_client_path = "UnrealClient.py"
+        mock_unreal_client_path.side_effect = [unreal_client_path]
+        adaptor = UnrealAdaptor(init_data)
+
+        with patch(
+            "builtins.open",
+            new_callable=mock_open,
+            read_data="-csvGpuStats -csvCaptureFrames=120",
+        ):
+            adaptor._start_unreal_client()
+
+        launch_ue_with_message = (
+            mock_logger.mock_calls[-1].args[0].replace("Starting Unreal Engine with args: ", "")
+        )
+        launch_args = ast.literal_eval(launch_ue_with_message)
+
+        assert "-csvGpuStats" in launch_args
+        assert not any(arg.startswith("-csvCaptureFrames") for arg in launch_args)
+        assert adaptor._csv_capture_frames == 120
+
+    @patch("os.path.exists", return_value=True)
+    @patch("os.makedirs")
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor.unreal_client_path",
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_regex_callbacks",
+        return_value=[],
+    )
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.logger")
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
+    def test__start_unreal_client_defers_memreport(
+        self,
+        mock_subprocess: Mock,
+        mock_logger: Mock,
+        mock_get_regex_callbacks: Mock,
+        mock_unreal_client_path: Mock,
+        mock_makedirs: Mock,
+        os_path_exists: Mock,
+        init_data: dict,
+    ):
+        init_data["extra_cmd_args_file"] = "path/to/args/file.txt"
+
+        unreal_client_path = "UnrealClient.py"
+        mock_unreal_client_path.side_effect = [unreal_client_path]
+        adaptor = UnrealAdaptor(init_data)
+
+        with patch(
+            "builtins.open",
+            new_callable=mock_open,
+            read_data="-MemReport -trace=cpu,frame",
+        ):
+            adaptor._start_unreal_client()
+
+        launch_ue_with_message = (
+            mock_logger.mock_calls[-1].args[0].replace("Starting Unreal Engine with args: ", "")
+        )
+        launch_args = ast.literal_eval(launch_ue_with_message)
+
+        assert "-MemReport" not in launch_args
+        assert adaptor._memreport_enabled is True
+
+    @patch("time.strftime", return_value="deadline-cloud-insights-20260803-220000.utrace")
+    @patch("os.makedirs")
+    @patch("os.path.exists", return_value=True)
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor.unreal_client_path",
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_regex_callbacks",
+        return_value=[],
+    )
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.logger")
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
+    def test__start_unreal_client_adds_tracefile_for_trace_capture(
+        self,
+        mock_subprocess: Mock,
+        mock_logger: Mock,
+        mock_get_regex_callbacks: Mock,
+        mock_unreal_client_path: Mock,
+        mock_os_path_exists: Mock,
+        mock_os_makedirs: Mock,
+        mock_strftime: Mock,
+        init_data: dict,
+    ):
+        unreal_client_path = "UnrealClient.py"
+        mock_unreal_client_path.side_effect = [unreal_client_path]
+        init_data["extra_cmd_args_file"] = "path/to/args/file.txt"
+        adaptor = UnrealAdaptor(init_data)
+
+        with patch(
+            "builtins.open",
+            new_callable=mock_open,
+            read_data="-trace=cpu,frame,bookmark,loadtime",
+        ):
+            adaptor._start_unreal_client()
+
+        launch_ue_with_message = (
+            mock_logger.mock_calls[1].args[0].replace("Starting Unreal Engine with args: ", "")
+        )
+        launch_args = ast.literal_eval(launch_ue_with_message)
+
+        assert any(arg.startswith("-trace=") for arg in launch_args)
+        assert (
+            "-tracefile=C:/LocalProjects/AWS_RND/Saved/Profiling/DeadlineCloud/"
+            "deadline-cloud-insights-20260803-220000.utrace"
+        ) in launch_args
+        mock_os_makedirs.assert_called_once_with(
+            "C:/LocalProjects/AWS_RND/Saved/Profiling/DeadlineCloud", exist_ok=True
+        )
+
+    @patch("os.makedirs")
+    @patch("os.path.exists", return_value=True)
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor.unreal_client_path",
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_regex_callbacks",
+        return_value=[],
+    )
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.logger")
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
+    def test__start_unreal_client_defers_feature_insights(
+        self,
+        mock_subprocess: Mock,
+        mock_logger: Mock,
+        mock_get_regex_callbacks: Mock,
+        mock_unreal_client_path: Mock,
+        mock_os_path_exists: Mock,
+        mock_os_makedirs: Mock,
+        init_data: dict,
+    ):
+        mock_unreal_client_path.side_effect = ["UnrealClient.py"]
+        init_data["extra_cmd_args_file"] = "path/to/args/file.txt"
+        adaptor = UnrealAdaptor(init_data)
+
+        with patch(
+            "builtins.open",
+            new_callable=mock_open,
+            read_data="-DeadlineCloudInsights=cpu,frame -stdout",
+        ):
+            adaptor._start_unreal_client()
+
+        launch_ue_with_message = next(
+            call.args[0].replace("Starting Unreal Engine with args: ", "")
+            for call in mock_logger.mock_calls
+            if call.args and str(call.args[0]).startswith("Starting Unreal Engine with args:")
+        )
+        launch_args = ast.literal_eval(launch_ue_with_message)
+
+        assert not any(arg.lower().startswith("-trace") for arg in launch_args)
+        assert not any(arg.lower().startswith("-deadlinecloudinsights") for arg in launch_args)
+        assert adaptor._insights_categories == "cpu,frame"
+        mock_os_makedirs.assert_not_called()
+
+    @patch("os.path.exists", return_value=True)
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor.unreal_client_path",
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_regex_callbacks",
+        return_value=[],
+    )
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.logger")
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
+    def test_raw_trace_takes_precedence_over_feature_insights(
+        self,
+        mock_subprocess: Mock,
+        mock_logger: Mock,
+        mock_get_regex_callbacks: Mock,
+        mock_unreal_client_path: Mock,
+        mock_os_path_exists: Mock,
+        init_data: dict,
+    ):
+        mock_unreal_client_path.side_effect = ["UnrealClient.py"]
+        init_data["extra_cmd_args_file"] = "path/to/args/file.txt"
+        adaptor = UnrealAdaptor(init_data)
+
+        with (
+            patch(
+                "builtins.open",
+                new_callable=mock_open,
+                read_data=(
+                    "-DeadlineCloudInsights=cpu,frame " "-trace=gpu -tracefile=C:/manual.utrace"
+                ),
+            ),
+            patch("os.makedirs"),
+        ):
+            adaptor._start_unreal_client()
+
+        launch_ue_with_message = next(
+            call.args[0].replace("Starting Unreal Engine with args: ", "")
+            for call in mock_logger.mock_calls
+            if call.args and str(call.args[0]).startswith("Starting Unreal Engine with args:")
+        )
+        launch_args = ast.literal_eval(launch_ue_with_message)
+
+        assert "-trace=gpu" in launch_args
+        assert "-tracefile=C:/manual.utrace" in launch_args
+        assert adaptor._insights_categories is None
+        assert any(
+            call.args and str(call.args[0]).startswith("Raw -trace arguments take precedence")
+            for call in mock_logger.warning.mock_calls
+        )
+
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.logger")
+    @patch("os.makedirs", side_effect=PermissionError("access denied"))
+    def test_get_tracefile_arg_ignores_unwritable_output_directory(
+        self, mock_os_makedirs: Mock, mock_logger: Mock
+    ):
+        tracefile_arg = UnrealAdaptor._get_tracefile_arg(
+            "C:/LocalProjects/AWS_RND/AWS_RND.uproject", "-trace=cpu,frame"
+        )
+
+        assert tracefile_arg is None
+        mock_os_makedirs.assert_called_once()
+        mock_logger.warning.assert_called_once()
+
+    @patch("os.path.exists", return_value=True)
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor.unreal_client_path",
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor._get_regex_callbacks",
+        return_value=[],
+    )
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.logger")
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
     def test__start_unreal_client_with_extra_execcmds_arg(
         self,
         mock_subprocess: Mock,
@@ -415,6 +705,71 @@ class TestUnrealAdaptor_on_run:
 
         # THEN
         mock_sleep.assert_called_once_with(1)
+
+    @patch.object(UnrealAdaptor, "_maybe_submit_renders_to_perforce")
+    @patch.object(UnrealAdaptor, "_snapshot_output_files", return_value={})
+    @patch("time.sleep")
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor.telemetry_client",
+        new_callable=PropertyMock,
+    )
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.ActionsQueue.enqueue_action")
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.ActionsQueue.__len__", return_value=0)
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealSubprocessWithLogs")
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.AdaptorServer")
+    def test_on_run_injects_deferred_profiling_run_data(
+        self,
+        mock_server: Mock,
+        mock_logging_subprocess: Mock,
+        mock_actions_queue_len: Mock,
+        mock_enqueue_action: Mock,
+        mock_telemetry_client: Mock,
+        mock_sleep: Mock,
+        mock_snapshot_output_files: Mock,
+        mock_submit_renders_to_perforce: Mock,
+        init_data: dict,
+        run_data: dict,
+    ) -> None:
+        adaptor = UnrealAdaptor(init_data)
+        mock_server.return_value.server_path = "/tmp/9999"
+        is_rendering_mock = PropertyMock(side_effect=[None, True, False])
+        UnrealAdaptor._is_rendering = is_rendering_mock
+        adaptor.on_start()
+        adaptor._csv_capture_frames = 120
+        adaptor._memreport_enabled = True
+        adaptor._insights_categories = "cpu,frame"
+
+        with (
+            patch("os.path.expandvars", return_value="C:/Expanded/Project.uproject"),
+            patch.object(
+                UnrealAdaptor,
+                "_get_task_trace_file",
+                return_value=(
+                    "C:/LocalProjects/AWS_RND/Saved/Profiling/DeadlineCloud/"
+                    "deadline-cloud-insights-task-0.utrace"
+                ),
+            ) as get_task_trace_file,
+        ):
+            run_data["task_index"] = 0
+            adaptor.on_run(run_data)
+
+        assert get_task_trace_file.call_args.args[0] == "C:/Expanded/Project.uproject"
+
+        run_script_action = next(
+            call.args[0]
+            for call in mock_enqueue_action.call_args_list
+            if call.args and getattr(call.args[0], "name", None) == "run_script"
+        )
+
+        assert run_script_action.args["csv_capture_frames"] == 120
+        assert run_script_action.args["memreport"] is True
+        assert run_script_action.args["insights_categories"] == "cpu,frame"
+        assert run_script_action.args["insights_trace_file"].endswith(
+            "deadline-cloud-insights-task-0.utrace"
+        )
+        assert "csv_capture_frames" not in run_data
+        assert "memreport" not in run_data
+        assert "insights_categories" not in run_data
 
     @patch("time.sleep")
     @patch(

--- a/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_render_step_handler.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_render_step_handler.py
@@ -1,8 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+import os
 import sys
 import pytest
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
 
 unreal_mock = MagicMock()
 unreal_mock.log = MagicMock()
@@ -15,6 +17,10 @@ def unreal_render_step_handler():
         UnrealRenderStepHandler,
     )
 
+    UnrealRenderStepHandler.cached_frame_range_start = None
+    UnrealRenderStepHandler.cached_frame_range_end = None
+    UnrealRenderStepHandler.active_executor = None
+    UnrealRenderStepHandler.render_wait_started = False
     return UnrealRenderStepHandler()
 
 
@@ -147,3 +153,614 @@ class TestApplyParamAliases:
     def test_returns_same_dict(self, unreal_render_step_handler):
         args = {"handler": "render", "chunk_size": 1}
         assert unreal_render_step_handler._apply_param_aliases(args) is args
+
+
+class TestCsvCaptureHelpers:
+    @pytest.mark.parametrize(
+        "args, expected",
+        [
+            ({}, 0),
+            ({"csv_capture_frames": 120}, 120),
+            ({"csv_capture_frames": "42"}, 42),
+            ({"csv_capture_frames": 0}, 0),
+            ({"csv_capture_frames": -5}, 0),
+        ],
+    )
+    def test_get_csv_capture_frames(self, unreal_render_step_handler, args, expected):
+        assert unreal_render_step_handler._get_csv_capture_frames(args) == expected
+
+    def test_stop_executor_csv_capture_calls_hook(self, unreal_render_step_handler):
+        executor = MagicMock()
+
+        unreal_render_step_handler._stop_executor_csv_capture(executor, "render completed")
+
+        executor._stop_csv_capture.assert_called_once_with("render completed")
+
+
+class TestExecutorProfilingLifecycle:
+    @staticmethod
+    def _executor(**overrides):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler,
+        )
+
+        executor = SimpleNamespace()
+        unreal_render_step_handler._initialize_executor_profiling_state(executor)
+        for name, value in overrides.items():
+            setattr(executor, name, value)
+        return executor
+
+    def test_disabled_profiling_completion_runs_no_console_commands(self):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler,
+        )
+
+        executor = self._executor()
+        with (
+            patch.object(
+                unreal_render_step_handler, "_execute_editor_console_command"
+            ) as execute_command,
+            patch.object(unreal_render_step_handler.logger, "info") as log_info,
+        ):
+            unreal_render_step_handler._handle_executor_render_completion(executor)
+
+        execute_command.assert_not_called()
+        log_info.assert_called_once_with("Render Executor: Rendering is complete")
+        assert executor.renderCompletionHandled is True
+        assert executor.csvFinished is True
+        assert executor.memreportGenerated is False
+
+    def test_csv_capture_stops_after_requested_render_frames(self):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler,
+        )
+
+        executor = self._executor(csvCaptureFrames=2)
+        with patch.object(
+            unreal_render_step_handler,
+            "_execute_editor_console_command",
+            return_value=True,
+        ) as execute_command:
+            unreal_render_step_handler._observe_executor_csv_frame(executor)
+            assert executor.csvStarted is True
+            assert executor.csvFramesObserved == 1
+
+            unreal_render_step_handler._observe_executor_csv_frame(executor)
+
+        assert execute_command.call_args_list == [
+            call("CsvProfile Start"),
+            call("CsvProfile Stop"),
+        ]
+        assert executor.csvFramesObserved == 2
+        assert executor.csvStarted is False
+        assert executor.csvFinished is True
+
+    def test_csv_capture_is_not_retried_when_start_fails(self):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler,
+        )
+
+        executor = self._executor(csvCaptureFrames=2)
+        with patch.object(
+            unreal_render_step_handler,
+            "_execute_editor_console_command",
+            return_value=False,
+        ) as execute_command:
+            unreal_render_step_handler._observe_executor_csv_frame(executor)
+            unreal_render_step_handler._observe_executor_csv_frame(executor)
+
+        execute_command.assert_called_once_with("CsvProfile Start")
+        assert executor.csvStarted is False
+        assert executor.csvFinished is True
+
+    def test_memreport_is_generated_only_once(self):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler,
+        )
+
+        executor = self._executor(memreportEnabled=True)
+        with patch.object(
+            unreal_render_step_handler,
+            "_execute_editor_console_command",
+            return_value=True,
+        ) as execute_command:
+            unreal_render_step_handler._generate_executor_memreport(executor)
+            unreal_render_step_handler._generate_executor_memreport(executor)
+
+        execute_command.assert_called_once_with("MemReport -full")
+        assert executor.memreportGenerated is True
+
+    def test_insights_trace_starts_and_stops_once(self):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler,
+        )
+
+        executor = self._executor(
+            insightsCategories="cpu,frame",
+            insightsTraceFile="C:/Project/Saved/Profiling/task-0.utrace",
+        )
+        with (
+            patch.object(
+                unreal_render_step_handler.os,
+                "makedirs",
+            ) as makedirs,
+            patch.object(
+                unreal_render_step_handler.tempfile,
+                "gettempdir",
+                return_value="C:/Temp",
+            ),
+            patch.object(
+                unreal_render_step_handler,
+                "_execute_editor_console_command",
+                return_value=True,
+            ) as execute_command,
+            patch.object(unreal_render_step_handler.shutil, "move") as move,
+        ):
+            unreal_render_step_handler._start_executor_insights_trace(executor)
+            unreal_render_step_handler._start_executor_insights_trace(executor)
+            unreal_render_step_handler._stop_executor_insights_trace(executor, "render completed")
+            unreal_render_step_handler._stop_executor_insights_trace(executor, "render completed")
+
+        makedirs.assert_called_once_with("C:/Project/Saved/Profiling", exist_ok=True)
+        assert execute_command.call_args_list == [
+            call("Trace.File C:/Temp/task-0.utrace cpu,frame"),
+            call("Trace.Stop"),
+        ]
+        move.assert_called_once_with(
+            os.path.join("C:/Temp", "task-0.utrace"),
+            "C:/Project/Saved/Profiling/task-0.utrace",
+        )
+        assert executor.insightsStarted is False
+        assert executor.insightsFinished is True
+
+    def test_insights_trace_is_not_started_when_directory_creation_fails(self):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler,
+        )
+
+        executor = self._executor(
+            insightsCategories="cpu,frame",
+            insightsTraceFile="C:/Project/Saved/Profiling/task-0.utrace",
+        )
+        with (
+            patch.object(
+                unreal_render_step_handler.os,
+                "makedirs",
+                side_effect=OSError("access denied"),
+            ) as makedirs,
+            patch.object(
+                unreal_render_step_handler,
+                "_execute_editor_console_command",
+            ) as execute_command,
+            patch.object(unreal_render_step_handler.logger, "warning") as log_warning,
+        ):
+            unreal_render_step_handler._start_executor_insights_trace(executor)
+            unreal_render_step_handler._start_executor_insights_trace(executor)
+
+        makedirs.assert_called_once_with("C:/Project/Saved/Profiling", exist_ok=True)
+        execute_command.assert_not_called()
+        log_warning.assert_called_once()
+        assert executor.insightsStarted is False
+        assert executor.insightsFinished is True
+
+    def test_reused_session_creates_an_independent_trace_for_each_task(self):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler,
+        )
+
+        task_zero = self._executor(
+            insightsCategories="cpu,frame",
+            insightsTraceFile="C:/Profiling/task-0.utrace",
+        )
+        task_one = self._executor(
+            insightsCategories="cpu,frame",
+            insightsTraceFile="C:/Profiling/task-1.utrace",
+        )
+        with (
+            patch.object(
+                unreal_render_step_handler.os,
+                "makedirs",
+            ) as makedirs,
+            patch.object(
+                unreal_render_step_handler.tempfile,
+                "gettempdir",
+                return_value="C:/Temp",
+            ),
+            patch.object(
+                unreal_render_step_handler,
+                "_execute_editor_console_command",
+                return_value=True,
+            ) as execute_command,
+            patch.object(unreal_render_step_handler.shutil, "move") as move,
+        ):
+            for executor in (task_zero, task_one):
+                unreal_render_step_handler._start_executor_insights_trace(executor)
+                unreal_render_step_handler._handle_executor_render_completion(executor)
+
+        assert makedirs.call_args_list == [
+            call("C:/Profiling", exist_ok=True),
+            call("C:/Profiling", exist_ok=True),
+        ]
+        assert execute_command.call_args_list == [
+            call("Trace.File C:/Temp/task-0.utrace cpu,frame"),
+            call("Trace.Stop"),
+            call("Trace.File C:/Temp/task-1.utrace cpu,frame"),
+            call("Trace.Stop"),
+        ]
+        assert move.call_args_list == [
+            call(os.path.join("C:/Temp", "task-0.utrace"), "C:/Profiling/task-0.utrace"),
+            call(os.path.join("C:/Temp", "task-1.utrace"), "C:/Profiling/task-1.utrace"),
+        ]
+
+    def test_insights_trace_uses_relative_working_file_when_temp_path_has_spaces(self):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler,
+        )
+
+        executor = self._executor(
+            insightsCategories="cpu,frame",
+            insightsTraceFile="C:/Project With Spaces/Saved/Profiling/task-0.utrace",
+        )
+        with (
+            patch.object(unreal_render_step_handler.os, "makedirs"),
+            patch.object(
+                unreal_render_step_handler.tempfile,
+                "gettempdir",
+                return_value="C:/Temp With Spaces",
+            ),
+            patch.object(
+                unreal_render_step_handler,
+                "unreal",
+                SimpleNamespace(
+                    Paths=SimpleNamespace(
+                        convert_relative_path_to_full=lambda _: (
+                            "C:/Working Directory/task-0.utrace"
+                        )
+                    )
+                ),
+            ),
+            patch.object(
+                unreal_render_step_handler,
+                "_execute_editor_console_command",
+                return_value=True,
+            ) as execute_command,
+            patch.object(unreal_render_step_handler.shutil, "move") as move,
+        ):
+            unreal_render_step_handler._start_executor_insights_trace(executor)
+            unreal_render_step_handler._stop_executor_insights_trace(executor, "render completed")
+
+        assert execute_command.call_args_list == [
+            call("Trace.File task-0.utrace cpu,frame"),
+            call("Trace.Stop"),
+        ]
+        move.assert_called_once_with(
+            "C:/Working Directory/task-0.utrace",
+            "C:/Project With Spaces/Saved/Profiling/task-0.utrace",
+        )
+
+    def test_insights_trace_move_retries_transient_windows_lock(self):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler,
+        )
+
+        with (
+            patch.object(
+                unreal_render_step_handler.shutil,
+                "move",
+                side_effect=[PermissionError("locked"), None],
+            ) as move,
+            patch.object(unreal_render_step_handler.time, "sleep") as sleep,
+        ):
+            moved = unreal_render_step_handler._move_finalized_insights_trace("source", "dest")
+
+        assert moved is True
+        assert move.call_count == 2
+        sleep.assert_called_once_with(0.1)
+
+    def test_completion_attempts_all_profilers_and_is_idempotent(self):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler,
+        )
+
+        executor = self._executor(
+            csvCaptureFrames=10,
+            csvStarted=True,
+            memreportEnabled=True,
+            insightsCategories="cpu,frame",
+            insightsTraceFile="C:/Project/Saved/Profiling/task-0.utrace",
+            insightsStarted=True,
+        )
+        with (
+            patch.object(
+                unreal_render_step_handler,
+                "_execute_editor_console_command",
+                return_value=True,
+            ) as execute_command,
+            patch.object(
+                unreal_render_step_handler,
+                "_move_finalized_insights_trace",
+                return_value=True,
+            ),
+        ):
+            unreal_render_step_handler._handle_executor_render_completion(executor)
+            unreal_render_step_handler._handle_executor_render_completion(executor)
+
+        assert execute_command.call_args_list == [
+            call("CsvProfile Stop"),
+            call("MemReport -full"),
+            call("Trace.Stop"),
+        ]
+        assert executor.csvFinished is True
+        assert executor.memreportGenerated is True
+        assert executor.insightsFinished is True
+        assert executor.renderCompletionHandled is True
+
+    def test_profiler_failure_cannot_suppress_render_completion(self):
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import (
+            unreal_render_step_handler,
+        )
+
+        executor = self._executor(memreportEnabled=True)
+        with (
+            patch.object(
+                unreal_render_step_handler,
+                "_stop_executor_csv_capture",
+                side_effect=RuntimeError("CSV failure"),
+            ),
+            patch.object(
+                unreal_render_step_handler,
+                "_generate_executor_memreport",
+                side_effect=RuntimeError("MemReport failure"),
+            ),
+            patch.object(
+                unreal_render_step_handler,
+                "_stop_executor_insights_trace",
+                side_effect=RuntimeError("Insights failure"),
+            ),
+            patch.object(unreal_render_step_handler.logger, "info") as log_info,
+        ):
+            unreal_render_step_handler._handle_executor_render_completion(executor)
+
+        log_info.assert_called_once_with("Render Executor: Rendering is complete")
+        assert executor.renderCompletionHandled is True
+
+
+class TestMemreportHelpers:
+    @pytest.mark.parametrize(
+        "args, expected",
+        [
+            ({}, False),
+            ({"memreport": True}, True),
+            ({"memreport": 1}, True),
+            ({"memreport": "true"}, True),
+            ({"memreport": "false"}, False),
+            ({"memreport": 0}, False),
+        ],
+    )
+    def test_get_memreport_enabled(self, unreal_render_step_handler, args, expected):
+        assert unreal_render_step_handler._get_memreport_enabled(args) is expected
+
+    def test_generate_executor_memreport_calls_hook(self, unreal_render_step_handler):
+        executor = MagicMock()
+
+        unreal_render_step_handler._generate_executor_memreport(executor)
+
+        executor._generate_memreport.assert_called_once_with()
+
+    def test_handle_executor_completion_prefers_executor_hook(self, unreal_render_step_handler):
+        executor = MagicMock()
+
+        with patch(
+            "deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler."
+            "UnrealRenderStepHandler._stop_executor_csv_capture"
+        ) as stop_capture_mock:
+            with patch(
+                "deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler."
+                "UnrealRenderStepHandler._generate_executor_memreport"
+            ) as generate_memreport_mock:
+                unreal_render_step_handler._handle_executor_completion(executor)
+
+        executor._handle_render_completion.assert_called_once_with()
+        stop_capture_mock.assert_not_called()
+        generate_memreport_mock.assert_not_called()
+
+    def test_handle_executor_completion_falls_back_to_legacy_hooks(
+        self, unreal_render_step_handler
+    ):
+        executor = object()
+
+        with patch(
+            "deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler."
+            "UnrealRenderStepHandler._stop_executor_csv_capture"
+        ) as stop_capture_mock:
+            with patch(
+                "deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler."
+                "UnrealRenderStepHandler._generate_executor_memreport"
+            ) as generate_memreport_mock:
+                with patch(
+                    "deadline.unreal_adaptor.UnrealClient.step_handlers."
+                    "unreal_render_step_handler.UnrealRenderStepHandler."
+                    "_stop_executor_insights_trace"
+                ) as stop_insights_mock:
+                    unreal_render_step_handler._handle_executor_completion(executor)
+
+        stop_capture_mock.assert_called_once_with(executor, "render completed")
+        generate_memreport_mock.assert_called_once_with(executor)
+        stop_insights_mock.assert_called_once_with(executor, "render completed")
+
+    def test_executor_finished_callback_requests_memreport(self, unreal_render_step_handler):
+        executor = MagicMock()
+
+        with patch(
+            "deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler."
+            "UnrealRenderStepHandler._handle_executor_completion"
+        ) as handle_completion_mock:
+            unreal_render_step_handler.executor_finished_callback(executor, True)
+
+        handle_completion_mock.assert_called_once_with(executor)
+
+    def test_executor_finished_callback_uses_active_executor(self, unreal_render_step_handler):
+        executor = MagicMock()
+        type(unreal_render_step_handler).active_executor = executor
+
+        with patch.object(
+            type(unreal_render_step_handler), "_handle_executor_completion"
+        ) as handle_completion:
+            unreal_render_step_handler.executor_finished_callback()
+
+        handle_completion.assert_called_once_with(executor)
+
+    def test_executor_failed_callback_uses_active_executor(self, unreal_render_step_handler):
+        executor = MagicMock()
+        type(unreal_render_step_handler).active_executor = executor
+
+        with (
+            patch.object(
+                type(unreal_render_step_handler), "_stop_executor_csv_capture"
+            ) as stop_csv,
+            patch.object(
+                type(unreal_render_step_handler), "_stop_executor_insights_trace"
+            ) as stop_insights,
+        ):
+            unreal_render_step_handler.executor_failed_callback(
+                None,
+                None,
+                True,
+                "failed",
+            )
+
+        stop_csv.assert_called_once_with(executor, "render error")
+        stop_insights.assert_called_once_with(executor, "render error")
+
+
+class TestRenderWaitResult:
+    def test_regex_pattern_complete_requires_explicit_render_completion(
+        self, unreal_render_step_handler
+    ):
+        regexes = unreal_render_step_handler.regex_pattern_complete()
+
+        assert regexes[0].search("Render Executor: Rendering is complete")
+        assert not regexes[0].search(
+            "LogMovieRenderPipeline: MoviePipelineLinearExecutorBase finished 1 jobs in +00:00:04.017."
+        )
+
+    def test_wait_result_ignores_executor_before_render_starts(self, unreal_render_step_handler):
+        executor = MagicMock()
+        executor.renderStarted = False
+        executor.renderCompletionHandled = False
+        executor.is_rendering.return_value = False
+        type(unreal_render_step_handler).active_executor = executor
+
+        with patch(
+            "deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler."
+            "UnrealRenderStepHandler._handle_executor_completion"
+        ) as handle_completion_mock:
+            unreal_render_step_handler.wait_result()
+
+        handle_completion_mock.assert_not_called()
+        assert type(unreal_render_step_handler).active_executor is executor
+        assert type(unreal_render_step_handler).render_wait_started is True
+
+    def test_wait_result_ignores_executor_while_rendering(self, unreal_render_step_handler):
+        executor = MagicMock()
+        executor.renderStarted = True
+        executor.renderCompletionHandled = False
+        executor.is_rendering.return_value = True
+        type(unreal_render_step_handler).active_executor = executor
+
+        with patch(
+            "deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler."
+            "UnrealRenderStepHandler._handle_executor_completion"
+        ) as handle_completion_mock:
+            unreal_render_step_handler.wait_result()
+
+        handle_completion_mock.assert_not_called()
+        assert type(unreal_render_step_handler).active_executor is executor
+        assert type(unreal_render_step_handler).render_wait_started is True
+
+    def test_wait_result_does_not_infer_completion_when_render_temporarily_stops(
+        self, unreal_render_step_handler
+    ):
+        executor = MagicMock()
+        executor.renderStarted = True
+        executor.renderCompletionHandled = False
+        executor.is_rendering.return_value = False
+        type(unreal_render_step_handler).active_executor = executor
+
+        with patch(
+            "deadline.unreal_adaptor.UnrealClient.step_handlers.unreal_render_step_handler."
+            "UnrealRenderStepHandler._handle_executor_completion"
+        ) as handle_completion_mock:
+            unreal_render_step_handler.wait_result()
+
+        handle_completion_mock.assert_not_called()
+        assert type(unreal_render_step_handler).active_executor is executor
+        assert type(unreal_render_step_handler).render_wait_started is True
+
+    def test_wait_result_finishes_after_delegate_handles_completion(
+        self, unreal_render_step_handler
+    ):
+        executor = MagicMock()
+        executor.renderCompletionHandled = True
+        type(unreal_render_step_handler).active_executor = executor
+        type(unreal_render_step_handler).render_wait_started = True
+
+        unreal_render_step_handler.wait_result()
+
+        assert type(unreal_render_step_handler).active_executor is None
+        assert type(unreal_render_step_handler).render_wait_started is False
+
+
+class TestConsoleCommandWorld:
+    @staticmethod
+    def _module():
+        from deadline.unreal_adaptor.UnrealClient.step_handlers import unreal_render_step_handler
+
+        unreal_render_step_handler.unreal = unreal_mock
+        unreal_mock.reset_mock()
+        return unreal_render_step_handler
+
+    def test_prefers_pie_world(self):
+        unreal_render_step_handler = self._module()
+        pie_world = object()
+        unreal_render_step_handler.unreal.EditorLevelLibrary.get_pie_worlds.return_value = [
+            pie_world
+        ]
+
+        assert unreal_render_step_handler._get_command_world() is pie_world
+
+    def test_falls_back_to_game_world(self):
+        unreal_render_step_handler = self._module()
+        game_world = object()
+        unreal_render_step_handler.unreal.EditorLevelLibrary.get_pie_worlds.return_value = []
+        unreal_render_step_handler.unreal.EditorLevelLibrary.get_game_world.return_value = (
+            game_world
+        )
+
+        assert unreal_render_step_handler._get_command_world() is game_world
+
+    def test_falls_back_to_editor_world(self):
+        unreal_render_step_handler = self._module()
+        editor_world = object()
+        unreal_render_step_handler.unreal.EditorLevelLibrary.get_pie_worlds.return_value = []
+        unreal_render_step_handler.unreal.EditorLevelLibrary.get_game_world.return_value = None
+        unreal_render_step_handler.unreal.get_editor_subsystem.return_value = None
+        unreal_render_step_handler.unreal.EditorLevelLibrary.get_editor_world.return_value = (
+            editor_world
+        )
+
+        assert unreal_render_step_handler._get_command_world() is editor_world
+
+    def test_console_command_failure_is_nonfatal(self):
+        unreal_render_step_handler = self._module()
+        pie_world = object()
+        unreal_render_step_handler.unreal.EditorLevelLibrary.get_pie_worlds.return_value = [
+            pie_world
+        ]
+        unreal_render_step_handler.unreal.SystemLibrary.execute_console_command.side_effect = (
+            RuntimeError("console unavailable")
+        )
+
+        assert (
+            unreal_render_step_handler._execute_editor_console_command("MemReport -full") is False
+        )

--- a/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_dynamic_chunking.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealClient/step_handlers/test_unreal_render_step_handler_dynamic_chunking.py
@@ -132,6 +132,7 @@ class TestDynamicChunkingPrecedence:
         subsystem = MagicMock()
         subsystem.get_queue.return_value.get_jobs.return_value = [job]
         unreal_mock.get_editor_subsystem.return_value = subsystem
+        executor_class = MagicMock()
 
         # The handler module may already have been imported by another test
         # module with a different (or absent) `unreal`; patch its globals so
@@ -143,7 +144,7 @@ class TestDynamicChunkingPrecedence:
             patch.object(
                 handler_module,
                 "RemoteRenderMoviePipelineEditorExecutor",
-                MagicMock(),
+                executor_class,
                 create=True,
             ),
             patch.object(
@@ -164,6 +165,7 @@ class TestDynamicChunkingPrecedence:
                 "enable_shots": enable_shots,
                 "apply_filename": apply_filename,
                 "get_frame_range": get_frame_range,
+                "executor": executor_class.return_value,
             }
             yield unreal_render_step_handler, job, output_settings, patches
 
@@ -230,6 +232,8 @@ class TestDynamicChunkingPrecedence:
         patches["enable_shots"].assert_not_called()
         patches["apply_filename"].assert_not_called()
         patches["get_frame_range"].assert_not_called()
+        assert patches["executor"].csvCaptureFrames == 0
+        assert patches["executor"].memreportEnabled is False
 
 
 class TestStaticMethodBehavior:

--- a/test/deadline_cmd_utils_for_unreal/test_cmd_utils.py
+++ b/test/deadline_cmd_utils_for_unreal/test_cmd_utils.py
@@ -79,6 +79,15 @@ def test_merge_execcmds():
     assert params["ExecCmds"] == "stat fps,toggledebugcamera,r.SetNearClipPlane 1"
 
 
+def test_merge_trace_categories():
+    lower = "-trace=cpu,frame,bookmark"
+    higher = "-trace=GPU,bookmark,loadtime"
+
+    _, _, params = parse_command_line(merge_cmd_args_with_priority(higher, lower))
+
+    assert params["trace"] == "cpu,frame,bookmark,GPU,loadtime"
+
+
 # ──────────────────────────────────────────────────────────────
 # Auto‑quoting for values containing spaces or commas
 # ──────────────────────────────────────────────────────────────

--- a/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
+++ b/test/deadline_submitter_for_unreal/unit/test_unreal_open_job/test_unreal_open_job.py
@@ -2,6 +2,7 @@
 
 import sys
 import pytest
+from types import SimpleNamespace
 from unittest.mock import patch, Mock, MagicMock
 from openjd.model import parse_model
 from openjd.model.v2023_09 import (
@@ -28,6 +29,7 @@ unreal_mock = MagicMock()
 sys.modules["unreal"] = unreal_mock
 
 from deadline.unreal_submitter.unreal_open_job.unreal_open_job import (  # noqa: E402
+    ProfilingSettings,
     UnrealOpenJob,
     RenderUnrealOpenJob,
     P4RenderUnrealOpenJob,
@@ -35,7 +37,13 @@ from deadline.unreal_submitter.unreal_open_job.unreal_open_job import (  # noqa:
     UnrealOpenJobParameterDefinition,
     TransferProjectFilesStrategy,
 )
+from deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity import (  # noqa: E402
+    OpenJobParameterNames,
+)
 from deadline.unreal_submitter import exceptions  # noqa: E402
+from deadline.unreal_cmd_utils import (  # noqa: E402
+    parse_command_line,
+)
 
 
 class TestUnrealOpenJobStepParameterDefinition:
@@ -744,6 +752,223 @@ class TestRenderUnrealOpenJob:
         )
         assert count == 1
 
+    def test_profiling_settings_from_u_deadline_cloud_profiling_settings(self):
+        class FakeProfilingStruct:
+            def get_editor_property(self, name):
+                values = {
+                    "bInsightsCpu": True,
+                    "bInsightsGpu": True,
+                    "bInsightsMemory": False,
+                    "bCsvProfiler": True,
+                    "CsvCaptureFrames": 120,
+                    "bMemReport": True,
+                }
+                return values[name]
+
+        profiling_settings = ProfilingSettings.from_u_deadline_cloud_profiling_settings(
+            FakeProfilingStruct()
+        )
+
+        assert profiling_settings.insights_cpu is True
+        assert profiling_settings.insights_gpu is True
+        assert profiling_settings.insights_memory is False
+        assert profiling_settings.csv_profiler is True
+        assert profiling_settings.csv_capture_frames == 120
+        assert profiling_settings.memreport is True
+
+    def test_profiling_settings_build_cmd_args_includes_csv_capture_frames(self):
+        profiling_settings = ProfilingSettings(
+            insights_cpu=True,
+            csv_profiler=True,
+            csv_capture_frames=120,
+            memreport=True,
+        )
+
+        cmd_args = profiling_settings.build_cmd_args()
+
+        assert "-DeadlineCloudInsights=cpu,frame,bookmark,loadtime" in cmd_args
+        assert "-csvGpuStats" in cmd_args
+        assert "-csvCaptureFrames=120" in cmd_args
+        assert "-MemReport" in cmd_args
+
+    @pytest.mark.parametrize(
+        "profiling_settings,expected",
+        [
+            (
+                ProfilingSettings(insights_cpu=True, csv_profiler=True, memreport=True),
+                ["/project/Saved/Profiling"],
+            ),
+            (
+                ProfilingSettings(csv_profiler=True),
+                ["/project/Saved/Profiling/CSV"],
+            ),
+            (
+                ProfilingSettings(memreport=True),
+                ["/project/Saved/Profiling/MemReports"],
+            ),
+            (
+                ProfilingSettings(csv_profiler=True, memreport=True),
+                [
+                    "/project/Saved/Profiling/CSV",
+                    "/project/Saved/Profiling/MemReports",
+                ],
+            ),
+        ],
+    )
+    def test_profiling_settings_output_directories(self, profiling_settings, expected):
+        assert profiling_settings.get_output_directories("/project") == expected
+
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job_entity."
+        "UnrealOpenJobEntity.get_template_object",
+        return_value={
+            "parameterDefinitions": [
+                {"name": OpenJobParameterNames.UNREAL_EXTRA_CMD_ARGS, "type": "STRING"},
+                {"name": OpenJobParameterNames.UNREAL_EXTRA_CMD_ARGS_FILE, "type": "PATH"},
+                {"name": OpenJobParameterNames.UNREAL_PROJECT_PATH, "type": "PATH"},
+                {"name": OpenJobParameterNames.MARKETPLACE_PLUGINS_DIR, "type": "PATH"},
+            ]
+        },
+    )
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job.common.get_in_process_executor_cmd_args",
+        return_value=["-stdout", "-trace=gpu"],
+    )
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job.common.get_project_file_path",
+        return_value="/project dir/MyProject.uproject",
+    )
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job.common.get_project_directory",
+        return_value="/project dir",
+    )
+    @patch(
+        "deadline.unreal_submitter.unreal_open_job.unreal_open_job.common.create_deadline_cloud_temp_file",
+        return_value="/tmp/ExtraCmdArgsFile.txt",
+    )
+    @patch.object(
+        UnrealOpenJob,
+        "get_marketplace_plugins_dir",
+        return_value="/Engine/Plugins/Marketplace",
+    )
+    def test__build_parameter_values_merges_profiling_cmd_args(
+        self,
+        get_marketplace_plugins_dir_mock,
+        create_deadline_cloud_temp_file_mock,
+        get_project_directory_mock,
+        get_project_file_path_mock,
+        get_in_process_executor_cmd_args_mock,
+        get_template_object_mock,
+    ):
+        render_job = RenderUnrealOpenJob(
+            file_path="",
+            name="JobA",
+            extra_parameters=[
+                UnrealOpenJobParameterDefinition(
+                    OpenJobParameterNames.UNREAL_EXTRA_CMD_ARGS,
+                    "STRING",
+                    '-execcmds="stat fps" -trace=cpu,frame -csvCaptureFrames=999',
+                )
+            ],
+            profiling_settings=ProfilingSettings(
+                insights_cpu=True,
+                insights_memory=True,
+                csv_profiler=True,
+                csv_capture_frames=120,
+                memreport=True,
+            ),
+        )
+
+        parameter_values = render_job._build_parameter_values()
+        file_data = create_deadline_cloud_temp_file_mock.call_args.kwargs["file_data"]
+        _, switches, params = parse_command_line(file_data)
+
+        assert {p["name"]: p["value"] for p in parameter_values}[
+            OpenJobParameterNames.UNREAL_EXTRA_CMD_ARGS
+        ] == ""
+        assert {p["name"]: p["value"] for p in parameter_values}[
+            OpenJobParameterNames.UNREAL_EXTRA_CMD_ARGS_FILE
+        ] == "/tmp/ExtraCmdArgsFile.txt"
+        assert {p["name"]: p["value"] for p in parameter_values}[
+            OpenJobParameterNames.UNREAL_PROJECT_PATH
+        ] == "/project dir/MyProject.uproject"
+        assert {p["name"]: p["value"] for p in parameter_values}[
+            OpenJobParameterNames.MARKETPLACE_PLUGINS_DIR
+        ] == "/Engine/Plugins/Marketplace"
+        assert set(switches) == {"stdout", "csvGpuStats", "MemReport"}
+        assert params["trace"] == "gpu,cpu,frame"
+        assert params["DeadlineCloudInsights"] == "cpu,frame,bookmark,loadtime,memory"
+        assert "tracefile" not in params
+        assert params["csvCaptureFrames"] == "999"
+        assert "ExecCmds" not in params
+        assert "/tmp/ExtraCmdArgsFile.txt" in render_job._asset_references.input_filenames
+
+    def test_get_asset_references_adds_profiling_output_directories(self):
+        render_job = RenderUnrealOpenJob.__new__(RenderUnrealOpenJob)
+        render_job._transfer_files_strategy = None  # type: ignore[assignment]
+        render_job._mrq_job = None
+        render_job._extra_parameters = []
+        render_job._profiling_settings = ProfilingSettings(
+            insights_cpu=True, csv_profiler=True, csv_capture_frames=60, memreport=True
+        )
+
+        refs = AssetReferences()
+        with patch.object(UnrealOpenJob, "get_asset_references", return_value=refs):
+            with patch(
+                "deadline.unreal_submitter.unreal_open_job.unreal_open_job.common.get_project_directory",
+                return_value="/project",
+            ):
+                result = render_job.get_asset_references()
+
+        assert result.output_directories == {
+            "/project/Saved/Profiling",
+        }
+
+    def test_mrq_job_without_profiling_override_preserves_existing_settings(self):
+        existing = ProfilingSettings(insights_cpu=True, csv_profiler=True)
+        render_job = RenderUnrealOpenJob.__new__(RenderUnrealOpenJob)
+        render_job._profiling_settings = existing
+        render_job._extra_parameters = []
+        render_job._steps = []
+        render_job._environments = []
+        render_job._name = "Job"
+        mrq_job = SimpleNamespace(
+            job_template_overrides=SimpleNamespace(parameters=[]),
+            preset_overrides=SimpleNamespace(job_shared_settings=None),
+            job_name="MRQ Job",
+        )
+
+        render_job.mrq_job = mrq_job
+
+        assert render_job.profiling_settings is existing
+
+    def test_mrq_job_profiling_override_replaces_existing_settings(self):
+        render_job = RenderUnrealOpenJob.__new__(RenderUnrealOpenJob)
+        render_job._profiling_settings = ProfilingSettings(insights_cpu=True)
+        render_job._extra_parameters = []
+        render_job._steps = []
+        render_job._environments = []
+        render_job._name = "Job"
+        profiling_override = SimpleNamespace(
+            insights_cpu=False,
+            insights_gpu=True,
+            insights_memory=False,
+            csv_profiler=False,
+            csv_capture_frames=300,
+            memreport=True,
+        )
+        mrq_job = SimpleNamespace(
+            job_template_overrides=SimpleNamespace(parameters=[]),
+            preset_overrides=SimpleNamespace(
+                job_shared_settings=None, profiling_settings=profiling_override
+            ),
+            job_name="MRQ Job",
+        )
+
+        render_job.mrq_job = mrq_job
+
+        assert render_job.profiling_settings == ProfilingSettings(insights_gpu=True, memreport=True)
+
 
 class TestP4RenderUnrealOpenJobSubmitModeSkipsJA:
     """
@@ -830,6 +1055,23 @@ class TestP4RenderUnrealOpenJobSubmitModeSkipsJA:
         assert result.referenced_paths == {"C:/renders/output"}
         assert len(result.input_directories) == 1
         assert len(result.input_filenames) == 1
+
+    def test_submit_mode_keeps_profiling_outputs_in_job_attachments(self):
+        job = self._make_job(submit_mode_value="submit")
+        job._profiling_settings = ProfilingSettings(insights_cpu=True)
+        refs = AssetReferences()
+        refs.output_directories.add("C:/renders/output")
+
+        with (
+            patch.object(UnrealOpenJob, "get_asset_references", return_value=refs),
+            patch(
+                "deadline.unreal_submitter.unreal_open_job.unreal_open_job.common.get_project_directory",
+                return_value="C:/project",
+            ),
+        ):
+            result = job.get_asset_references()
+
+        assert result.output_directories == {"C:/project/Saved/Profiling"}
 
 
 class TestP4RenderUnrealOpenJobAssembleShelvesInjection:

--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -938,6 +938,7 @@ def run_unreal_test(request, reusable_farm_id, reusable_queue_id) -> Callable:
         uproject_file: str,
         deadlineargs: Optional[str] = None,
         job_name: Optional[str] = None,
+        extra_test_params: Optional[Dict[str, Any]] = None,
     ) -> Tuple[bool, List[str]]:
         """
         Runs an Unreal Engine automation test and determines success or failure by analyzing output patterns
@@ -949,6 +950,7 @@ def run_unreal_test(request, reusable_farm_id, reusable_queue_id) -> Callable:
             deadlineargs: Optional arguments to pass to Deadline, defaults to basic settings if None
             job_name: Optional name for the submitted Deadline Cloud job. Defaults to the
                 requesting pytest test's name so each job can be traced back to its test
+            extra_test_params: Optional parameters forwarded to the Unreal automation test
 
         Returns:
             Tuple of (success, output_lines) where success is a boolean indicating whether the test passed,
@@ -971,10 +973,20 @@ def run_unreal_test(request, reusable_farm_id, reusable_queue_id) -> Callable:
         config.set_setting("defaults.queue_id", reusable_queue_id)
         config.set_setting("settings.deadline_regions", TEST_TARGET_REGION)
 
-        test_params_str = (
-            f"-testparams=farm_id={reusable_farm_id};queue_id={reusable_queue_id}"
-            f";job_name={job_name}"
-        )
+        test_param_values = {
+            "farm_id": reusable_farm_id,
+            "queue_id": reusable_queue_id,
+            "job_name": job_name,
+        }
+        if extra_test_params:
+            test_param_values.update(extra_test_params)
+
+        sanitized_test_params = []
+        for key, value in test_param_values.items():
+            sanitized_key = re.sub(r"[;=]", "_", str(key))
+            sanitized_value = re.sub(r"[;=]", "_", str(value))
+            sanitized_test_params.append(f"{sanitized_key}={sanitized_value}")
+        test_params_str = f"-testparams={';'.join(sanitized_test_params)}"
 
         engine_root = find_engine_root(request.config.getoption("--ueversion"))
 

--- a/test/end_to_end/test_worker_agent.py
+++ b/test/end_to_end/test_worker_agent.py
@@ -181,23 +181,41 @@ def test_worker_agent_profiling_outputs_are_attached(
         queue_id=queue_id,
         queue_display_name=queue["displayName"],
     )
-    trace_downloader = OutputDownloader(
+    profiling_output_downloader = OutputDownloader(
         s3_settings=JobAttachmentS3Settings(**queue["jobAttachmentSettings"]),
         farm_id=farm_id,
         queue_id=queue_id,
         job_id=job_id,
         session=queue_user_session,
-        include_filters=["**/*.utrace"],
+        include_filters=["**/*.utrace", "**/*.csv", "**/*.memreport"],
     )
-    trace_download_dir = tmp_path / "profiling-outputs"
-    for root in trace_downloader.get_paths_by_root():
-        trace_downloader.set_root_path(root, str(trace_download_dir))
-    trace_downloader.download()
+    profiling_output_dir = tmp_path / "profiling-outputs"
+    for root in profiling_output_downloader.get_paths_by_root():
+        profiling_output_downloader.set_root_path(root, str(profiling_output_dir))
+    profiling_output_downloader.download()
 
-    downloaded_traces = list(trace_download_dir.rglob("*.utrace"))
+    downloaded_traces = list(profiling_output_dir.rglob("*.utrace"))
     assert len(downloaded_traces) == 1
-    with downloaded_traces[0].open("rb") as trace_file:
-        assert trace_file.read(4) == b"2CRT"
+    trace_data = downloaded_traces[0].read_bytes()
+    assert trace_data[:4] == b"2CRT"
+    assert b"Memory" in trace_data and b"Alloc" in trace_data
+
+    downloaded_csv_files = list(profiling_output_dir.rglob("*.csv"))
+    assert len(downloaded_csv_files) == 1
+    csv_lines = [
+        line
+        for line in downloaded_csv_files[0].read_text(errors="replace").splitlines()
+        if line.strip()
+    ]
+    assert len(csv_lines) > 1
+    assert any("," in line for line in csv_lines)
+
+    downloaded_memreports = list(profiling_output_dir.rglob("*.memreport"))
+    assert len(downloaded_memreports) == 1
+    memreport = downloaded_memreports[0].read_text(errors="replace")
+    assert 'MemReport: Begin command "Mem FromReport"' in memreport
+    assert "Platform Memory Stats" in memreport
+    assert 'MemReport: End command "Mem FromReport"' in memreport
 
 
 def test_worker_agent_project_plugins(

--- a/test/end_to_end/test_worker_agent.py
+++ b/test/end_to_end/test_worker_agent.py
@@ -1,6 +1,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 import logging
+
+from deadline.client.api import get_queue_user_boto3_session
+from deadline.job_attachments.download import (
+    OutputDownloader,
+    get_output_manifests_by_asset_root,
+)
+from deadline.job_attachments.models import JobAttachmentS3Settings
+
 from conftest import (
     DEFAULT_ENV_ENTER_TIMEOUT_SECONDS,
     DEFAULT_ENV_EXIT_TIMEOUT_SECONDS,
@@ -15,6 +23,33 @@ from conftest import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def get_job_output_manifest_paths(deadline_client, farm_id, queue_id, job_id):
+    """List the paths uploaded through a job's output attachment manifests."""
+    queue = deadline_client.get_queue(farmId=farm_id, queueId=queue_id)
+    queue_user_session = get_queue_user_boto3_session(
+        deadline=deadline_client,
+        farm_id=farm_id,
+        queue_id=queue_id,
+        queue_display_name=queue["displayName"],
+    )
+    manifests_by_root = get_output_manifests_by_asset_root(
+        s3_settings=JobAttachmentS3Settings(**queue["jobAttachmentSettings"]),
+        farm_id=farm_id,
+        queue_id=queue_id,
+        job_id=job_id,
+        session=queue_user_session,
+    )
+
+    output_paths = []
+    for root, manifests in manifests_by_root.items():
+        normalized_root = root.replace("\\", "/").rstrip("/")
+        for manifest in manifests:
+            for entry in manifest.paths:
+                normalized_path = entry.path.replace("\\", "/").lstrip("/")
+                output_paths.append(f"{normalized_root}/{normalized_path}")
+    return sorted(output_paths)
 
 
 def test_create_job_with_worker_agent(
@@ -66,10 +101,103 @@ def test_create_job_with_worker_agent(
 
         assert success, message
 
+        output_paths = get_job_output_manifest_paths(
+            deadline_client=deadline_client,
+            farm_id=farm_id,
+            queue_id=queue_id,
+            job_id=job_id,
+        )
+        assert not any(
+            "/saved/profiling/" in path.lower() for path in output_paths
+        ), f"Profiling outputs were produced for a profiling-disabled job: {output_paths}"
+
         logger.info(f"Job {job_id} SUCCEEDED")
     else:
         logger.warning("Could not extract job ID or farm ID from test output")
         assert False, "Could not extract job information from test output"
+
+
+def test_worker_agent_profiling_outputs_are_attached(
+    deadline_client,
+    build_plugin,
+    create_readonly_test_project,
+    run_unreal_test,
+    reusable_queue_fleet_association,
+    deadline_worker_agent,
+    tmp_path,
+):
+    """
+    Submit a profiling-enabled render and verify its Insights, CSV, and
+    MemReport artifacts are uploaded as Deadline job outputs.
+    """
+
+    _, uproject_file = create_readonly_test_project
+
+    success, output_lines = run_unreal_test(
+        "DeadlineCloud.Integration.CreateJob",
+        uproject_file,
+        extra_test_params={"profiling": "all", "csv_capture_frames": 10},
+    )
+    assert success, "Profiling job submission failed"
+
+    job_id, farm_id, queue_id = extract_job_info_from_test_output(output_lines)
+    assert job_id and farm_id and queue_id, "Could not extract profiling job information"
+
+    success, status, message = wait_for_job_state(
+        deadline_client=deadline_client,
+        farm_id=farm_id,
+        job_id=job_id,
+        queue_id=queue_id,
+        expected_states=["SUCCEEDED"],
+        max_wait_time=600,
+        wait_interval=10,
+    )
+    assert success, message
+
+    output_paths = get_job_output_manifest_paths(
+        deadline_client=deadline_client,
+        farm_id=farm_id,
+        queue_id=queue_id,
+        job_id=job_id,
+    )
+    profiling_paths = [path for path in output_paths if "/saved/profiling/" in path.lower()]
+
+    assert any(
+        "/deadlinecloud/" in path.lower() and path.lower().endswith(".utrace")
+        for path in profiling_paths
+    ), f"Insights trace missing from profiling outputs: {profiling_paths}"
+    assert any(
+        "/csv/" in path.lower() and path.lower().endswith(".csv") for path in profiling_paths
+    ), f"CSV profile missing from profiling outputs: {profiling_paths}"
+    assert any(
+        "/memreports/" in path.lower() and path.lower().endswith(".memreport")
+        for path in profiling_paths
+    ), f"MemReport missing from profiling outputs: {profiling_paths}"
+
+    queue = deadline_client.get_queue(farmId=farm_id, queueId=queue_id)
+    queue_user_session = get_queue_user_boto3_session(
+        deadline=deadline_client,
+        farm_id=farm_id,
+        queue_id=queue_id,
+        queue_display_name=queue["displayName"],
+    )
+    trace_downloader = OutputDownloader(
+        s3_settings=JobAttachmentS3Settings(**queue["jobAttachmentSettings"]),
+        farm_id=farm_id,
+        queue_id=queue_id,
+        job_id=job_id,
+        session=queue_user_session,
+        include_filters=["**/*.utrace"],
+    )
+    trace_download_dir = tmp_path / "profiling-outputs"
+    for root in trace_downloader.get_paths_by_root():
+        trace_downloader.set_root_path(root, str(trace_download_dir))
+    trace_downloader.download()
+
+    downloaded_traces = list(trace_download_dir.rglob("*.utrace"))
+    assert len(downloaded_traces) == 1
+    with downloaded_traces[0].open("rb") as trace_file:
+        assert trace_file.read(4) == b"2CRT"
 
 
 def test_worker_agent_project_plugins(


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)

Unreal render jobs could not request Unreal Insights, CSV Profiler, or MemReport capture through the Deadline submitter. Profiling files must be finalized at the correct render-task boundary and registered as job outputs so users can retrieve complete artifacts through the standard Deadline output-download path.

### What was the solution? (How)

- Added opt-in Movie Render Queue settings for Unreal Insights CPU, GPU, and memory tracing.
- Added opt-in CSV Profiler capture with a configurable frame count.
- Added opt-in MemReport capture.
- Propagated profiling settings through submission, command-line arguments, adaptor run data, and the Unreal render executor.
- Preserved explicit user command-line values over profiling preset defaults.
- Added task-scoped render lifecycle handling that starts, stops, and finalizes profiling before reporting task completion.
- Enabled process-level memory instrumentation when Memory Insights is requested while keeping trace capture task-scoped.
- Finalized Insights traces into unique per-task files, including retries for transient Windows file locks and path handling for environment variables and whitespace.
- Registered profiling directories as Job Attachments outputs, including for Perforce SubmitMode jobs.
- Added the profiling fields to the adaptor run-data schema.
- Added unit coverage for argument propagation, path handling, lifecycle behavior, task reuse, Perforce output handling, and disabled defaults.
- Added worker end-to-end coverage that downloads and validates complete `.utrace`, `.csv`, and `.memreport` artifacts through the standard Deadline output path.

### What is the impact of this change?

Users can enable any combination of Unreal Insights, CSV Profiler, and MemReport capture from render job settings and retrieve the generated artifacts as Deadline job outputs. Profiling options remain disabled by default, so non-profiling jobs retain their existing behavior. Explicit user command-line profiling arguments continue to take precedence over preset-derived defaults.

### How was this change tested?

- Ran `hatch run lint` successfully.
- Ran the full Python test suite successfully: 747 passed, 2 skipped.
- Built and installed the plugin with Unreal Engine 5.7.
- Ran profiling-disabled and all-profiling worker end-to-end jobs on a customer-managed fleet.
- Verified the disabled job produced no profiling files.
- Cleared prior test-project profiling data and reran the enabled E2E job successfully in 437.08 seconds.
- Downloaded a new 892 MB task trace, 70 KB CSV profile, and 510 KB MemReport through Job Attachments, then validated the Insights header and memory metadata, non-empty CSV rows, and complete MemReport begin/end markers.

### Have you run a render job successfully with these changes?

Yes. Profiling-disabled and all-profiling render jobs completed successfully on a customer-managed fleet. The disabled job produced no profiling outputs, while the enabled job uploaded complete Unreal Insights, CSV Profiler, and MemReport artifacts as Deadline job outputs.

### Was this change documented?

Yes. The submit-job use-case documentation and submitter setup guide describe the profiling controls, generated output locations, and Memory Insights instrumentation behavior. The adaptor run-data schema also documents the task-level profiling fields.

### Is this a breaking change?

No. The new profiling controls and run-data fields are optional and disabled by default. No existing required adaptor inputs or public interfaces were removed or renamed.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
