### PR TITLE
ci: gate releases on Unreal integration tests

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - mainline
+    paths-ignore:
+      - CHANGELOG.md
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - mainline
+    paths-ignore:
+      - CHANGELOG.md
   workflow_dispatch:
     inputs:
       ref_type:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -23,12 +23,6 @@ on:
         description: 'Tag to test (only used when ref_type is "tag")'
         required: false
         type: string
-      run_ui_automation:
-        description: 'Run the offline Unreal UI automation suite'
-        required: false
-        default: false
-        type: boolean
-
 jobs:
   IntegrationTests:
     name: ${{ matrix.name }} Integration Tests
@@ -48,4 +42,4 @@ jobs:
       branch: ${{ github.event.inputs.ref_type == 'branch' && github.event.inputs.branch || 'mainline' }}
       tag: ${{ github.event.inputs.ref_type == 'tag' && github.event.inputs.tag || '' }}
       os: ${{ matrix.os }}
-      run_ui_automation: ${{ github.event_name == 'workflow_dispatch' && inputs.run_ui_automation || false }}
+      run_ui_automation: true

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -44,6 +44,7 @@ jobs:
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
+      # Unreal has no release integ/e2e projects; test the release tag using the mainline projects.
       environment: mainline
       os: windows
       tag: ${{ needs.TagRelease.outputs.tag }}
@@ -59,6 +60,7 @@ jobs:
     secrets: inherit
     with:
       repository: ${{ github.event.repository.name }}
+      # Unreal has no release integ/e2e projects; test the release tag using the mainline projects.
       environment: mainline
       os: windows
       tag: ${{ needs.TagRelease.outputs.tag }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -34,8 +34,37 @@ jobs:
     with:
       tag: ${{ needs.TagRelease.outputs.tag }}
 
+  IntegrationTests:
+    needs: [TagRelease]
+    name: Integration and UI Automation Tests
+    uses: aws-deadline/.github/.github/workflows/reusable_integration_test.yml@mainline
+    permissions:
+      id-token: write
+      contents: read
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      environment: mainline
+      os: windows
+      tag: ${{ needs.TagRelease.outputs.tag }}
+      run_ui_automation: true
+
+  E2ETests:
+    needs: [TagRelease]
+    name: E2E Tests
+    uses: aws-deadline/.github/.github/workflows/reusable_e2e_test.yml@mainline
+    permissions:
+      id-token: write
+      contents: read
+    secrets: inherit
+    with:
+      repository: ${{ github.event.repository.name }}
+      environment: mainline
+      os: windows
+      tag: ${{ needs.TagRelease.outputs.tag }}
+
   ManualTestGate:
-    needs: [TagRelease, UnitTests]
+    needs: [TagRelease, UnitTests, IntegrationTests, E2ETests]
     runs-on: ubuntu-latest
     environment: release-gate
     steps:


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)

UI automation was opt-in, and releases were not gated by integration or E2E tests.

### What was the solution? (How)

Always enable UI automation for integration runs. Run tagged integration/UI and E2E tests before the manual release gate.

### What is the impact of this change?

Mainline and release integration runs include UI automation. Releases wait for integration and E2E success before manual approval.

### How was this change tested?

Validated workflow YAML and reusable-workflow inputs. The latest production UI run passed 47/47 tests.

### Have you run a render job successfully with these changes?

Not applicable; this changes workflow orchestration only.

### Was this change documented?

No documentation changes are required.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*