### PR TITLE
fix: skip disabled MRQ jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.0.0 (2026-09-11)
 
 ### BREAKING CHANGES
-* The Unreal adaptor no longer supports the legacy `chunk_size` and `chunk_id` run-data keys. If you have legacy job templates or saved job bundles that use these keys, you must update them to use `shots_per_task` and `task_index` instead. This affects workers running the 1.0 adaptor: the bundled job templates in this release still pin `unrealengine-openjd=0.7.*`, which accepts both the legacy and current key names, and the pin moves to the 1.0 line in a later release once that adaptor is published to the Conda channel. (#384)
+* The Unreal adaptor no longer supports the legacy `chunk_size` and `chunk_id` run-data keys. If you have legacy job templates or saved job bundles that use these keys, you must update them to use `shots_per_task` and `task_index` instead. (#384)
 
 ### Bug Fixes
 * Adaptor and submitter error telemetry now includes sanitized stack traces, and events are grouped by the operation that raised them, so failures can be diagnosed from telemetry alone. (#380)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 1.0.0 (2026-09-11)
 
 ### BREAKING CHANGES
-* The Unreal adaptor no longer supports the legacy `chunk_size` and `chunk_id` run-data keys. If you have legacy job templates or saved job bundles that use these keys, you must update them to use `shots_per_task` and `task_index` instead. (#384)
+* The Unreal adaptor no longer supports the legacy `chunk_size` and `chunk_id` run-data keys. If you have legacy job templates or saved job bundles that use these keys, you must update them to use `shots_per_task` and `task_index` instead. This affects workers running the 1.0 adaptor: the bundled job templates in this release still pin `unrealengine-openjd=0.7.*`, which accepts both the legacy and current key names, and the pin moves to the 1.0 line in a later release once that adaptor is published to the Conda channel. (#384)
+
+### Bug Fixes
+* Adaptor and submitter error telemetry now includes sanitized stack traces, and events are grouped by the operation that raised them, so failures can be diagnosed from telemetry alone. (#380)
 ## 0.7.2 (2026-08-26)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0 (2026-09-11)
+
+### BREAKING CHANGES
+* The Unreal adaptor no longer supports the legacy `chunk_size` and `chunk_id` run-data keys. If you have legacy job templates or saved job bundles that use these keys, you must update them to use `shots_per_task` and `task_index` instead. (#384)
 ## 0.7.2 (2026-08-26)
 
 ### Features


### PR DESCRIPTION
Fixes: #387

### What was the problem/requirement? (What/Why)
Disabled MRQ jobs and jobs with no enabled shots were submitted. The latter created an invalid empty OpenJD task range.

### What was the solution? (How)
Filter the MRQ queue before validation and submission; finish cleanly when no jobs qualify.

### What is the impact of this change?
Remote rendering now matches local MRQ enablement behavior and avoids the submission failure.

### How was this change tested?
Hatch unit suite: 783 passed, 2 skipped. Hatch lint: Ruff, Black, and mypy passed.

### Have you run a render job successfully with these changes?
Yes, successfully submitted a render with these changes

### Was this change documented?
No. This behavior fix needs no documentation change.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*