### PR TITLE
test: support installed worker service in E2E runs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,6 +35,16 @@ End to end tests validate a more complete render job workflow than our unit test
 hatch run e2e -s
 ```
 
+On a persistent development CMF host, use its installed worker service so jobs run as the
+configured worker user:
+
+```powershell
+hatch run e2e -s --use-installed-worker
+```
+
+This stops `DeadlineWorker` while updating worker packages, then restarts it before the
+worker tests. CI does not set this option and continues to launch an isolated worker subprocess.
+
 ### Run linting
 
 ```bash

--- a/test/end_to_end/conftest.py
+++ b/test/end_to_end/conftest.py
@@ -263,6 +263,15 @@ def pytest_addoption(parser) -> None:
             "a legitimate production deadline-worker-agent service running)."
         ),
     )
+    parser.addoption(
+        "--use-installed-worker",
+        action="store_true",
+        default=False,
+        help=(
+            "Use and restart the installed DeadlineWorker service instead of "
+            "launching a worker subprocess. Intended for persistent development CMF hosts."
+        ),
+    )
 
 
 def _record_leftover(
@@ -361,6 +370,10 @@ def pytest_sessionstart(session) -> None:
         return
 
     leftover = _find_leftover_processes()
+    if session.config.getoption("--use-installed-worker"):
+        leftover = [
+            process for process in leftover if process["category"] != "deadline-worker-agent"
+        ]
     if not leftover:
         logger.info("No conflicting processes found")
         return
@@ -419,6 +432,29 @@ def get_build_script_args() -> List[str]:
         List of command line arguments for the build script
     """
     return ["--install", "--test", "--worker"]
+
+
+def manage_installed_worker_service(action: str) -> None:
+    if sys.platform != "win32":
+        raise RuntimeError("--use-installed-worker is only supported on Windows")
+    if action not in {"start", "stop", "restart"}:
+        raise ValueError(f"Unsupported DeadlineWorker service action: {action}")
+
+    command = action.capitalize()
+    powershell = (
+        f"{command}-Service -Name 'DeadlineWorker' -ErrorAction Stop; "
+        f"(Get-Service -Name 'DeadlineWorker').WaitForStatus("
+        f"'{('Stopped' if action == 'stop' else 'Running')}', "
+        "[TimeSpan]::FromSeconds(30))"
+    )
+    result = subprocess.run(
+        ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", powershell],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        details = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"Could not {action} DeadlineWorker: {details}")
 
 
 # Default OpenJD action timeouts (in seconds) of the LaunchUnrealEditor
@@ -1101,9 +1137,15 @@ def build_plugin(request) -> None:
             else:
                 logger.debug(f"Arg {arg} not present")
 
-        # Run the script and capture the output
-        result = subprocess.run(build_args, text=True)
-        assert result.returncode == 0
+        use_installed_worker = request.config.getoption("--use-installed-worker")
+        if use_installed_worker:
+            manage_installed_worker_service("stop")
+        try:
+            result = subprocess.run(build_args, text=True)
+            assert result.returncode == 0
+        finally:
+            if use_installed_worker:
+                manage_installed_worker_service("start")
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -1873,7 +1915,7 @@ def stop_queue_fleet_associations_and_wait(
 @pytest.fixture(scope="session")
 def deadline_worker_agent(
     request, reusable_farm_id: str, reusable_fleet_id: str
-) -> Generator[Tuple[subprocess.Popen, str], None, None]:
+) -> Generator[Tuple[Optional[subprocess.Popen], str], None, None]:
     """
     Launch deadline-worker-agent as a subprocess using the farm ID and fleet ID from our tests.
 
@@ -1892,6 +1934,22 @@ def deadline_worker_agent(
     import os
     import datetime
     import shutil
+
+    if request.config.getoption("--use-installed-worker"):
+        try:
+            manage_installed_worker_service("restart")
+        except (RuntimeError, ValueError) as exc:
+            pytest.fail(str(exc))
+        log_file = os.path.join(
+            os.environ.get("ProgramData", r"C:\ProgramData"),
+            "Amazon",
+            "Deadline",
+            "Logs",
+            "worker-agent.log",
+        )
+        logger.info("Using installed DeadlineWorker service")
+        yield None, log_file
+        return
 
     # Check if deadline-worker-agent is available using 'where' or 'which'
     agent_path = None

--- a/test/test_e2e_installed_worker.py
+++ b/test/test_e2e_installed_worker.py
@@ -1,0 +1,98 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from test.end_to_end import conftest
+
+
+def make_session(use_installed_worker):
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            getoption=lambda option: {
+                "--no-prerun-checks": False,
+                "--use-installed-worker": use_installed_worker,
+            }[option]
+        )
+    )
+
+
+@pytest.mark.parametrize("action", ["start", "stop", "restart"])
+def test_manage_installed_worker_service(monkeypatch, action):
+    calls = []
+
+    def record_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(conftest.sys, "platform", "win32")
+    monkeypatch.setattr(conftest.subprocess, "run", record_run)
+
+    conftest.manage_installed_worker_service(action)
+
+    command, kwargs = calls[0]
+    assert command[:4] == [
+        "powershell.exe",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+    ]
+    assert f"{action.capitalize()}-Service -Name 'DeadlineWorker'" in command[4]
+    assert kwargs == {"capture_output": True, "text": True}
+
+
+def test_manage_installed_worker_service_requires_windows(monkeypatch):
+    monkeypatch.setattr(conftest.sys, "platform", "linux")
+
+    with pytest.raises(RuntimeError, match="only supported on Windows"):
+        conftest.manage_installed_worker_service("restart")
+
+
+def test_manage_installed_worker_service_reports_failure(monkeypatch):
+    monkeypatch.setattr(conftest.sys, "platform", "win32")
+    monkeypatch.setattr(
+        conftest.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 1, "", "access denied"),
+    )
+
+    with pytest.raises(RuntimeError, match="access denied"):
+        conftest.manage_installed_worker_service("restart")
+
+
+def test_prerun_allows_installed_worker(monkeypatch):
+    monkeypatch.setattr(
+        conftest,
+        "_find_leftover_processes",
+        lambda: [{"category": "deadline-worker-agent"}],
+    )
+
+    conftest.pytest_sessionstart(make_session(use_installed_worker=True))
+
+
+def test_prerun_rejects_worker_by_default(monkeypatch):
+    exits = []
+    monkeypatch.setattr(
+        conftest,
+        "_find_leftover_processes",
+        lambda: [
+            {
+                "category": "deadline-worker-agent",
+                "pid": 123,
+                "name": "deadline-worker-agent.exe",
+                "cmdline_short": "deadline-worker-agent",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        conftest.pytest,
+        "exit",
+        lambda message, returncode: exits.append((message, returncode)),
+    )
+
+    conftest.pytest_sessionstart(make_session(use_installed_worker=False))
+
+    assert len(exits) == 1
+    assert exits[0][1] == 3


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)

Persistent development CMF hosts already have a registered worker and a configured
`DeadlineWorker` service. Launching another worker from an SSM-run E2E process either conflicts
with the existing worker identity or runs as the machine account, which cannot create the
required Windows session ACLs.

### What was the solution? (How)

Add an opt-in `--use-installed-worker` E2E option. It allows the installed worker through
pre-run validation, stops the service while worker packages are updated, and restarts the
service before worker tests. Runs without the option retain the existing isolated worker
subprocess behavior.

### What is the impact of this change?

This only affects E2E runs that explicitly pass `--use-installed-worker`. CI behavior and
runtime plugin behavior are unchanged.

### How was this change tested?

- `hatch run test` (`709 passed, 2 skipped`)
- `hatch run lint`
- E2E collection with `--use-installed-worker`

### Have you run a render job successfully with these changes?

Yes. The installed `DeadlineWorker` service successfully processed the CMF render job used to
validate the motivating development workflow.

### Was this change documented?

Yes. `DEVELOPMENT.md` documents the opt-in command and service lifecycle.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
