### PR TITLE
fix: prepare Unreal 5.8 release defaults

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -46,7 +46,7 @@ pre-install-commands = [
 python = ["3.11"]
 
 [envs.integ-ci.scripts]
-setup = "python ./pipeline/setup-runner.py --versions {env:UE_VERSION:5.7}"
+setup = "python ./pipeline/setup-runner.py --versions {env:UE_VERSION:5.8}"
 integ = "pytest --no-cov {args:test/integ} -vvv --numprocesses=1 --nobuild"
 
 [envs.e2e-ci]
@@ -59,7 +59,7 @@ pre-install-commands = [
 python = ["3.11"]
 
 [envs.e2e-ci.scripts]
-setup = "python ./pipeline/setup-runner.py --versions {env:UE_VERSION:5.7}"
+setup = "python ./pipeline/setup-runner.py --versions {env:UE_VERSION:5.8}"
 e2e = "pytest --no-cov {args:test/end_to_end/test_create_job.py} -vvv --numprocesses=1 --nobuild"
 worker = "pytest --no-cov {args:test/end_to_end/test_worker_agent.py} -vvv --numprocesses=1 --nobuild --deselect test/end_to_end/test_worker_agent.py::test_create_job_with_worker_agent"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ fail_under = 65
 [tool.semantic_release]
 # Can be removed or set to true once we are v1
 major_on_zero = false
+allow_zero_version = true
 tag_format = "{version}"
 
 [tool.semantic_release.commit_parser_options]

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,2 @@
 python-semantic-release == 10.6.*
+gitpython < 3.1.60

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -61,8 +61,8 @@ def find_unreal_engine(folder: str, version: Optional[str] = None) -> str:
     if version:
         check_version = version
     else:
-        # Default to 5.7 if no other versions are found
-        check_version = "5.7"
+        # Default to 5.8 if no other versions are found
+        check_version = "5.8"
         for subfolder in os.listdir(folder):
             if subfolder.startswith("UE_"):
                 version = subfolder.split("_")[1]

--- a/scripts/ci/run_unreal_automation_tests.ps1
+++ b/scripts/ci/run_unreal_automation_tests.ps1
@@ -13,7 +13,7 @@ $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
 if (-not $UEVersion) {
-    $UEVersion = if ($env:UE_VERSION) { $env:UE_VERSION } else { "5.7" }
+    $UEVersion = if ($env:UE_VERSION) { $env:UE_VERSION } else { "5.8" }
 }
 if (-not $EngineRoot) {
     $EngineRoot = "C:\Program Files\Epic Games\UE_$UEVersion"

--- a/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step_host_requirements.py
+++ b/src/deadline/unreal_submitter/unreal_open_job/unreal_open_job_step_host_requirements.py
@@ -19,7 +19,7 @@ DEFAULT_HOST_REQUIREMENTS: dict[str, list[Any]] = {
         {"name": "amount.worker.disk.scratch", "min": 16},
     ],
     "attributes": [
-        {"name": "attr.worker.os.family", "anyOf": ["windows", "linux", "macos"]},
+        {"name": "attr.worker.os.family", "anyOf": ["windows"]},
         {"name": "attr.worker.cpu.arch", "anyOf": ["x86_64", "arm64"]},
     ],
 }

--- a/src/unreal_plugin/Content/Python/openjd_templates/host_requirements.yml
+++ b/src/unreal_plugin/Content/Python/openjd_templates/host_requirements.yml
@@ -13,6 +13,6 @@ hostRequirements:
 
   attributes:
     - name: attr.worker.os.family
-      anyOf: [windows, linux, macos]
+      anyOf: [windows]
     - name: attr.worker.cpu.arch
       anyOf: [x86_64, arm64]


### PR DESCRIPTION
Fixes: N/A

### What was the problem/requirement? (What/Why)
Release preparation required updated Unreal defaults, Windows-only fleet routing, and a working semantic-release environment.

### What was the solution? (How)
- Updated fallback Unreal Engine versions from 5.7 to 5.8 while preserving explicit CI version selection.
- Restricted default job host requirements to Windows.
- Pinned GitPython below 3.1.60 and enabled zero-version releases so semantic-release can produce the next 0.x release. We can remove this pin once https://github.com/python-semantic-release/python-semantic-release/pull/1477 is merged

### What is the impact of this change?
Unreal 5.8 becomes the fallback, new jobs avoid unsupported operating systems, and release bumps remain functional.

### How was this change tested?
The unit suite passed with 775 tests and 2 skips; semantic-release resolved GitPython 3.1.45 and calculated version 0.7.2.

### Have you run a render job successfully with these changes?
N/A; CI still explicitly tests Unreal 5.6, 5.7, and 5.8.

### Was this change documented?
N/A; no user documentation changes are required.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
