### PR TITLE
fix: cleanup of read-only Unreal install files

### DIFF
--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -19,6 +19,7 @@ import json
 import os
 import platform
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -169,6 +170,14 @@ def install_is_ci_managed(install_dir):
     )
 
 
+def remove_readonly(func, path, exc_info):
+    """Clear a Windows read-only attribute and retry a failed removal."""
+    if not isinstance(exc_info[1], PermissionError) or func not in (os.unlink, os.rmdir):
+        raise exc_info[1]
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
+
+
 def cleanup_stale_version_artifacts(version, local_installer, staging_dir):
     """Remove temporary files left by previous artifacts for one engine version."""
     stale_paths = [
@@ -180,7 +189,7 @@ def cleanup_stale_version_artifacts(version, local_installer, staging_dir):
             continue
         print(f"Removing stale UE {version} setup artifact: {stale_path}")
         if stale_path.is_dir():
-            shutil.rmtree(stale_path)
+            shutil.rmtree(stale_path, onerror=remove_readonly)
         else:
             stale_path.unlink(missing_ok=True)
 
@@ -195,7 +204,7 @@ def replace_ci_managed_install(staged_install_dir, install_dir):
                 "Move or remove it before running CI setup."
             )
         print(f"Replacing incomplete or outdated UE install at {install_dir}")
-        shutil.rmtree(install_dir)
+        shutil.rmtree(install_dir, onerror=remove_readonly)
     shutil.move(str(staged_install_dir), str(install_dir))
 
 
@@ -208,7 +217,7 @@ def install_engine_artifact(version, install_dir, installer_info):
     cleanup_stale_version_artifacts(version, local_installer, staging_dir)
 
     if staging_dir.exists():
-        shutil.rmtree(staging_dir)
+        shutil.rmtree(staging_dir, onerror=remove_readonly)
 
     try:
         download_from_s3(installer_info["s3_key"], local_installer)


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)

CI failed with `WinError 5` when replacing an Unreal installation containing read-only files.

### What was the solution? (How)

Clear the read-only attribute and retry failed removals for CI-managed installs and staging directories.

### What is the impact of this change?

CI can replace or update Unreal installations; unrelated behavior is unchanged.

### How was this change tested?

`python3 -m py_compile pipeline/setup-runner.py` and `hatch run style pipeline/setup-runner.py`.

### Have you run a render job successfully with these changes?

N/A - this only changes CI setup cleanup.

### Was this change documented?

N/A - this is an internal CI implementation fix; the helper includes a docstring.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*