### PR TITLE
docs: document pre-GUI submission hooks for Unreal Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This package provides a Unreal Engine plugin that creates Unreal Movie Render Qu
 
 See [Submitter Setup Guide](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/blob/mainline/docs/user_guide/setup-submitter.md) for instructions on setting up your Unreal Submitter plugin and Deadline Cloud Service Managed Fleets (SMF) or Customer Managed Fleets (CMF).
 
+For Deadline Cloud submission hooks (pre-GUI, pre/post-submission) from `DEADLINE_HOOKS_DIR`, see [Submission Hooks](https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/blob/mainline/docs/user_guide/setup-submitter.md#submission-hooks).
+
 ## Adaptor
 
 The Unreal Engine Adaptor implements the [OpenJD][openjd-adaptor-runtime] interface that allows render workloads to launch Unreal Engine and feed it commands. This gives the following benefits:

--- a/docs/user_guide/setup-submitter.md
+++ b/docs/user_guide/setup-submitter.md
@@ -206,31 +206,17 @@ This example will use the Meerkat Demo from the Unreal Marketplace:
 1. You can go to Deadline Cloud Monitor and watch the progress of your job. 
 
 
-# Submission Hooks (Pre-GUI)
+# Submission Hooks
 
-The submitter runs **pre-GUI** submission hooks sourced from `DEADLINE_HOOKS_DIR`. A pre-GUI hook runs when a Deadline Cloud job's **Details panel is built**, letting a studio pre-populate the job's shared settings (name, description, priority, initial state, maximum failed tasks / retries) and template parameters *before* the artist reviews them.
+This submitter supports Deadline Cloud **submission hooks** (pre-GUI, pre-submission, and post-submission) sourced from `DEADLINE_HOOKS_DIR`. Enable them with:
 
-## Enable pre-GUI hooks
+```
+deadline config set settings.allow_environment_hooks true
+```
 
-1. Set `DEADLINE_HOOKS_DIR` to a directory containing a `hooks.yaml` with a `preGUI` entry (see the Deadline Cloud submission-hooks documentation for the file format). This environment variable must be set **before** you launch Unreal Editor.
-1. Allow environment-sourced hooks:
-	```
-	deadline config set settings.allow_environment_hooks true
-	```
-1. (Optional) Skip the per-run confirmation dialog:
-	```
-	deadline config set settings.auto_accept true
-	```
-	When `auto_accept` is `false` (the default), opening a job's Details panel shows a confirmation dialog listing the hooks that will run; the hook applies only after you accept.
+Because the Unreal submitter has no Qt submit dialog, its **pre-GUI** hooks run when a job's **C++ Details panel is built** — the `DeadlineCloudRenderJob` data-asset editor, and the **Movie Render Queue → Deadline Cloud → Preset Overrides** panel. On the MRQ path, **Render (Remote)** submits every queued job, so open each job you want a pre-GUI hook to touch at least once. A pre-GUI hook mutates only the in-memory panel (it does not save the `.uasset`) and re-applies the first time a saved job's panel is opened in a new editor session.
 
-## When pre-GUI hooks run
-
-Pre-GUI hooks are **panel-tied** — they run when a job's Deadline Cloud Details panel is built:
-
-- **Data asset** — when you open a `DeadlineCloudRenderJob` (`UDeadlineCloudJob`) data asset in the editor.
-- **Movie Render Queue** — when you select a Deadline Cloud job in the Movie Render Queue so its **Preset Overrides** panel is shown. Because **Render (Remote)** submits every job in the queue, open each job you want hooked at least once; a job whose panel is never opened is submitted without the pre-GUI hook applied.
-
-A value a hook sets is skipped (and surfaced as an editor notification instead of written to the job) when it fails the panel's validation, matches no field, or names a parameter the submitter resolves itself at submit time (for example `ProjectFilePath`, `ExtraCmdArgs`, `Frames`, or Perforce settings).
+For the `hooks.yaml` format, the hook input/output contract, the recognized job properties, and the confirmation prompt (`settings.auto_accept`), see the Deadline Cloud client's [submission hooks documentation](https://github.com/aws-deadline/deadline-cloud/blob/mainline/docs/submission-hooks.md).
 
 
 # Update Notifications


### PR DESCRIPTION
Fixes: N/A — documentation gap.

### What was the problem/requirement? (What/Why)

Pre-GUI submission hooks shipped for Unreal in #336, but there was no discoverable doc for them (the README had no pointer). Rather than duplicate the base client's hooks documentation, this adds a concise reference.

### What was the solution? (How)

Docs only. Adds a short **Submission Hooks** section to `docs/user_guide/setup-submitter.md` — how to enable env-sourced hooks (`settings.allow_environment_hooks`) plus the UE-specific note that pre-GUI hooks run when the C++ Details panels are built (data-asset editor / Movie Render Queue Preset Overrides) — and links the base client's [`docs/submission-hooks.md`](https://github.com/aws-deadline/deadline-cloud/blob/mainline/docs/submission-hooks.md) for the `hooks.yaml` format, hook contract, and recognized properties. Adds a one-line README pointer to the section.

### What is the impact of this change?

Unreal users can discover and enable submission hooks, with the shared format/contract sourced once from the base doc. No code or behavior change.

### How was this change tested?

Documentation only — no unit tests apply. Verified the Markdown renders and that the README anchor and the base-doc link resolve.

- Have you run the unit tests? N/A (documentation only).

### Have you run a render job successfully with these changes?

N/A — documentation-only change; no code paths are affected.

### Was this change documented?

Yes — this change is the documentation.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
