### PR TITLE
chore: classify features as minor releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,11 @@ The Unreal Engine and adaptor must be manually installed on worker hosts of Cust
 
 ## Versioning
 
-This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its
-initial development, thus backwards incompatible versions are denoted by minor version bumps. To help illustrate how
-versions will increment during this initial development stage, they are described below:
+This package's version follows [Semantic Versioning 2.0](https://semver.org/). Versions increment as follows:
 
-1. The MAJOR version is currently 0, indicating initial development.
-2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API.
-3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API.
+1. The MAJOR version is incremented when backwards incompatible changes are introduced to the public API.
+2. The MINOR version is incremented when new features are introduced.
+3. The PATCH version is incremented when bug fixes or backwards compatible changes are introduced to the public API.
 
 ## Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,9 +166,9 @@ source = [
 show_missing = true
 fail_under = 65
 [tool.semantic_release]
-# Can be removed or set to true once we are v1
-major_on_zero = false
+# Keep both overrides: 0.x release and patch_.* branches must not force published 1.0.0.
 allow_zero_version = true
+major_on_zero = false
 tag_format = "{version}"
 
 [tool.semantic_release.commit_parser_options]
@@ -184,10 +184,9 @@ allowed_tags = [
     "refactor",
     "test",
 ]
-minor_tags = []
+minor_tags = ["feat"]
 patch_tags = [
   "chore",
-  "feat",
   "fix",
   "refactor",
   "perf",


### PR DESCRIPTION
## What this changes

After 1.0.0, a `feat:` commit should cut a MINOR release. Today it cuts a patch, because
`feat` sits in `patch_tags` and `minor_tags` is empty - the mapping the package used during
0.x initial development.

- `pyproject.toml`: `minor_tags = ["feat"]`, and `feat` removed from `patch_tags`.
  `fix`, `chore`, `refactor` and `perf` still map to patch; breaking changes still map to major.
- `pyproject.toml`: the two zero-version overrides (`allow_zero_version = true`,
  `major_on_zero = false`) are RETAINED, now with a comment naming why - see "0.x lanes" below.
- `README.md`: the Versioning section is rewritten for post-1.0 SemVer.

No source code changes; this commit is itself a `chore:`, so it cannot cut a minor release.

## Measured, not assumed

All version numbers below come from `semantic-release -v --strict version --print`
(python-semantic-release 10.6.2, the pinned version) run against throwaway repos, not from docs.

| branch | base tag | commit | before | after |
| --- | --- | --- | --- | --- |
| mainline | 1.0.0 | `feat: ...` | 1.0.1 | 1.1.0 |
| mainline | 1.0.0 | `fix: ...` | 1.0.1 | 1.0.1 |
| mainline | 1.0.0 | `chore:` / `perf:` | 1.0.1 | 1.0.1 |
| mainline | 1.0.0 | `refactor!: ...` | 2.0.0 | 2.0.0 |

Project commands over this exact commit: `hatch run test` 781 passed / 2 skipped,
`hatch run lint` (ruff + black + mypy) clean, `hatch build` produced sdist + wheel.

## Why the two zero-version overrides stay

`[tool.semantic_release.branches.release]` matches `(mainline|release|patch_.*)`, and those
0.x lanes still have 0.x history (`release` is at 0.5.0). Upstream defaults are
`allow_zero_version = false` and `major_on_zero = true`, so DELETING either override pushes
commits on those branches onto the ALREADY PUBLISHED 1.0.0:

- with `major_on_zero` deleted, a `feat!:` / `BREAKING CHANGE:` commit resolves to 1.0.0 on
  both `release` (0.5.0) and `patch_0.7` (0.7.0);
- with `allow_zero_version` deleted, even a plain `fix:` backport on `patch_0.7` resolves to
  1.0.0 and then hard-fails, or writes a second 1.0.0 tag onto a 0.x commit.

With both overrides in place those same probes give 0.6.0, 0.8.0 and 0.7.1 respectively.

## Caveats a reviewer should decide on, not discover later

1. The reclassification is GLOBAL. `commit_parser_options` is a single table and this version of
   python-semantic-release has no per-branch parser override, so `feat -> minor` also applies to
   the `release` and `patch_.*` lanes: a backported `feat:` on `patch_0.7` now resolves to 0.8.0
   instead of 0.7.1, leaving the very line that branch maintains. Measured control pair: new
   config 0.8.0, old config 0.7.1. If those lanes are dead in practice this is moot; if they are
   live, either drop `patch_.*` from the release group or state that features are not backportable.
2. `parse_squash_commits` is at its upstream default `true` and is not overridden here. GitHub
   squash bodies in this repo are bullet lists of conventional headers, and the parser takes the
   maximum bump across them - so a `fix:`-titled squash-merged PR with a `feat:` bullet in its body
   now cuts a minor rather than a patch. That conflicts with CONTRIBUTING.md:93-94, which only
   requires the first commit to be conventional. Zero occurrences in the last 60 mainline commits,
   so this is latent, not active. Cheapest mitigation if you want it closed:
   `parse_squash_commits = false`.
3. Ordering hazard if a `patch_1.x` lane is ever created: it and `mainline` both compute 1.1.0.
   If the patch lane tags first it takes the number and mainline's own release then fails.
   No `patch_1.*` branch exists today.
4. The README now states one universal scheme. On the 0.x lanes kept alive above, a breaking
   change still yields a minor, so scoping the wording to "from 1.0.0 onward" would keep the
   README true for the whole repo.

## Review

An independent adversarial review was run over this exact commit (not over an earlier version of
it): 0 HIGH, 3 MEDIUM, 2 LOW, verdict "safe to ship as a draft, state caveat 1 in the PR". The
MEDIUM findings are the four items above; each was reproduced by execution across 34 throwaway
repositories. Deliberately opened as a DRAFT: marking it ready and merging is the maintainer's call.
