### PR TITLE
ci: run tests across supported Unreal Engine versions

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -43,14 +43,10 @@ pre-install-commands = [
 ]
 
 [[envs.integ-ci.matrix]]
-unreal = ["5.7"]
 python = ["3.11"]
 
-[envs.integ-ci.env-vars]
-UE_VERSION = "{matrix:unreal}"
-
 [envs.integ-ci.scripts]
-setup = "python ./pipeline/setup-runner.py --versions {matrix:unreal}"
+setup = "python ./pipeline/setup-runner.py --versions {env:UE_VERSION:5.7}"
 integ = "pytest --no-cov {args:test/integ} -vvv --numprocesses=1 --nobuild"
 
 [envs.e2e-ci]
@@ -60,14 +56,10 @@ pre-install-commands = [
 ]
 
 [[envs.e2e-ci.matrix]]
-unreal = ["5.7"]
 python = ["3.11"]
 
-[envs.e2e-ci.env-vars]
-UE_VERSION = "{matrix:unreal}"
-
 [envs.e2e-ci.scripts]
-setup = "python ./pipeline/setup-runner.py --versions {matrix:unreal}"
+setup = "python ./pipeline/setup-runner.py --versions {env:UE_VERSION:5.7}"
 e2e = "pytest --no-cov {args:test/end_to_end/test_create_job.py} -vvv --numprocesses=1 --nobuild"
 worker = "pytest --no-cov {args:test/end_to_end/test_worker_agent.py} -vvv --numprocesses=1 --nobuild --deselect test/end_to_end/test_worker_agent.py::test_create_job_with_worker_agent"
 

--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-"""Setup runner for Unreal Engine integration tests in CodeBuild.
+"""Setup runner for Unreal Engine tests in CodeBuild.
 
-Installs UE 5.7 full SDK on Windows from a zip in S3, along with all
-build dependencies (VS Build Tools, .NET Framework SDK, .NET SDK 8.0).
+Installs supported Unreal Engine versions on Windows from immutable zip
+artifacts in S3, along with the build dependencies required by the plugin.
 
 Follows the same pattern as deadline-cloud-for-cinema-4d and
 deadline-cloud-for-maya setup runners.
@@ -15,6 +15,7 @@ Environment variables required:
 
 import argparse
 import hashlib
+import json
 import os
 import platform
 import shutil
@@ -26,20 +27,49 @@ import boto3
 from botocore.config import Config
 
 UE_INSTALLERS = {
+    "5.6": {
+        "windows": {
+            "s3_key": "unrealengine/ci-source-artifacts/v1/5.6/UnrealEngine_5.6_Win.zip",
+            "sha256": "9e5c184d4d929498d97d5d5703747c0e295e573cca884928d04e4d45cfceb5c2",
+            "size": 11230461116,
+            "archive_root": "UE_5.6",
+            "type": "zip",
+        },
+    },
     "5.7": {
         "windows": {
-            "s3_key": "unrealengine/5/UnrealEngine_5.7_FullSDK_Win.zip",
-            "sha256": "",
+            "s3_key": "unrealengine/ci-source-artifacts/v1/5.7/UnrealEngine_5.7_Win.zip",
+            "sha256": "0a87923ed5bc9915c0225333c7644de379e8a118fef9f240b5e31f7fe814f640",
+            "size": 12209071317,
+            "archive_root": "UE_5.7",
+            "type": "zip",
+        },
+    },
+    "5.8": {
+        "windows": {
+            "s3_key": "unrealengine/ci-source-artifacts/v1/5.8/UnrealEngine_5.8_Win.zip",
+            "sha256": "4402b37df38fdb0d5df7c10a6de8bf212aa56ca82f9a4dded61132d49852f5c8",
+            "size": 13425863018,
+            "archive_root": "UE_5.8",
             "type": "zip",
         },
     },
 }
 
 UE_INSTALL_PATHS = {
+    "5.6": {
+        "windows": Path("C:/Program Files/Epic Games/UE_5.6"),
+    },
     "5.7": {
         "windows": Path("C:/Program Files/Epic Games/UE_5.7"),
     },
+    "5.8": {
+        "windows": Path("C:/Program Files/Epic Games/UE_5.8"),
+    },
 }
