### PR TITLE
fix: emit stack traces in adaptor error telemetry

### DIFF
--- a/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
+++ b/src/deadline/unreal_adaptor/UnrealAdaptor/adaptor.py
@@ -571,17 +571,28 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
         self, exc: Exception, exception_scope: str, exit_code: Optional[int] = None
     ) -> None:
         """
-        Record telemetry error event and raise given exception
+        Record telemetry error event with stack trace and raise given exception
         """
-        self.telemetry_client.record_error(
-            event_details={
-                "exit_code": exit_code,
-                "exception_scope": "caught",
-                "error_operation": exception_scope,
-            },
-            exception_type=str(type(exc)),
-            from_gui=False,
-        )
+        # Callers must pass an exception that has already been raised and caught,
+        # so `exc.__traceback__` is populated — the recorded stack trace is derived
+        # from it and would otherwise be empty.
+        if exc.__traceback__ is None:
+            logger.warning(
+                "Recording %s with no traceback; the emitted stack trace will be empty. "
+                "Raise and catch the exception before calling _record_error_and_raise.",
+                type(exc).__qualname__,
+            )
+        try:
+            self.telemetry_client.record_error_with_trace(
+                exc=exc,
+                exception_scope=exception_scope,
+                extra_details={
+                    "exit_code": exit_code,
+                    "error_operation": exception_scope,
+                },
+            )
+        except Exception:
+            logger.warning("Failed to record error telemetry", exc_info=True)
         raise exc
 
     def on_start(self) -> None:
