### PR TITLE
fix: recover CodeBuild Unreal installs

### DIFF
--- a/pipeline/setup-runner.py
+++ b/pipeline/setup-runner.py
@@ -198,7 +198,10 @@ def replace_ci_managed_install(staged_install_dir, install_dir):
     """Move a staged engine into place without deleting an unmanaged installation."""
     install_dir.parent.mkdir(parents=True, exist_ok=True)
     if install_dir.exists():
-        if not install_is_ci_managed(install_dir):
+        is_configured_codebuild_install = bool(os.environ.get("CODEBUILD_BUILD_ID")) and (
+            install_dir in {paths["windows"] for paths in UE_INSTALL_PATHS.values()}
+        )
+        if not install_is_ci_managed(install_dir) and not is_configured_codebuild_install:
             raise RuntimeError(
                 f"Refusing to replace unmanaged Unreal Engine install at {install_dir}. "
                 "Move or remove it before running CI setup."


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)

A failed engine cleanup removed its CI marker, causing persistent CodeBuild hosts to reject the remaining installation as unmanaged.

### What was the solution? (How)

When `CODEBUILD_BUILD_ID` is set, paths configured in `UE_INSTALL_PATHS` are treated as CI-owned even if their marker was lost, allowing setup to replace the partial installation. Outside CodeBuild, the marker is still required, so developer or Launcher installations are not deleted.

### What is the impact of this change?

Affected CodeBuild hosts recover on their next run and future marker loss does not permanently block CI.

### How was this change tested?

`hatch run style pipeline/setup-runner.py` and `hatch run python -m pytest test/test_setup_runner.py --no-cov -q` (6 passed).

### Have you run a render job successfully with these changes?

N/A - this only changes CI setup recovery.

### Was this change documented?

N/A - internal CI behavior only.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*