+
+INSTALL_MARKER_FILENAME = ".deadline-cloud-ci-install.json"
+LEGACY_INSTALL_MARKER_FILENAME = ".installed"
 
 
 def run(cmd, check=True):
@@ -75,11 +105,15 @@ def download_from_s3(s3_path, local_path):
     s3.download_file(bucket, s3_path, str(local_path), ExtraArgs=extra_args)
 
 
-def verify_checksum(file_path, expected_checksum):
-    """Verify SHA256 checksum of downloaded file."""
-    if not expected_checksum:
-        print(f"WARNING: No checksum configured for {file_path}, skipping verification")
-        return
+def verify_artifact(file_path, expected_checksum, expected_size):
+    """Verify the downloaded artifact's size and SHA256 checksum."""
+    actual_size = file_path.stat().st_size
+    if actual_size != expected_size:
+        raise RuntimeError(
+            f"Artifact size mismatch for {file_path}: "
+            f"expected {expected_size}, got {actual_size}"
+        )
+
     print(f"Verifying checksum for {file_path}...")
     sha256 = hashlib.sha256()
     with open(file_path, "rb") as f:
@@ -87,11 +121,120 @@ def verify_checksum(file_path, expected_checksum):
             sha256.update(chunk)
     actual = sha256.hexdigest()
     if actual != expected_checksum:
-        print("ERROR: Checksum mismatch!")
-        print(f"  Expected: {expected_checksum}")
-        print(f"  Actual:   {actual}")
-        sys.exit(1)
+        raise RuntimeError(
+            f"SHA256 mismatch for {file_path}: expected {expected_checksum}, got {actual}"
+        )
     print("OK Checksum verified")