@@ -649,10 +660,11 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
         :raises RuntimeError: When Unreal exited early and did not render successfully
         """
         if not self._unreal_is_running:
-            self._record_error_and_raise(
-                exc=UnrealNotRunningError("Cannot render because Unreal is not running"),
-                exception_scope="on_run",
-            )
+            # Raise and catch here so the recorded stack trace points at this frame
+            try:
+                raise UnrealNotRunningError("Cannot render because Unreal is not running")
+            except UnrealNotRunningError as e:
+                self._record_error_and_raise(exc=e, exception_scope="on_run")
 
         try:
             self.data_validation.validate_run_data(run_data)
@@ -704,14 +716,16 @@ class UnrealAdaptor(Adaptor[AdaptorConfiguration]):
         if not self._unreal_is_running and self._unreal_client:
             exit_code = self._unreal_client.returncode
             if exit_code != 0:
-                self._record_error_and_raise(
-                    exc=RuntimeError(
+                # Raise and catch here so the recorded stack trace points at this frame
+                try:
+                    raise RuntimeError(
                         "Unreal exited early and did not render successfully, please check render logs. "
                         f"Exit code {exit_code}"
-                    ),
-                    exception_scope="on_run",
-                    exit_code=exit_code,
-                )
+                    )
+                except RuntimeError as e:
+                    self._record_error_and_raise(
+                        exc=e, exception_scope="on_run", exit_code=exit_code
+                    )
 
         # Render succeeded. If the customer requested it (SubmitMode set),
         # push the outputs into the worker's Perforce client. This runs

--- a/src/deadline/unreal_submitter/submitter.py
+++ b/src/deadline/unreal_submitter/submitter.py
@@ -51,11 +51,17 @@ def error_notify(
                 unreal.log(str(e))
                 unreal.log(traceback.format_exc())
 
-                telemetry_client.record_error(
-                    event_details={"exception_scope": "caught", "error_operation": "on_submit"},
-                    exception_type=str(type(e)),
-                    from_gui=not self._silent_mode,
-                )
+                try:
+                    telemetry_client.record_error_with_trace(
+                        exc=e,
+                        exception_scope="on_submit",
+                        extra_details={
+                            "error_operation": "on_submit",
+                        },
+                        from_gui=not self._silent_mode,
+                    )
+                except Exception:
+                    logger.warning("Failed to record error telemetry", exc_info=True)
 
                 if isinstance(e, UserException):
                     return

--- a/test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py
+++ b/test/deadline_adaptor_for_unreal/unit/UnrealAdaptor/test_adaptor.py
@@ -6,6 +6,7 @@ import os
 import re
 import ast
 import sys
+import traceback
 from unittest.mock import Mock, PropertyMock, patch, mock_open
 
 import pytest
@@ -171,6 +172,91 @@ class TestUnrealAdaptor_on_start:
             str(exc_info.value)
             == "Could not find a socket path because the server did not finish initializing"
         )
+
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor.telemetry_client",
+        new_callable=PropertyMock,
+    )
+    @patch("threading.Thread")
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.AdaptorServer")
+    def test_error_emits_stack_trace_telemetry(
+        self, mock_server: Mock, mock_thread: Mock, mock_telemetry_client: Mock, init_data: dict
+    ) -> None:
+        """Tests that adaptor errors emit telemetry with stack traces via record_error_with_trace"""
+        # GIVEN
+        adaptor = UnrealAdaptor(init_data)
+        mock_tc = mock_telemetry_client.return_value
+
+        with (
+            patch.object(adaptor, "_SERVER_START_TIMEOUT_SECONDS", 0.01),
+            pytest.raises(RuntimeError),
+        ):
+            # WHEN
+            adaptor.on_start()
+
+        # THEN — record_error_with_trace is called (not record_error)
+        mock_tc.record_error_with_trace.assert_called_once()
+        call_kwargs = mock_tc.record_error_with_trace.call_args
+        assert isinstance(call_kwargs.kwargs["exc"], RuntimeError)
+        assert call_kwargs.kwargs["exception_scope"] == "on_start"
+        assert call_kwargs.kwargs["extra_details"]["error_operation"] == "on_start"
+        mock_tc.record_error.assert_not_called()
+
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor.telemetry_client",
+        new_callable=PropertyMock,
+    )
+    def test_inline_exception_still_has_traceback(
+        self, mock_telemetry_client: Mock, init_data: dict
+    ) -> None:
+        """
+        Regression: call sites that construct the exception inline (e.g. on_run's
+        UnrealNotRunningError path) must still emit a traceback naming the
+        originating frame. The traceback must be inspected at record time via a
+        side_effect — `raise` mutates `exc.__traceback__` in place, so checking
+        it after the fact passes even if recording happened before the raise.
+        """
+        # GIVEN
+        adaptor = UnrealAdaptor(init_data)
+        mock_tc = mock_telemetry_client.return_value
+        frames_at_record_time: list = []
+        mock_tc.record_error_with_trace.side_effect = (
+            lambda exc, **kw: frames_at_record_time.extend(traceback.extract_tb(exc.__traceback__))
+        )
+
+        # WHEN — on_run with _unreal_is_running False triggers the inline-exception path
+        with pytest.raises(UnrealNotRunningError):
+            adaptor.on_run({})
+
+        # THEN — the traceback recorded at call time names the originating frame
+        mock_tc.record_error_with_trace.assert_called_once()
+        assert any(frame.name == "on_run" for frame in frames_at_record_time)
+
+    @patch(
+        "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor.telemetry_client",
+        new_callable=PropertyMock,
+    )
+    @patch("threading.Thread")
+    @patch("deadline.unreal_adaptor.UnrealAdaptor.adaptor.AdaptorServer")
+    def test_telemetry_failure_does_not_mask_original_error(
+        self, mock_server: Mock, mock_thread: Mock, mock_telemetry_client: Mock, init_data: dict
+    ) -> None:
+        """Tests that if record_error_with_trace raises, the original exception is still raised"""
+        # GIVEN
+        adaptor = UnrealAdaptor(init_data)
+        mock_tc = mock_telemetry_client.return_value
+        mock_tc.record_error_with_trace.side_effect = Exception("telemetry broke")
+
+        with (
+            patch.object(adaptor, "_SERVER_START_TIMEOUT_SECONDS", 0.01),
+            pytest.raises(RuntimeError, match="server did not finish initializing"),
+        ):
+            # WHEN
+            adaptor.on_start()
+
+        # THEN — telemetry was attempted but the original RuntimeError was raised, not the
+        # telemetry Exception
+        mock_tc.record_error_with_trace.assert_called_once()
 
     @patch(
         "deadline.unreal_adaptor.UnrealAdaptor.adaptor.UnrealAdaptor.telemetry_client",
@@ -806,6 +892,14 @@ class TestUnrealAdaptor_on_run:
         mock_server.return_value.server_path = "/tmp/9999"
         adaptor.on_start()
 
+        # Capture the traceback at record time — `raise` mutates exc.__traceback__
+        # in place, so an after-the-fact assertion would pass even if the exception
+        # were recorded before being raised.
+        frames_at_record_time: list = []
+        mock_telemetry_client.return_value.record_error_with_trace.side_effect = (
+            lambda exc, **kw: frames_at_record_time.extend(traceback.extract_tb(exc.__traceback__))
+        )
+
         # WHEN
         with pytest.raises(RuntimeError) as exc_info:
             adaptor.on_run(run_data)
@@ -817,6 +911,9 @@ class TestUnrealAdaptor_on_run:
             "please check render logs. "
             "Exit code 1"
         )
+        # The exit-code exception is constructed inline, so it must be raised and
+        # caught before recording for the trace to name the originating frame.
+        assert any(frame.name == "on_run" for frame in frames_at_record_time)
 
     @patch("time.sleep")
     @patch(


### PR DESCRIPTION
What was the problem/requirement? (What/Why)

When investigating adaptor errors (on_start, on_run) from telemetry, we only had the exception type and scope — no stack trace. This made it impossible to diagnose root causes from telemetry alone. The telemetry client has record_error_with_trace() which captures sanitized stack traces, but the adaptor was using record_error() which doesn't.

What was the solution? (How)

Switch _record_error_and_raise from record_error() to record_error_with_trace(). The exception object is already available at the call site — we just weren't passing it through the trace-capturing path.

Note: this is a broader gap across other Deadline Cloud DCC adaptors (Houdini, Maya, Blender, etc.) that use the same record_error() pattern. Those should be addressed similarly in their respective repos.

What is the impact of this change?

- Adaptor error telemetry events now include sanitized stack traces
- exception_type field changes from `<class 'RuntimeError'>` to `RuntimeError` (cleaner format, derived by record_error_with_trace from the exception object)
- Same event type (com.amazon.rum.deadline.error) — no backend changes needed

How was this change tested?

- New unit test test_error_emits_stack_trace_telemetry verifies record_error_with_trace is called with the exception, scope, and operation
- All 23 existing on_start tests pass

Have you run a render job successfully with these changes?

Not required — telemetry-only change. Error handling and rendering behavior are unchanged.

Was this change documented?

No external documentation needed. Commit message notes the broader gap across other adaptors.

Is this a breaking change?

No. Same telemetry event type with an additional stack_trace field. The exception_type format changes slightly (RuntimeError vs `<class 'RuntimeError'>`).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.