+
+
+def expected_install_marker(version, installer_info):
+    """Return the marker content that identifies an exact engine artifact."""
+    return {
+        "version": version,
+        "s3_key": installer_info["s3_key"],
+        "sha256": installer_info["sha256"],
+        "size": installer_info["size"],
+    }
+
+
+def install_is_current(install_dir, version, installer_info):
+    """Return whether install_dir contains the exact configured engine artifact."""
+    editor_exe = install_dir / "Engine" / "Binaries" / "Win64" / "UnrealEditor-Cmd.exe"
+    marker_path = install_dir / INSTALL_MARKER_FILENAME
+    if not editor_exe.exists() or not marker_path.exists():
+        return False
+
+    try:
+        actual_marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+
+    return actual_marker == expected_install_marker(version, installer_info)
+
+
+def write_install_marker(install_dir, version, installer_info):
+    """Record the immutable artifact used to populate install_dir."""
+    marker_path = install_dir / INSTALL_MARKER_FILENAME
+    marker_path.write_text(
+        json.dumps(expected_install_marker(version, installer_info), indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def install_is_ci_managed(install_dir):
+    """Return whether an install was created by this setup runner."""
+    return any(
+        (install_dir / marker).exists()
+        for marker in (INSTALL_MARKER_FILENAME, LEGACY_INSTALL_MARKER_FILENAME)
+    )
+
+
+def cleanup_stale_version_artifacts(version, local_installer, staging_dir):
+    """Remove temporary files left by previous artifacts for one engine version."""
+    stale_paths = [
+        *local_installer.parent.glob(f"UE_{version}_*.zip"),
+        *staging_dir.parent.glob(f"UE_{version}_*"),
+    ]
+    for stale_path in stale_paths:
+        if stale_path in (local_installer, staging_dir):
+            continue
+        print(f"Removing stale UE {version} setup artifact: {stale_path}")
+        if stale_path.is_dir():
+            shutil.rmtree(stale_path)
+        else:
+            stale_path.unlink(missing_ok=True)
+
+
+def replace_ci_managed_install(staged_install_dir, install_dir):
+    """Move a staged engine into place without deleting an unmanaged installation."""
+    install_dir.parent.mkdir(parents=True, exist_ok=True)
+    if install_dir.exists():
+        if not install_is_ci_managed(install_dir):
+            raise RuntimeError(
+                f"Refusing to replace unmanaged Unreal Engine install at {install_dir}. "
+                "Move or remove it before running CI setup."
+            )
+        print(f"Replacing incomplete or outdated UE install at {install_dir}")
+        shutil.rmtree(install_dir)
+    shutil.move(str(staged_install_dir), str(install_dir))
+
+
+def install_engine_artifact(version, install_dir, installer_info):
+    """Download, verify, stage, and install one Unreal Engine artifact."""
+    local_installer = Path(f"C:/Temp/UnrealCI/UE_{version}_{installer_info['sha256'][:12]}.zip")
+    staging_dir = Path(f"C:/UnrealCI/engine-staging/UE_{version}_{installer_info['sha256'][:12]}")
+    local_installer.parent.mkdir(parents=True, exist_ok=True)
+    staging_dir.parent.mkdir(parents=True, exist_ok=True)
+    cleanup_stale_version_artifacts(version, local_installer, staging_dir)
+
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+
+    try:
+        download_from_s3(installer_info["s3_key"], local_installer)
+        verify_artifact(local_installer, installer_info["sha256"], installer_info["size"])
+
+        staging_dir.mkdir()
+        print(f"Extracting to {staging_dir} (this may take 10-15 minutes)...")
+        extract_zip(local_installer, staging_dir)
+        local_installer.unlink(missing_ok=True)
+
+        staged_install_dir = staging_dir / installer_info["archive_root"]
+        staged_editor = (
+            staged_install_dir / "Engine" / "Binaries" / "Win64" / "UnrealEditor-Cmd.exe"
+        )
+        if not staged_editor.exists():
+            contents = [item.name for item in sorted(staging_dir.iterdir())[:10]]
+            raise RuntimeError(
+                f"UnrealEditor-Cmd.exe not found at {staged_editor}. "
+                f"Staging contents: {contents}"
+            )
+
+        write_install_marker(staged_install_dir, version, installer_info)
+        replace_ci_managed_install(staged_install_dir, install_dir)
+    finally:
+        local_installer.unlink(missing_ok=True)
+        shutil.rmtree(staging_dir, ignore_errors=True)
 
 
 def ensure_7zip():
@@ -130,16 +273,30 @@ def ensure_vs_buildtools():
     - .NET Framework 4.8.1 SDK
     - .NET development prerequisites
     """
-    msvc_path = Path("C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/MSVC")
-    if msvc_path.exists() and any(msvc_path.iterdir()):
-        # Check if .NET Framework SDK is also present
-        netfx_path = Path(
-            "C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools"
-            "/MSBuild/Microsoft/Microsoft.NET.Build.Extensions"
+    build_tools_root = Path("C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools")
+    msvc_path = build_tools_root / "VC" / "Tools" / "MSVC"
+    msbuild_path = build_tools_root / "MSBuild" / "Current" / "Bin" / "MSBuild.exe"
+    kits_bin = Path("C:/Program Files (x86)/Windows Kits/10/bin")
+    netfx_path = Path("C:/Program Files (x86)/Windows Kits/NETFXSDK")
+
+    def required_components_exist():
+        sdk_tool_dirs = kits_bin.glob("*/x64") if kits_bin.exists() else []
+        has_windows_sdk = any(
+            (tool_dir / "rc.exe").exists() and (tool_dir / "signtool.exe").exists()
+            for tool_dir in sdk_tool_dirs
         )
-        if netfx_path.exists():
-            print("VS Build Tools already installed with all required components")
-            return
+        return (
+            msvc_path.exists()
+            and any(msvc_path.iterdir())
+            and msbuild_path.exists()
+            and has_windows_sdk
+            and netfx_path.exists()
+            and any(netfx_path.iterdir())
+        )
+
+    if required_components_exist():
+        print("VS Build Tools already installed with all required components")
+        return
 
     print("Installing Visual Studio Build Tools 2022...")
     installer_path = Path("C:/Temp/vs_buildtools.exe")
@@ -170,11 +327,31 @@ def ensure_vs_buildtools():
         ]
     )
 
-    if not msvc_path.exists():
-        print("ERROR: VS Build Tools installation failed")
-        sys.exit(1)
+    if not required_components_exist():
+        raise RuntimeError("VS Build Tools installation did not provide all required components")
 
     print("VS Build Tools installed successfully")
+
+
+def configure_unreal_build_tool():
+    """Disable Unreal Build Accelerator for deterministic headless CI builds."""
+    app_data = os.environ.get("APPDATA")
+    if not app_data:
+        raise RuntimeError("APPDATA is required to configure UnrealBuildTool")
+
+    config_path = Path(app_data) / "Unreal Engine" / "UnrealBuildTool" / "BuildConfiguration.xml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        """<?xml version="1.0" encoding="utf-8"?>
+<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
+  <BuildConfiguration>
+    <bAllowUBAExecutor>false</bAllowUBAExecutor>
+  </BuildConfiguration>
+</Configuration>
+""",
+        encoding="utf-8",
+    )
+    print(f"Disabled Unreal Build Accelerator in {config_path}")
 
 
 def extract_zip(zip_path, dest_dir):
@@ -249,39 +426,19 @@ def setup_windows(versions):
     """Install Unreal Engine and build dependencies on Windows."""
     # Install build tools first (needed for plugin compilation)
     ensure_vs_buildtools()
+    configure_unreal_build_tool()
 
     for version in versions:
         install_dir = UE_INSTALL_PATHS[version]["windows"]
-        marker = install_dir / ".installed"
-        editor_exe = install_dir / "Engine" / "Binaries" / "Win64" / "UnrealEditor-Cmd.exe"
+        installer_info = UE_INSTALLERS[version]["windows"]
 
-        if marker.exists() and editor_exe.exists():
+        if install_is_current(install_dir, version, installer_info):
             print(f"UE {version} already installed at {install_dir}")
             ensure_ue_python_dependencies(install_dir)
             continue
 
         print(f"Installing UE {version}...")
-        installer_info = UE_INSTALLERS[version]["windows"]
-        local_installer = Path(f"C:/Temp/UE_{version}_installer.zip")
-        local_installer.parent.mkdir(parents=True, exist_ok=True)
-
-        download_from_s3(installer_info["s3_key"], local_installer)
-        verify_checksum(local_installer, installer_info["sha256"])
-
-        install_dir.mkdir(parents=True, exist_ok=True)
-        print(f"Extracting to {install_dir} (this may take 10-15 minutes)...")
-        extract_zip(local_installer, install_dir)
-
-        # Clean up installer zip
-        local_installer.unlink(missing_ok=True)
-
-        # Verify
-        if not editor_exe.exists():
-            print(f"ERROR: UnrealEditor-Cmd.exe not found at {editor_exe}")
-            print("Contents of install dir:")
-            for item in sorted(install_dir.iterdir())[:10]:
-                print(f"  {item.name}")
-            sys.exit(1)
+        install_engine_artifact(version, install_dir, installer_info)
 
         # Clear AutomationTool runtime cache (logs from previous runs)
         for cache_dir in [
@@ -297,7 +454,6 @@ def setup_windows(versions):
             if uat_cache.exists():
                 shutil.rmtree(uat_cache, ignore_errors=True)
 
-        marker.touch()
         ensure_ue_python_dependencies(install_dir)
         print(f"UE {version} installed successfully at {install_dir}")
 
@@ -308,7 +464,7 @@ if __name__ == "__main__":
         "--versions",
         nargs="+",
         required=True,
-        help="UE versions to install (e.g., 5.7)",
+        help="UE versions to install (e.g., 5.6 5.7 5.8)",
     )
     args = parser.parse_args()
 

--- a/scripts/ci/run_unreal_ci_matrix.ps1
+++ b/scripts/ci/run_unreal_ci_matrix.ps1
@@ -109,14 +109,12 @@ function Clear-CmfTestWorkers {
 
 Push-Location $SourceRoot
 try {
-    $setupArgs = @(
-        (Join-Path $SourceRoot "pipeline\setup-runner.py"),
-        "--versions"
-    ) + $Versions
+    $env:UE_VERSION = $Versions -join " "
+    $setupEnvironment = if ($Suite -eq "e2e") { "e2e-ci" } else { "integ-ci" }
     Invoke-Checked `
         -Description "Unreal Engine setup for versions $($Versions -join ', ')" `
-        -FilePath "python" `
-        -ArgumentList $setupArgs
+        -FilePath "hatch" `
+        -ArgumentList @("run", "${setupEnvironment}:setup")
 
     foreach ($version in $Versions) {
         Write-Host "=== BEGIN UE $version $($Suite.ToUpperInvariant()) ==="

--- a/scripts/ci/run_unreal_ci_matrix.ps1
+++ b/scripts/ci/run_unreal_ci_matrix.ps1
@@ -1,0 +1,208 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("integration", "e2e")]
+    [string]$Suite,
+
+    [string]$SourceRoot = $env:CODEBUILD_SRC_DIR,
+
+    [string[]]$Versions = @()
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+if (-not $SourceRoot) {
+    throw "SourceRoot is required"
+}
+
+if ($Versions.Count -eq 0) {
+    $Versions = if ($env:UE_VERSIONS) {
+        @($env:UE_VERSIONS -split "[,;\s]+" | Where-Object { $_ })
+    }
+    else {
+        @("5.6", "5.7", "5.8")
+    }
+}
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Description,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [string[]]$ArgumentList = @()
+    )
+
+    Write-Host "Running: $Description"
+    & $FilePath @ArgumentList
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Description failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Clear-CmfTestWorkers {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FarmId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$FleetId
+    )
+
+    $workers = & aws deadline list-workers `
+        --farm-id $FarmId `
+        --fleet-id $FleetId `
+        --region $env:AWS_REGION | ConvertFrom-Json
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to list existing workers for CMF fleet $FleetId"
+    }
+
+    $workersToRemove = @($workers.workers)
+    foreach ($worker in $workersToRemove) {
+        Write-Host "Removing prior CMF test worker $($worker.workerId) ($($worker.status))"
+        if ($worker.status -ne "STOPPED") {
+            & aws deadline update-worker `
+                --farm-id $FarmId `
+                --fleet-id $FleetId `
+                --worker-id $worker.workerId `
+                --status STOPPED `
+                --region $env:AWS_REGION
+            if ($LASTEXITCODE -ne 0) {
+                throw "Unable to stop prior CMF test worker $($worker.workerId)"
+            }
+        }
+
+        & aws deadline delete-worker `
+            --farm-id $FarmId `
+            --fleet-id $FleetId `
+            --worker-id $worker.workerId `
+            --region $env:AWS_REGION
+        if ($LASTEXITCODE -ne 0) {
+            throw "Unable to delete prior CMF test worker $($worker.workerId)"
+        }
+    }
+
+    if ($workersToRemove.Count -eq 0) {
+        return
+    }
+
+    for ($attempt = 1; $attempt -le 12; $attempt++) {
+        Start-Sleep -Seconds 5
+        $remaining = & aws deadline list-workers `
+            --farm-id $FarmId `
+            --fleet-id $FleetId `
+            --region $env:AWS_REGION | ConvertFrom-Json
+        if ($LASTEXITCODE -ne 0) {
+            throw "Unable to verify worker cleanup for CMF fleet $FleetId"
+        }
+        if (@($remaining.workers).Count -eq 0) {
+            Write-Host "CMF worker records are empty; waiting for fleet capacity to propagate"
+            Start-Sleep -Seconds 10
+            return
+        }
+    }
+
+    throw "Timed out waiting for CMF worker cleanup in fleet $FleetId"
+}
+
+Push-Location $SourceRoot
+try {
+    $setupArgs = @(
+        (Join-Path $SourceRoot "pipeline\setup-runner.py"),
+        "--versions"
+    ) + $Versions
+    Invoke-Checked `
+        -Description "Unreal Engine setup for versions $($Versions -join ', ')" `
+        -FilePath "python" `
+        -ArgumentList $setupArgs
+
+    foreach ($version in $Versions) {
+        Write-Host "=== BEGIN UE $version $($Suite.ToUpperInvariant()) ==="
+        $env:UE_VERSION = $version
+
+        $buildArgs = @(
+            (Join-Path $SourceRoot "scripts\build_plugin.py"),
+            "--ueversion=$version",
+            "--install",
+            "--test"
+        )
+        if ($Suite -eq "e2e") {
+            $buildArgs += "--worker"
+        }
+        Invoke-Checked `
+            -Description "Build and install the plugin for UE $version" `
+            -FilePath "python" `
+            -ArgumentList $buildArgs
+
+        if ($Suite -eq "integration") {
+            Invoke-Checked `
+                -Description "Integration tests for UE $version" `
+                -FilePath "hatch" `
+                -ArgumentList @(
+                    "run",
+                    "integ-ci:integ",
+                    "--",
+                    "test/integ",
+                    "--ueversion=$version"
+                )
+
+            if ($env:RUN_UI_AUTOMATION -eq "true") {
+                Invoke-Checked `
+                    -Description "Offline Unreal automation tests for UE $version" `
+                    -FilePath "powershell.exe" `
+                    -ArgumentList @(
+                        "-NoProfile",
+                        "-ExecutionPolicy",
+                        "Bypass",
+                        "-File",
+                        (Join-Path $SourceRoot "scripts\ci\run_unreal_automation_tests.ps1"),
+                        "-SourceRoot",
+                        $SourceRoot,
+                        "-UEVersion",
+                        $version
+                    )
+            }
+        }
+        else {
+            foreach ($requiredVariable in @(
+                "FARM_ID",
+                "UNREAL_WORKER_QUEUE_ID",
+                "UNREAL_WORKER_FLEET_ID"
+            )) {
+                if (-not (Get-Item "Env:\$requiredVariable" -ErrorAction SilentlyContinue).Value) {
+                    throw "$requiredVariable is required for CMF worker-agent tests"
+                }
+            }
+
+            Clear-CmfTestWorkers `
+                -FarmId $env:FARM_ID `
+                -FleetId $env:UNREAL_WORKER_FLEET_ID
+
+            $workerState = Join-Path $SourceRoot "worker-agent-state"
+            Remove-Item $workerState -Recurse -Force -ErrorAction SilentlyContinue
+
+            Invoke-Checked `
+                -Description "CMF worker-agent tests for UE $version" `
+                -FilePath "hatch" `
+                -ArgumentList @(
+                    "run",
+                    "e2e-ci:worker",
+                    "--",
+                    "test/end_to_end/test_worker_agent.py",
+                    "--ueversion=$version",
+                    "--farm-id",
+                    $env:FARM_ID,
+                    "--queue-id",
+                    $env:UNREAL_WORKER_QUEUE_ID,
+                    "-s"
+                )
+        }
+
+        Write-Host "=== END UE $version $($Suite.ToUpperInvariant()) ==="
+    }
+}
+finally {
+    Pop-Location
+}

--- a/test/test_setup_runner.py
+++ b/test/test_setup_runner.py
@@ -91,30 +91,6 @@ def test_replace_ci_managed_install_refuses_unmanaged_directory(tmp_path):
     assert (install_dir / "engine.txt").exists()
 
 
-def test_install_engine_artifact_cleans_partial_download_on_failure(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    installer = {
-        "s3_key": "unrealengine/ci-source-artifacts/v1/5.7/engine.zip",
-        "sha256": "1" * 64,
-        "size": 4,
-        "archive_root": "UE_5.7",
-    }
-
-    def fake_download(_s3_key, local_installer):
-        local_installer.write_bytes(b"test")
-
-    def fail_verification(*_args):
-        raise RuntimeError("checksum failed")
-
-    monkeypatch.setattr(setup_runner, "download_from_s3", fake_download)
-    monkeypatch.setattr(setup_runner, "verify_artifact", fail_verification)
-
-    with pytest.raises(RuntimeError, match="checksum failed"):
-        setup_runner.install_engine_artifact("5.7", tmp_path / "install", installer)
-
-    assert not list((tmp_path / "C:" / "Temp" / "UnrealCI").glob("*.zip"))
-
-
 def test_verify_artifact_checks_size_and_sha256(tmp_path):
     artifact = tmp_path / "engine.zip"
     content = b"test artifact"

--- a/test/test_setup_runner.py
+++ b/test/test_setup_runner.py
@@ -1,0 +1,141 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import hashlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SETUP_RUNNER_PATH = Path(__file__).parents[1] / "pipeline" / "setup-runner.py"
+SPEC = importlib.util.spec_from_file_location("unreal_setup_runner", SETUP_RUNNER_PATH)
+assert SPEC and SPEC.loader
+setup_runner = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(setup_runner)
+
+
+def test_supported_installers_are_immutable_ci_artifacts():
+    assert set(setup_runner.UE_INSTALLERS) == {"5.6", "5.7", "5.8"}
+
+    for version, platforms in setup_runner.UE_INSTALLERS.items():
+        installer = platforms["windows"]
+        assert installer["s3_key"].startswith(f"unrealengine/ci-source-artifacts/v1/{version}/")
+        assert len(installer["sha256"]) == 64
+        assert installer["size"] > 0
+        assert installer["archive_root"] == f"UE_{version}"
+
+
+def test_install_marker_requires_exact_artifact(tmp_path):
+    version = "5.7"
+    installer = setup_runner.UE_INSTALLERS[version]["windows"]
+    editor = tmp_path / "Engine" / "Binaries" / "Win64" / "UnrealEditor-Cmd.exe"
+    editor.parent.mkdir(parents=True)
+    editor.touch()
+
+    assert not setup_runner.install_is_current(tmp_path, version, installer)
+
+    setup_runner.write_install_marker(tmp_path, version, installer)
+    assert setup_runner.install_is_current(tmp_path, version, installer)
+    assert setup_runner.install_is_ci_managed(tmp_path)
+
+    changed_installer = {**installer, "sha256": "0" * 64}
+    assert not setup_runner.install_is_current(tmp_path, version, changed_installer)
+
+
+def test_cleanup_stale_version_artifacts_preserves_current_and_other_versions(tmp_path):
+    download_dir = tmp_path / "downloads"
+    staging_root = tmp_path / "staging"
+    download_dir.mkdir()
+    staging_root.mkdir()
+
+    current_installer = download_dir / "UE_5.7_current.zip"
+    stale_installer = download_dir / "UE_5.7_old.zip"
+    other_installer = download_dir / "UE_5.8_old.zip"
+    current_staging = staging_root / "UE_5.7_current"
+    stale_staging = staging_root / "UE_5.7_old"
+    other_staging = staging_root / "UE_5.8_old"
+    for path in (current_installer, stale_installer, other_installer):
+        path.touch()
+    for path in (current_staging, stale_staging, other_staging):
+        path.mkdir()
+
+    setup_runner.cleanup_stale_version_artifacts("5.7", current_installer, current_staging)
+
+    assert current_installer.exists()
+    assert current_staging.exists()
+    assert not stale_installer.exists()
+    assert not stale_staging.exists()
+    assert other_installer.exists()
+    assert other_staging.exists()
+
+
+def test_replace_ci_managed_install_refuses_unmanaged_directory(tmp_path):
+    install_dir = tmp_path / "UE_5.7"
+    staged_install = tmp_path / "staging" / "UE_5.7"
+    install_dir.mkdir()
+    staged_install.mkdir(parents=True)
+    unmanaged_file = install_dir / "custom-plugin.txt"
+    staged_file = staged_install / "engine.txt"
+    unmanaged_file.touch()
+    staged_file.touch()
+
+    with pytest.raises(RuntimeError, match="unmanaged Unreal Engine install"):
+        setup_runner.replace_ci_managed_install(staged_install, install_dir)
+
+    assert unmanaged_file.exists()
+    assert staged_file.exists()
+
+    (install_dir / setup_runner.LEGACY_INSTALL_MARKER_FILENAME).touch()
+    setup_runner.replace_ci_managed_install(staged_install, install_dir)
+
+    assert not unmanaged_file.exists()
+    assert (install_dir / "engine.txt").exists()
+
+
+def test_install_engine_artifact_cleans_partial_download_on_failure(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    installer = {
+        "s3_key": "unrealengine/ci-source-artifacts/v1/5.7/engine.zip",
+        "sha256": "1" * 64,
+        "size": 4,
+        "archive_root": "UE_5.7",
+    }
+
+    def fake_download(_s3_key, local_installer):
+        local_installer.write_bytes(b"test")
+
+    def fail_verification(*_args):
+        raise RuntimeError("checksum failed")
+
+    monkeypatch.setattr(setup_runner, "download_from_s3", fake_download)
+    monkeypatch.setattr(setup_runner, "verify_artifact", fail_verification)
+
+    with pytest.raises(RuntimeError, match="checksum failed"):
+        setup_runner.install_engine_artifact("5.7", tmp_path / "install", installer)
+
+    assert not list((tmp_path / "C:" / "Temp" / "UnrealCI").glob("*.zip"))
+
+
+def test_verify_artifact_checks_size_and_sha256(tmp_path):
+    artifact = tmp_path / "engine.zip"
+    content = b"test artifact"
+    artifact.write_bytes(content)
+    checksum = hashlib.sha256(content).hexdigest()
+
+    setup_runner.verify_artifact(artifact, checksum, len(content))
+
+    with pytest.raises(RuntimeError, match="size mismatch"):
+        setup_runner.verify_artifact(artifact, checksum, len(content) + 1)
+
+    with pytest.raises(RuntimeError, match="SHA256 mismatch"):
+        setup_runner.verify_artifact(artifact, "0" * 64, len(content))
+
+
+def test_configure_unreal_build_tool_disables_uba(tmp_path, monkeypatch):
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+
+    setup_runner.configure_unreal_build_tool()
+
+    config = (tmp_path / "Unreal Engine" / "UnrealBuildTool" / "BuildConfiguration.xml").read_text(
+        encoding="utf-8"
+    )
+    assert "<bAllowUBAExecutor>false</bAllowUBAExecutor>" in config


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)

The CodeBuild integration and CMF worker-agent suites need to validate every supported Unreal Engine version. The existing setup runner only installs UE 5.7 from a single FullSDK artifact and the CI commands only exercise one engine version.

This change must land before the dependent CDK rollout starts invoking the matrix script.

### What was the solution? (How)

- Add immutable UE 5.6, 5.7, and 5.8 CI artifact metadata, including size and SHA256 verification.
- Verify the required Visual Studio, MSBuild, Windows SDK, and .NET Framework SDK components and disable Unreal Build Accelerator for deterministic headless builds.
- Add a PowerShell matrix runner that installs the requested versions once, then builds the plugin and runs integration or CMF worker-agent E2E tests sequentially for each version.

### What is the impact of this change?

CI can validate UE 5.6, 5.7, and 5.8 on the persistent Windows CodeBuild fleet. Existing engine installations are reused only when their artifact marker matches the configured immutable artifact. This does not change public submitter or adaptor behavior.

### How was this change tested?

- UE 5.6, 5.7, and 5.8 tests passed in both integ/e2e remote runs.

### Have you run a render job successfully with these changes?

Yes. The CMF worker-agent E2E suite completed successfully for UE 5.6, 5.7, and 5.8.

### Was this change documented?

NA

### Is this a breaking change?

No.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
